### PR TITLE
Add a setting to load savestate on next seed

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -34,6 +34,13 @@ Main.LoadNextSeed = false
 
 -- Main loop
 function Main.Run()
+	if Settings.config.LOAD_STATE_AT_START ~= nil then
+		-- If using a startup savestate, we need to
+		-- advance one frame after ROM load else Bizhawk is unhappy.
+		emu.frameadvance()
+		savestate.load(Settings.config.LOAD_STATE_AT_START)
+	end
+
 	print("Waiting 5s before loading...")
 	local frames = 0
 	local waitBeforeHook = 300

--- a/Settings.ini
+++ b/Settings.ini
@@ -1,5 +1,6 @@
 [config]
 ROMS_FOLDER=
+LOAD_STATE_AT_START=
 
 [tracker]
 AUTO_TRACK=true


### PR DESCRIPTION
I was watching a streamer who was manually loading a savestate to skip past the initial naming, and I figured some people would find this feature useful.  I branched from the most recent commit, which has the newer settings file convention.  Feel free to message me on Discord if you want me to modify something.