### PR TITLE
Null check prior to accessing table

### DIFF
--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -65,7 +65,7 @@ function Program.main()
 
 		Program.StatButtonState = Tracker.getButtonState()
 		Buttons = Program.updateButtons(Program.StatButtonState)
-	
+
 		if Tracker.Data.selectedPlayer == 2 then
 			Drawing.DrawTracker(Tracker.Data.selectedPokemon, true, Tracker.Data.targetedPokemon)
 		else
@@ -584,9 +584,13 @@ function Program.getBagHealingItems(pkmn)
 		healing = 0,
 		numHeals = 0,
 	}
-	local maxHP = pkmn["maxHP"]
+	-- Need a null check before getting maxHP
+	if pkmn == nil then
+		return totals
+	end
 
-	if pkmn == nil or maxHP == 0 then
+	local maxHP = pkmn["maxHP"]
+	if maxHP == 0 then
 		return totals
 	end
 


### PR DESCRIPTION
There is a null check for `pkmn` passed into the `Program.getBagHealingItems()` method after the table is accessed. While this value should never be null, it makes sense to check before accessing to avoid an error.