### PR TITLE
Automatically reset tracker when ROM changes

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -112,15 +112,17 @@ function Main.Run()
 end
 
 function Main.LoadNext()
-	client.SetSoundOn(false)
-
 	userdata.clear()
+    print "Reset tracker"
 
 	if Settings.config.ROMS_FOLDER == nil then
 		print("ROMS_FOLDER unspecified. Set this in Settings.ini to automatically switch ROM.")
+        Main.LoadNextSeed = false
+		Main.Run()
 		return
 	end
 
+    client.SetSoundOn(false)
 	local romname = gameinfo.getromname()
 	client.closerom()
 

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -39,6 +39,7 @@ function Tracker.InitTrackerData()
             numHeals = 0,
         },
         notes = {},
+        romHash = nil,
     }
     return trackerData
 end
@@ -218,6 +219,15 @@ function Tracker.loadData()
         for k, v in pairs(trackerData) do
             Tracker.Data[k] = v
         end
+
+        if Tracker.Data.romHash then
+            if gameinfo.getromhash() == Tracker.Data.romHash then
+                print("Loaded tracker data")
+            else
+                print("New ROM detected, resetting tracker data")
+                Tracker.Data = Tracker.InitTrackerData()
+            end
+        end
     else
         Tracker.Data = Tracker.InitTrackerData()
         if Settings.tracker.MUST_CHECK_SUMMARY == true then
@@ -225,5 +235,6 @@ function Tracker.loadData()
         end
     end
 
+    Tracker.Data.romHash = gameinfo.getromhash()
     Tracker.redraw = true
 end


### PR DESCRIPTION
- Uses `gameinfo.getromhash()` to detect when the ROM changes (i.e. due to rerandomization) and reset data when detected -- this greatly improves macro/manual workflow with the tracker where the same filename is used
- Fixes a bug in #38 - I thought I tested this, but clearly I did not. It would reset the tracker but it would not load it again if `ROMS_FOLDER` was not set.