### PR TITLE
No Power move ineffectiveness to certain Pokémon types

### DIFF
--- a/Settings.ini
+++ b/Settings.ini
@@ -20,6 +20,9 @@ MUST_CHECK_SUMMARY=false
 SHOW_MOVE_CATEGORIES=true
 ; Display nature modifiers using font styles rather than colors: bold text for green and italic for red
 NATURE_WITH_FONT_STYLE=false
+; Move effectiveness against opponent Pokémon is displayed next to the power stat
+; 1 or 2 up chevrons = super effective; down chevrons = not very effective; red X = ineffective
+SHOW_MOVE_EFFECTIVENESS=true
 
 ; Set the various controls here using the following buttons:
 ; A, B, L, R, Up, Down, Left, Right, Start, Select

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -495,7 +495,7 @@ function Drawing.DrawTracker(monToDraw, monIsEnemy, targetMon)
 	end
 
 	-- Move effectiveness against the opponent
-	if Tracker.Data.inBattle == 1 then
+	if Settings.tracker.SHOW_MOVE_EFFECTIVENESS and Tracker.Data.inBattle == 1 then
 		if targetMon ~= nil then
 			for moveIndex = 1, 4, 1 do
 				local effectiveness = Utils.netEffectiveness(moves[moveIndex], PokemonData[targetMon.pokemonID + 1])

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -17,9 +17,13 @@ end
 
 function Utils.netEffectiveness(move, pkmnData)
 	local effectiveness = 1.0
+	-- Mirror Coat is a special case. It has no extra or reduced effectiveness, BUT will be ineffective against a Dark-type.
+	if move.id == "243" and pkmnData.type == PokemonTypes.DARK then
+		return 0.0
+	end
+
 	-- Skip check if move has no power.
-	-- In the case of Mirror Coat (id 243), we want to do the type check because it is ineffective against Dark type.
-	if move["power"] == NOPOWER and move.id ~= "243" then
+	if move["power"] == NOPOWER then
 		return 1.0
 	end
 

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -17,17 +17,22 @@ end
 
 function Utils.netEffectiveness(move, pkmnData)
 	local effectiveness = 1.0
-	-- Mirror Coat is a special case. It has no extra or reduced effectiveness, BUT will be ineffective against a Dark-type.
-	if move.id == "243" and pkmnData.type == PokemonTypes.DARK then
-		return 0.0
-	end
-	-- SonicBoom is another special case. Ineffective against Ghost-type.
-	if move.id == "49" and pkmnData.type == PokemonTypes.GHOST then
-		return 0.0
-	end
 
-	-- Skip check if move has no power.
-	if move["power"] == NOPOWER then
+	-- TODO: Do we want to handle Hidden Power's varied type in this? We could analyze the IV of the Pokémon and determine the type...
+
+	-- If move has no power, check for ineffectiveness by type first, then return 1.0 if ineffective cases not present
+	if move.power == NOPOWER then
+		if move.category ~= MoveCategories.STATUS then
+			if move.type == PokemonTypes.NORMAL and (pkmnData.type[1] == PokemonTypes.GHOST or pkmnData.type[2] == PokemonTypes.GHOST) then
+				return 0.0
+			elseif move.type == PokemonTypes.PSYCHIC and (pkmnData.type[1] == PokemonTypes.DARK or pkmnData.type[2] == PokemonTypes.DARK) then
+				return 0.0
+			elseif move.type == PokemonTypes.GROUND and (pkmnData.type[1] == PokemonTypes.FLYING or pkmnData.type[2] == PokemonTypes.FLYING) then
+				return 0.0
+			elseif move.type == PokemonTypes.GHOST and (pkmnData.type[1] == PokemonTypes.NORMAL or pkmnData.type[2] == PokemonTypes.NORMAL) then
+				return 0.0
+			end
+		end
 		return 1.0
 	end
 

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -21,6 +21,10 @@ function Utils.netEffectiveness(move, pkmnData)
 	if move.id == "243" and pkmnData.type == PokemonTypes.DARK then
 		return 0.0
 	end
+	-- SonicBoom is another special case. Ineffective against Ghost-type.
+	if move.id == "49" and pkmnData.type == PokemonTypes.GHOST then
+		return 0.0
+	end
 
 	-- Skip check if move has no power.
 	if move["power"] == NOPOWER then

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -25,6 +25,8 @@ function Utils.netEffectiveness(move, pkmnData)
 		if move.category ~= MoveCategories.STATUS then
 			if move.type == PokemonTypes.NORMAL and (pkmnData.type[1] == PokemonTypes.GHOST or pkmnData.type[2] == PokemonTypes.GHOST) then
 				return 0.0
+			elseif move.type == PokemonTypes.FIGHTING and (pkmnData.type[1] == PokemonTypes.GHOST or pkmnData.type[2] == PokemonTypes.GHOST) then
+				return 0.0
 			elseif move.type == PokemonTypes.PSYCHIC and (pkmnData.type[1] == PokemonTypes.DARK or pkmnData.type[2] == PokemonTypes.DARK) then
 				return 0.0
 			elseif move.type == PokemonTypes.GROUND and (pkmnData.type[1] == PokemonTypes.FLYING or pkmnData.type[2] == PokemonTypes.FLYING) then

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -17,7 +17,9 @@ end
 
 function Utils.netEffectiveness(move, pkmnData)
 	local effectiveness = 1.0
-	if move["power"] == NOPOWER then
+	-- Skip check if move has no power.
+	-- In the case of Mirror Coat (id 243), we want to do the type check because it is ineffective against Dark type.
+	if move["power"] == NOPOWER and move.id ~= "243" then
 		return 1.0
 	end
 


### PR DESCRIPTION
As found in issue #48, Mirror Coat does not show that it is ineffective against Dark-type Pokémon.
This update allows for checking of moves that have no power stat, but do cause damage, to be checked if they are ineffective against specific Pokémon types.
Additionally, added a setting to disable showing move effectiveness if the player would rather not have that information.