### PR TITLE
Hyper potion value fix

### DIFF
--- a/ironmon_tracker/Data.lua
+++ b/ironmon_tracker/Data.lua
@@ -112,7 +112,7 @@ MiscData = {
 		[21] = {
 			id = 21,
 			name = "Hyper Potion",
-			amount = 120,
+			amount = 200,
 			type = HealingType.Constant,
 			pocket = BagPocket.Items,
 		},


### PR DESCRIPTION
In gens 1-6, hyper potions heal for 200. I imagine you might want some logic to handle this if support grows to gen 7+, but for the currently supported games, 200 is the correct heal amount. 

https://pokemondb.net/item/hyper-potion