### PR TITLE
Reduce updating user data while walking in field

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -80,7 +80,7 @@ function Main.Run()
 		event.onmemoryexecute(Program.HandleCalculateMonStats, GameSettings.CalculateMonStats, "HandleHandleCalculateMonStats")
 		event.onmemoryexecute(Program.HandleDisplayMonLearnedMove, GameSettings.DisplayMonLearnedMove, "HandleDisplayMonLearnedMove")
 		event.onmemoryexecute(Program.HandleSwitchSelectedMons, GameSettings.SwitchSelectedMons, "HandleSwitchSelectedMons")
-		event.onmemoryexecute(Program.HandleUpdatePoisonStepCounter, GameSettings.UpdatePoisonStepCounter, "HandleUpdatePoisonStepCounter")
+		event.onmemoryexecute(Program.HandleDoPoisonFieldEffect, GameSettings.DoPoisonFieldEffect, "HandleDoPoisonFieldEffect")
 
 		-- Ability events
 		-- event.onmemoryread(Program.HandleBattleScriptDrizzleActivates, GameSettings.BattleScriptDrizzleActivates, "HandleBattleScriptDrizzleActivates")

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ https://github.com/mkdasher/PokemonBizhawkLua
 
 ## Installation
 
+0. If you haven't used BizHawk before, [download the emulator](https://tasvideos.org/BizHawk/ReleaseHistory) (v2.8 or higher).
+   - **IMPORTANT**: _Run BizHawk once and **close** it_, then start it again before continuing! This ensures that BizHawk sets itself up properly on your system. Otherwise, the tracker may get some odd errors when trying to start it during your first use of BizHawk.
 1. Download the project from the [releases](https://github.com/besteon/Ironmon-Tracker/releases/) section. The main branch has additional changes and may be broken.
    - If you are feeling adventurous and wish to help us in finding bugs, you are more than welcome to clone the main branch. If the tracker crashes, please provide the log dump from the Lua Console to us via Discord or the [Issues](https://github.com/besteon/Ironmon-Tracker/issues) tab.
 2. Unzip the project anywhere you like. We recommend using the `Lua` folder where you installed BizHawk. The ironmon_tracker folder must be in the same directory as Ironmon_Tracker.lua.

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -84,7 +84,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x08068d0c
 		GameSettings.DisplayMonLearnedMove = 0x081b7910
 		GameSettings.SwitchSelectedMons = 0x081b3938
-		GameSettings.DoPoisonFieldEffect = 0x0809cb94
+		GameSettings.DoPoisonFieldEffect = 0x080f9744
 		GameSettings.WeHopeToSeeYouAgain = 0x082727db
 		GameSettings.DoPokeballSendOutAnimation = 0x080753e8
 
@@ -182,7 +182,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x0803e47c
 		GameSettings.DisplayMonLearnedMove = 0x08126804
 		GameSettings.SwitchSelectedMons = 0x08122e5c
-		GameSettings.DoPoisonFieldEffect = 0x0806d79c
+		GameSettings.DoPoisonFieldEffect = 0x080a0618
 		GameSettings.WeHopeToSeeYouAgain = 0x081a5511
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a938
 
@@ -231,7 +231,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x0803e490
 		GameSettings.DisplayMonLearnedMove = 0x08126854
 		GameSettings.SwitchSelectedMons = 0x08122eac
-		GameSettings.DoPoisonFieldEffect = 0x0806d7b0
+		GameSettings.DoPoisonFieldEffect = 0x080a0600
 		GameSettings.WeHopeToSeeYouAgain = 0x081a5565
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a94c
 
@@ -280,7 +280,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x0803e47c
 		GameSettings.DisplayMonLearnedMove = 0x081267dc
 		GameSettings.SwitchSelectedMons = 0x08122e34
-		GameSettings.DoPoisonFieldEffect = 0x0806d79c
+		GameSettings.DoPoisonFieldEffect = 0x080a05ec
 		GameSettings.WeHopeToSeeYouAgain = 0x081a54ed
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a938
 

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -22,7 +22,7 @@ GameSettings = {
 	ShowPokemonSummaryScreen = 0,
 	CalculateMonStats = 0,
 	SwitchSelectedMons = 0,
-	UpdatePoisonStepCounter = 0,
+	DoPoisonFieldEffect = 0,
 	WeHopeToSeeYouAgain = 0,
 	DoPokeballSendOutAnimation = 0,
 
@@ -84,7 +84,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x08068d0c
 		GameSettings.DisplayMonLearnedMove = 0x081b7910
 		GameSettings.SwitchSelectedMons = 0x081b3938
-		GameSettings.UpdatePoisonStepCounter = 0x0809cb94
+		GameSettings.DoPoisonFieldEffect = 0x0809cb94
 		GameSettings.WeHopeToSeeYouAgain = 0x082727db
 		GameSettings.DoPokeballSendOutAnimation = 0x080753e8
 
@@ -133,7 +133,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x0803e490
 		GameSettings.DisplayMonLearnedMove = 0x0812687c
 		GameSettings.SwitchSelectedMons = 0x08122ed4
-		GameSettings.UpdatePoisonStepCounter = 0x0806d7b0
+		GameSettings.DoPoisonFieldEffect = 0x080a062c
 		GameSettings.WeHopeToSeeYouAgain = 0x081a5589
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a94c
 
@@ -182,7 +182,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x0803e47c
 		GameSettings.DisplayMonLearnedMove = 0x08126804
 		GameSettings.SwitchSelectedMons = 0x08122e5c
-		GameSettings.UpdatePoisonStepCounter = 0x0806d79c
+		GameSettings.DoPoisonFieldEffect = 0x0806d79c
 		GameSettings.WeHopeToSeeYouAgain = 0x081a5511
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a938
 
@@ -231,7 +231,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x0803e490
 		GameSettings.DisplayMonLearnedMove = 0x08126854
 		GameSettings.SwitchSelectedMons = 0x08122eac
-		GameSettings.UpdatePoisonStepCounter = 0x0806d7b0
+		GameSettings.DoPoisonFieldEffect = 0x0806d7b0
 		GameSettings.WeHopeToSeeYouAgain = 0x081a5565
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a94c
 
@@ -280,7 +280,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x0803e47c
 		GameSettings.DisplayMonLearnedMove = 0x081267dc
 		GameSettings.SwitchSelectedMons = 0x08122e34
-		GameSettings.UpdatePoisonStepCounter = 0x0806d79c
+		GameSettings.DoPoisonFieldEffect = 0x0806d79c
 		GameSettings.WeHopeToSeeYouAgain = 0x081a54ed
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a938
 

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -265,8 +265,11 @@ function Program.HandleDisplayMonLearnedMove()
 	Tracker.redraw = true
 end
 
-function Program.HandleUpdatePoisonStepCounter()
-	Tracker.redraw = true
+function Program.HandleDoPoisonFieldEffect()
+	-- Only update the tracker for poison damage if the lead Pokémon is poisoned
+	if Tracker.Data.selectedPokemon.status == 2 then
+		Tracker.redraw = true
+	end
 end
 
 function Program.HandleWeHopeToSeeYouAgain()
@@ -279,7 +282,7 @@ function Program.HandleDoPokeballSendOutAnimation()
 		Tracker.Data.targetPlayer = 2
 		Tracker.Data.targetSlot = 1
 	end
-	
+
 	if Program.transformedPokemon.isTransformed and not Program.transformedPokemon.forceSwitch then
 		-- Reset the transform tracking disable unless player was force-switched by roar/whirlwind
 		Program.transformedPokemon.isTransformed = false
@@ -697,4 +700,3 @@ function Program.getBagStatusItems()
 
 	return statusItems
 end
-


### PR DESCRIPTION
I finally dug into the slowdown issues. I was thinking at first that it was simply a performance issue of individual PCs because it wasn't consistent. Digging more into the code and talking with some users and Besteon, I was able to pinpoint one course of action that should alleviate the issue.

Every step, the tracker was executing the `HandleUpdatePoisonStepCounter()`, triggered by the event of the same name. It turns out that event triggers even if your Pokémon isn't poisoned! So, because this method was called, a tracker redraw event occurs, which in turn makes a call to `Tracker.SaveData()`, which is where all the current tracker data is stringified and stored in BizHawk's `userdata` so that it can be saved in a save state. When the data builds up over time as the player encounters more and more Pokémon, the writes to `userdata` take longer and longer, until the emulator begins to hiccup with those writes.

To mitigate this, I found another memory event for poison: `DoPoisonFieldEffect`. This occurs at less intervals because of the screen distortion effect taking place only every 3-5 steps. Also, I placed a check to see if the lead Pokémon is poisoned. If not, it won't redraw the tracker and write the `userdata`. So, slowdown will now only occur if the player has encountered a lot of Pokémon AND the lead is poisoned when walking in the field.

I'm sure there is more that we can do here, but at least this is a start.