### PR TITLE
Pokémon Center Heal Tracker

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -80,7 +80,7 @@ function Main.Run()
 		event.onmemoryexecute(Program.HandleCalculateMonStats, GameSettings.CalculateMonStats, "HandleHandleCalculateMonStats")
 		event.onmemoryexecute(Program.HandleDisplayMonLearnedMove, GameSettings.DisplayMonLearnedMove, "HandleDisplayMonLearnedMove")
 		event.onmemoryexecute(Program.HandleSwitchSelectedMons, GameSettings.SwitchSelectedMons, "HandleSwitchSelectedMons")
-		event.onmemoryexecute(Program.HandleDoPoisonFieldEffect, GameSettings.DoPoisonFieldEffect, "HandleDoPoisonFieldEffect")
+		event.onmemoryexecute(Program.HandleUpdatePoisonStepCounter, GameSettings.UpdatePoisonStepCounter, "HandleUpdatePoisonStepCounter")
 
 		-- Ability events
 		-- event.onmemoryread(Program.HandleBattleScriptDrizzleActivates, GameSettings.BattleScriptDrizzleActivates, "HandleBattleScriptDrizzleActivates")

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -2,7 +2,7 @@
 -- Created by besteon, based on the PokemonBizhawkLua project by MKDasher
 
 -- The latest version of the tracker. Should be updated with each PR.
-TRACKER_VERSION = "0.3.1"
+TRACKER_VERSION = "0.3.2"
 
 -- A frequently used placeholder when a data field is not applicable
 PLACEHOLDER = "---" -- TODO: Consider moving into a better global constant location? Placed here for now to ensure it is available to all subscripts.

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -81,6 +81,7 @@ function Main.Run()
 		event.onmemoryexecute(Program.HandleDisplayMonLearnedMove, GameSettings.DisplayMonLearnedMove, "HandleDisplayMonLearnedMove")
 		event.onmemoryexecute(Program.HandleSwitchSelectedMons, GameSettings.SwitchSelectedMons, "HandleSwitchSelectedMons")
 		event.onmemoryexecute(Program.HandleUpdatePoisonStepCounter, GameSettings.UpdatePoisonStepCounter, "HandleUpdatePoisonStepCounter")
+		event.onmemoryexecute(Program.HandleHealPlayerParty, GameSettings.HealPlayerParty, "HandleHealPlayerParty")
 
 		-- Ability events
 		-- event.onmemoryread(Program.HandleBattleScriptDrizzleActivates, GameSettings.BattleScriptDrizzleActivates, "HandleBattleScriptDrizzleActivates")

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ![Ironmon-Tracker_v0 2 0-min](https://user-images.githubusercontent.com/103706338/168518780-ceebdb88-57a8-49aa-b6b4-acc46c4d2101.gif)
 
 Ironmon-Tracker is a collection of lua scripts for the [Bizhawk emulator](https://tasvideos.org/BizHawk/ReleaseHistory) (v2.8 or higher) used to track ironMON attempts.
-For more information on ironMON, see https://gist.github.com/valiant-code/adb18d248fa0fae7da6b639e2ee8f9c1
+
+For more information on ironMON, see http://ironmon.gg
 
 Only Emerald, Leaf Green, and Fire Red (Generation 3 games) are supported. If you find any bugs or have feature requests, feel free to create a [GitHub issue](https://github.com/besteon/Ironmon-Tracker/issues) or DM me on Discord. You can find me on the Ironmon Discord server.
 
@@ -26,17 +27,12 @@ If you want to use your controller to toggle stat prediction markers on opponent
 
 ## Latest Changes
 
-<div style="display:flex">
-	<img style="padding-right:5px" src="https://user-images.githubusercontent.com/5532354/171784220-39601761-3df8-48d1-aff4-620e7d34de46.png" alt="Tracker with new gear icon">
-	<img src="https://user-images.githubusercontent.com/5532354/171784322-812000bb-55d2-4358-960b-79cfcb7f8c5d.png" alt="The tracker settings menu">
-</div>
+![image](https://user-images.githubusercontent.com/5532354/173256930-d61c961c-0fed-449a-bf86-ccb5e0f9632f.png)
 
-- **_NEW!!_ Settings**: You can now modify **nearly all** settings for the tracker within the tracker itself! Click on the gear icon near the Pokémon name to open the new Settings menu.
-  - Click on a setting to turn it on or off!
-  - Click on the Roms Folder setting to open a dialog that allows you to pick the folder where your files are stored.
-    - Note: Pick any file in the desired folder. The folder itself will be saved as the setting.
-    - Controller configuration will be coming to this menu soon!
-  - The Settings.ini file will update with your changes when you close the settings menu. You can still modify this file to set your controller button configurations and any other option.
+- **_NEW!!_ PokéCenter Heal Tracking**: The new Survival IronMon ruleset requires tracking the number of visits to the Pokémon Centers (and other full party healing visits like Mom, etc.) for healing. When between 5-9 visits, the number is yellow, and 10 visits is red.
+  - Turn this on by selecting the new "Survival ruleset" option in the settings menu or in the Settings.ini file.
+  - Note that a new game will start with -1 PC Heals. This is because successful Lab Escapes heals you once. This will then set the counter to 0 as your game begins proper.
+  - This is still **in testing!** I _<u>HIGHLY</u>_ recommend tracking the number of visits separately until this is fully tested. If you find any issues at all, please let us know in the Discord or at the [GitHub Issues](https://github.com/besteon/Ironmon-Tracker/issues) tab.
 
 ## Features
 
@@ -50,6 +46,12 @@ If you want to use your controller to toggle stat prediction markers on opponent
 - **Move effectiveness**: Moves that are super effective or not very effective against the opposing Pokémon will display one or two chevrons next to the move's power stat. Moves that are completely ineffective will display a red `X`.
 - **Attack type icons**: Icons for moves that are physical or special attack types can be displayed next to the move name.
 - **Healing items**: The tracker displays the number of healing items on hand in the bag and what percentage of max HP of the currently displayed Pokémon those items will heal by.
+- **Settings**: You can now modify **nearly all** settings for the tracker within the tracker itself! Click on the gear icon near the Pokémon name to open the new Settings menu.
+  - Click on a setting to turn it on or off!
+  - Click on the Roms Folder setting to open a dialog that allows you to pick the folder where your files are stored.
+    - Note: Pick any file in the desired folder. The folder itself will be saved as the setting.
+    - Controller configuration will be coming to this menu soon!
+  - The Settings.ini file will update with your changes when you close the settings menu. You can still modify this file to set your controller button configurations and any other option.
 
 ## FAQ
 

--- a/Settings.ini
+++ b/Settings.ini
@@ -7,7 +7,6 @@
 ; must be in a numerical order without leading zeroes. For example: you can name your series of seeds as 'kaizo21.gba',
 ; 'kaizo22.gba', 'kaizo23.gba', etc. and the controller shortcut will swap successfully.
 ; Example: ROMS_FOLDER=C:\Users\Besteon\roms
-ROMS_FOLDER=
 
 [tracker]
 ; AUTO_SWAP_TO_ENEMY: Swaps the tracker to the enemy Pokémon automatically at the start of battle and with every enemy action. Manual
@@ -21,6 +20,7 @@ ROMS_FOLDER=
 ; Eruption and Flail). HP-based moves are not calculated for enemy Pokémon.
 ; SHOW_MOVE_EFFECTIVENESS: Move effectiveness against opponent Pokémon is displayed next to the power stat
 ; 1 or 2 up chevrons = super effective; down chevrons = not very effective; red X = ineffective
+; SURVIVAL_RULESET: Using the survival ruleset will track the Pokémon Center heals remaining in a run
 AUTO_SWAP_TO_ENEMY=true
 MUST_CHECK_SUMMARY=false
 SHOW_MOVE_CATEGORIES=true
@@ -28,6 +28,7 @@ NATURE_WITH_FONT_STYLE=false
 RIGHT_JUSTIFIED_NUMBERS=false
 CALCULATE_VARIABLE_DAMAGE=true
 SHOW_MOVE_EFFECTIVENESS=true
+SURVIVAL_RULESET=false
 
 [controls]
 ; Set the various controls here using the following buttons:

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -300,9 +300,16 @@ function Drawing.DrawTracker(monToDraw, monIsEnemy, targetMon)
 	local infoBoxHeight = 23
 	gui.drawRectangle(GraphicConstants.SCREEN_WIDTH + borderMargin, borderMargin + statBoxHeight, statBoxWidth - borderMargin, infoBoxHeight, GraphicConstants.LAYOUTCOLORS.BOXBORDER, GraphicConstants.LAYOUTCOLORS.BOXFILL)
 
+	-- Heals in bag/PokéCenter heals
 	if monIsEnemy == false then
-		Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 6, 57, "Heals in Bag:", GraphicConstants.LAYOUTCOLORS.INCREASE)
+		Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 6, 57, "Heals in Bag:", GraphicConstants.LAYOUTCOLORS.NEUTRAL)
 		Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 6, 67, string.format("%.0f%%", Tracker.Data.healingItems.healing) .. " HP (" .. Tracker.Data.healingItems.numHeals .. ")", GraphicConstants.LAYOUTCOLORS.INCREASE)
+		Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 57, "PC Heals:", GraphicConstants.LAYOUTCOLORS.NEUTRAL)
+		if Tracker.Data.centerHealsRemaining == 11 then
+			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 67, "Infinite", GraphicConstants.LAYOUTCOLORS.INCREASE)
+		else
+			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 67, Tracker.Data.centerHealsRemaining, Utils.inlineIf(Tracker.Data.centerHealsRemaining > 5, GraphicConstants.LAYOUTCOLORS.INCREASE, Utils.inlineIf(Tracker.Data.centerHealsRemaining > 1, GraphicConstants.LAYOUTCOLORS.HIGHLIGHT, GraphicConstants.LAYOUTCOLORS.DECREASE)))
+		end
 	end
 
 	-- Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 35, 67, "4", GraphicConstants.LAYOUTCOLORS.NEUTRAL)
@@ -532,7 +539,7 @@ function Drawing.DrawTracker(monToDraw, monIsEnemy, targetMon)
 			elseif movePower == ">HP" and not monIsEnemy then
 				-- Calculate the power of water spout & eruption moves for the player only
 				newPower = Utils.calculateHighHPBasedDamage(currentHP, maxHP)
-			else 
+			else
 				newPower = movePower
 			end
 			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + powerOffset, moveStartY + (distanceBetweenMoves * (moveIndex - 1)), newPower, stabColors[moveIndex])

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -306,7 +306,7 @@ function Drawing.DrawTracker(monToDraw, monIsEnemy, targetMon)
 		Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 6, 67, string.format("%.0f%%", Tracker.Data.healingItems.healing) .. " HP (" .. Tracker.Data.healingItems.numHeals .. ")", GraphicConstants.LAYOUTCOLORS.INCREASE)
 		if (Settings.tracker.SURVIVAL_RULESET) then
 			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 57, "PC Heals:", GraphicConstants.LAYOUTCOLORS.NEUTRAL)
-			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 67, Tracker.Data.centerHeals, Utils.inlineIf(Tracker.Data.centerHeals < 5, GraphicConstants.LAYOUTCOLORS.INCREASE, Utils.inlineIf(Tracker.Data.centerHeals < 10, GraphicConstants.LAYOUTCOLORS.HIGHLIGHT, GraphicConstants.LAYOUTCOLORS.DECREASE)))
+			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 85, 67, Tracker.Data.centerHeals, Utils.inlineIf(Tracker.Data.centerHeals < 5, GraphicConstants.LAYOUTCOLORS.INCREASE, Utils.inlineIf(Tracker.Data.centerHeals < 10, GraphicConstants.LAYOUTCOLORS.HIGHLIGHT, GraphicConstants.LAYOUTCOLORS.DECREASE)))
 		end
 	end
 

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -304,11 +304,9 @@ function Drawing.DrawTracker(monToDraw, monIsEnemy, targetMon)
 	if monIsEnemy == false then
 		Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 6, 57, "Heals in Bag:", GraphicConstants.LAYOUTCOLORS.NEUTRAL)
 		Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 6, 67, string.format("%.0f%%", Tracker.Data.healingItems.healing) .. " HP (" .. Tracker.Data.healingItems.numHeals .. ")", GraphicConstants.LAYOUTCOLORS.INCREASE)
-		Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 57, "PC Heals:", GraphicConstants.LAYOUTCOLORS.NEUTRAL)
-		if Tracker.Data.centerHealsRemaining == 11 then
-			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 67, "Infinite", GraphicConstants.LAYOUTCOLORS.INCREASE)
-		else
-			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 67, Tracker.Data.centerHealsRemaining, Utils.inlineIf(Tracker.Data.centerHealsRemaining > 5, GraphicConstants.LAYOUTCOLORS.INCREASE, Utils.inlineIf(Tracker.Data.centerHealsRemaining > 1, GraphicConstants.LAYOUTCOLORS.HIGHLIGHT, GraphicConstants.LAYOUTCOLORS.DECREASE)))
+		if (Settings.tracker.SURVIVAL_RULESET) then
+			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 57, "PC Heals:", GraphicConstants.LAYOUTCOLORS.NEUTRAL)
+			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 67, Tracker.Data.centerHeals, Utils.inlineIf(Tracker.Data.centerHeals < 5, GraphicConstants.LAYOUTCOLORS.INCREASE, Utils.inlineIf(Tracker.Data.centerHeals < 10, GraphicConstants.LAYOUTCOLORS.HIGHLIGHT, GraphicConstants.LAYOUTCOLORS.DECREASE)))
 		end
 	end
 

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -22,7 +22,7 @@ GameSettings = {
 	ShowPokemonSummaryScreen = 0,
 	CalculateMonStats = 0,
 	SwitchSelectedMons = 0,
-	DoPoisonFieldEffect = 0,
+	UpdatePoisonStepCounter = 0,
 	WeHopeToSeeYouAgain = 0,
 	DoPokeballSendOutAnimation = 0,
 
@@ -84,7 +84,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x08068d0c
 		GameSettings.DisplayMonLearnedMove = 0x081b7910
 		GameSettings.SwitchSelectedMons = 0x081b3938
-		GameSettings.DoPoisonFieldEffect = 0x080f9744
+		GameSettings.UpdatePoisonStepCounter = 0x0809cb94
 		GameSettings.WeHopeToSeeYouAgain = 0x082727db
 		GameSettings.DoPokeballSendOutAnimation = 0x080753e8
 
@@ -133,9 +133,10 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x0803e490
 		GameSettings.DisplayMonLearnedMove = 0x0812687c
 		GameSettings.SwitchSelectedMons = 0x08122ed4
-		GameSettings.DoPoisonFieldEffect = 0x080a062c
+		GameSettings.UpdatePoisonStepCounter = 0x080a062c
 		GameSettings.WeHopeToSeeYouAgain = 0x081a5589
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a94c
+		-- 080a006c g 000000c4 HealPlayerParty
 
 		GameSettings.BattleScriptDrizzleActivates = 0x081d92ef
 		GameSettings.BattleScriptSpeedBoostActivates = 0x081d9303
@@ -182,7 +183,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x0803e47c
 		GameSettings.DisplayMonLearnedMove = 0x08126804
 		GameSettings.SwitchSelectedMons = 0x08122e5c
-		GameSettings.DoPoisonFieldEffect = 0x080a0618
+		GameSettings.UpdatePoisonStepCounter = 0x0806d79c
 		GameSettings.WeHopeToSeeYouAgain = 0x081a5511
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a938
 
@@ -231,7 +232,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x0803e490
 		GameSettings.DisplayMonLearnedMove = 0x08126854
 		GameSettings.SwitchSelectedMons = 0x08122eac
-		GameSettings.DoPoisonFieldEffect = 0x080a0600
+		GameSettings.UpdatePoisonStepCounter = 0x0806d7b0
 		GameSettings.WeHopeToSeeYouAgain = 0x081a5565
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a94c
 
@@ -280,7 +281,7 @@ function GameSettings.initialize()
 		GameSettings.CalculateMonStats = 0x0803e47c
 		GameSettings.DisplayMonLearnedMove = 0x081267dc
 		GameSettings.SwitchSelectedMons = 0x08122e34
-		GameSettings.DoPoisonFieldEffect = 0x080a05ec
+		GameSettings.UpdatePoisonStepCounter = 0x0806d79c
 		GameSettings.WeHopeToSeeYouAgain = 0x081a54ed
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a938
 

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -25,6 +25,7 @@ GameSettings = {
 	UpdatePoisonStepCounter = 0,
 	WeHopeToSeeYouAgain = 0,
 	DoPokeballSendOutAnimation = 0,
+	HealPlayerParty = 0,
 
 	BattleScriptDrizzleActivates = 0,
 	BattleScriptSpeedBoostActivates = 0,
@@ -87,6 +88,7 @@ function GameSettings.initialize()
 		GameSettings.UpdatePoisonStepCounter = 0x0809cb94
 		GameSettings.WeHopeToSeeYouAgain = 0x082727db
 		GameSettings.DoPokeballSendOutAnimation = 0x080753e8
+		GameSettings.HealPlayerParty = 0x080f9180
 
 		GameSettings.BattleScriptDrizzleActivates = 0x082db430
 		GameSettings.BattleScriptSpeedBoostActivates = 0x082db444
@@ -136,7 +138,7 @@ function GameSettings.initialize()
 		GameSettings.UpdatePoisonStepCounter = 0x080a062c
 		GameSettings.WeHopeToSeeYouAgain = 0x081a5589
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a94c
-		-- 080a006c g 000000c4 HealPlayerParty
+		GameSettings.HealPlayerParty = 0x080a006c
 
 		GameSettings.BattleScriptDrizzleActivates = 0x081d92ef
 		GameSettings.BattleScriptSpeedBoostActivates = 0x081d9303
@@ -186,6 +188,7 @@ function GameSettings.initialize()
 		GameSettings.UpdatePoisonStepCounter = 0x0806d79c
 		GameSettings.WeHopeToSeeYouAgain = 0x081a5511
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a938
+		GameSettings.HealPlayerParty = 0x080a0058
 
 		GameSettings.BattleScriptDrizzleActivates = 0x081d927f
 		GameSettings.BattleScriptSpeedBoostActivates = 0x081d9293
@@ -235,6 +238,7 @@ function GameSettings.initialize()
 		GameSettings.UpdatePoisonStepCounter = 0x0806d7b0
 		GameSettings.WeHopeToSeeYouAgain = 0x081a5565
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a94c
+		GameSettings.HealPlayerParty = 0x080a0040
 
 		GameSettings.BattleScriptDrizzleActivates = 0x081d92cb
 		GameSettings.BattleScriptSpeedBoostActivates = 0x081d92df
@@ -284,6 +288,7 @@ function GameSettings.initialize()
 		GameSettings.UpdatePoisonStepCounter = 0x0806d79c
 		GameSettings.WeHopeToSeeYouAgain = 0x081a54ed
 		GameSettings.DoPokeballSendOutAnimation = 0x0804a938
+		GameSettings.HealPlayerParty = 0x080a002c
 
 		GameSettings.BattleScriptDrizzleActivates = 0x081d925b
 		GameSettings.BattleScriptSpeedBoostActivates = 0x081d926f

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -149,7 +149,9 @@ function Input.check(xmouse, ymouse)
 			-- Use the standard file open dialog to get the roms folder
 			local file = forms.openfile(nil, Settings.config.ROMS_FOLDER)
 			-- Since the user had to pick a file, strip out the file name to just get the folder.
-			Settings.config.ROMS_FOLDER = string.sub(file, 0, string.match(file, "^.*()\\") - 1)
+			if file ~= "" then
+				Settings.config.ROMS_FOLDER = string.sub(file, 0, string.match(file, "^.*()\\") - 1)
+			end
 			Options.redraw = true
 			Options.updated = true
 		end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -272,6 +272,11 @@ function Program.HandleUpdatePoisonStepCounter()
 	end
 end
 
+function Program.HandleHealPlayerParty()
+	Tracker.Data.centerHeals = Tracker.Data.centerHeals + 1
+	Tracker.redraw = true
+end
+
 function Program.HandleWeHopeToSeeYouAgain()
 	Tracker.redraw = true
 end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -265,7 +265,7 @@ function Program.HandleDisplayMonLearnedMove()
 	Tracker.redraw = true
 end
 
-function Program.HandleDoPoisonFieldEffect()
+function Program.HandleUpdatePoisonStepCounter()
 	-- Only update the tracker for poison damage if the lead Pokémon is poisoned
 	if Tracker.Data.selectedPokemon.status == 2 then
 		Tracker.redraw = true

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -38,7 +38,7 @@ function Tracker.InitTrackerData()
 			healing = 0,
 			numHeals = 0,
 		},
-		centerHealsRemaining = 0,
+		centerHeals = 0,
 		notes = {},
 		currentHiddenPowerType = PokemonTypes.NORMAL,
 		romHash = nil,

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -38,6 +38,7 @@ function Tracker.InitTrackerData()
 			healing = 0,
 			numHeals = 0,
 		},
+		centerHealsRemaining = 0,
 		notes = {},
 		currentHiddenPowerType = PokemonTypes.NORMAL,
 		romHash = nil,

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -38,7 +38,7 @@ function Tracker.InitTrackerData()
 			healing = 0,
 			numHeals = 0,
 		},
-		centerHeals = 0,
+		centerHeals = -1,
 		notes = {},
 		currentHiddenPowerType = PokemonTypes.NORMAL,
 		romHash = nil,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5532354/173256930-d61c961c-0fed-449a-bf86-ccb5e0f9632f.png)
Add full party healing checks to the tracker, showing under the PC Heals value in the tracker.
- Turn this on by selecting the "Survival ruleset" option in the settings menu/Settings.ini file.
- Starts at -1 because the lab gives you a free heal, so successfully escaping the lab will show 0 visits.

Bug fixes:
- Reverted to using the Poison step counter memory stamp while also using the poison status to perform tracker updates and userdata writes
- Check for cancelling file selection when setting the ROMS folder in the settings menu of the tracker

Also updates the readme and increments the release version. I do note that this is not heavily tested yet so there is a chance for problems, so people should be independently tracking until we work out the kinks in this.