### PR TITLE
Linux fixes

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -137,10 +137,10 @@ function Main.LoadNext()
 	local romnumber = tonumber(string.match(romname, '[0-9]+')) + 1
 	local nextromname = ""
 	if rombasename == nil then
-		nextromname = Settings.config.ROMS_FOLDER .. "\\" .. romnumber .. ".gba"
+		nextromname = Settings.config.ROMS_FOLDER .. "/" .. romnumber .. ".gba"
 	else
 		rombasename = rombasename:gsub(" ", "_")
-		nextromname = Settings.config.ROMS_FOLDER .. "\\" .. rombasename .. romnumber .. ".gba"
+		nextromname = Settings.config.ROMS_FOLDER .. "/" .. rombasename .. romnumber .. ".gba"
 		print(nextromname)
 	end
 

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -21,7 +21,9 @@ DATA_FOLDER = "ironmon_tracker"
 
 -- Get the user settings saved on disk and create the base Settings object
 INI = dofile(DATA_FOLDER .. "/Inifile.lua")
-Settings = INI.parse("Settings.ini")
+-- Need to manually read the file to work around a bug in the ini parser, which
+-- does not correctly handle that the last iteration over lines() returns nil
+Settings = INI.parse(io.open("Settings.ini"):read("*a"), "memory")
 
 -- Import all scripts before starting the main loop
 dofile(DATA_FOLDER .. "/PokemonData.lua")


### PR DESCRIPTION
This might fix #68, at least it does so for me.

After some printf debugging, I noticed that Inifile implementation uses `file:lines()` to read the ini file, but does not break at the `nil` that signifies the end of the file. Instead it unconditionally calls `line:match(…)` [here](https://github.com/besteon/Ironmon-Tracker/blob/2efc900215de2b18d54c3983e87426170f4cdd5a/ironmon_tracker/Inifile.lua#L66), even when `line == nil`.

I have no idea why this only fails sometimes for some people, but for me it was 100%, maybe because under Linux BizHawk uses a different Lua backend.

Also contains a fix to use `/` instead of `\` as the path separator. This fixes loading the next rom under Linux. I believe also works on Windows since 7 or 8, but someone with a Windows machine needs to test this. It did work for me under wine, but that might behave differently in this regard. Otherwise it needs to be some hack like `package.config:sub(1,1)` to be compatible with both.