### PR TITLE
Survival Pokemon Center Heal Tracking hotfix

### DIFF
--- a/Settings.ini
+++ b/Settings.ini
@@ -7,6 +7,7 @@
 ; must be in a numerical order without leading zeroes. For example: you can name your series of seeds as 'kaizo21.gba',
 ; 'kaizo22.gba', 'kaizo23.gba', etc. and the controller shortcut will swap successfully.
 ; Example: ROMS_FOLDER=C:\Users\Besteon\roms
+ROMS_FOLDER=
 
 [tracker]
 ; AUTO_SWAP_TO_ENEMY: Swaps the tracker to the enemy Pokémon automatically at the start of battle and with every enemy action. Manual

--- a/ironmon_tracker/Buttons.lua
+++ b/ironmon_tracker/Buttons.lua
@@ -184,16 +184,14 @@ Buttons = {
 	{ -- PC Heal Increment Button
 		type = ButtonType.singleButton,
 		visible = function() return Tracker.Data.selectedPlayer == 1 and Settings.tracker.SURVIVAL_RULESET end,
-		text = "",
+		text = "+",
 		box = {
 			GraphicConstants.SCREEN_WIDTH + 67,
-			67,
-			6,
+			68,
+			8,
 			4
 		},
-		drawChevron = function(x, y, w, h, t) 
-			Drawing.drawChevronUp(x, y - 1, w, h, t, GraphicConstants.LAYOUTCOLORS.NEUTRAL)
-		end,
+		textcolor = GraphicConstants.LAYOUTCOLORS.INCREASE,
 		onclick = function() 
 			Tracker.Data.centerHeals = Tracker.Data.centerHeals + 1
 			-- Prevent triple digit values (shouldn't go anywhere near this in survival)
@@ -203,16 +201,14 @@ Buttons = {
 	{ -- PC Heal Decrement Button
 		type = ButtonType.singleButton,
 		visible = function() return Tracker.Data.selectedPlayer == 1 and Settings.tracker.SURVIVAL_RULESET end,
-		text = "",
+		text = "--",
 		box = {
 			GraphicConstants.SCREEN_WIDTH + 67,
-			73,
-			6,
+			74,
+			7,
 			4
 		},
-		drawChevron = function(x, y, w, h, t) 
-			return Drawing.drawChevronDown(x, y - 3, w, h, t, GraphicConstants.LAYOUTCOLORS.NEUTRAL)
-		end,
+		textcolor = GraphicConstants.LAYOUTCOLORS.DECREASE,
 		onclick = function() 
 			Tracker.Data.centerHeals = Tracker.Data.centerHeals - 1
 			-- Prevent negative values

--- a/ironmon_tracker/Buttons.lua
+++ b/ironmon_tracker/Buttons.lua
@@ -196,6 +196,8 @@ Buttons = {
 		end,
 		onclick = function() 
 			Tracker.Data.centerHeals = Tracker.Data.centerHeals + 1
+			-- Prevent triple digit values (shouldn't go anywhere near this in survival)
+			if Tracker.Data.centerHeals > 99 then Tracker.Data.centerHeals = 99 end
 		end
 	},
 	{ -- PC Heal Decrement Button
@@ -213,6 +215,7 @@ Buttons = {
 		end,
 		onclick = function() 
 			Tracker.Data.centerHeals = Tracker.Data.centerHeals - 1
+			-- Prevent negative values
 			if Tracker.Data.centerHeals < 0 then Tracker.Data.centerHeals = 0 end
 		end
 	}

--- a/ironmon_tracker/Buttons.lua
+++ b/ironmon_tracker/Buttons.lua
@@ -23,16 +23,6 @@ StatButtonColors = {
 	GraphicConstants.LAYOUTCOLORS.INCREASE
 }
 
-PCHealTrackingButtonStates = {
-	"x",
-	"+"
-}
-
-PCHealTrackingButtonColors = {
-	GraphicConstants.LAYOUTCOLORS.DECREASE,
-	GraphicConstants.LAYOUTCOLORS.INCREASE
-}
-
 local buttonXOffset = 129
 
 local HiddenPowerState = 0
@@ -47,7 +37,6 @@ HiddenPowerButton = {
 		65,
 		10
 	},
-	backgroundcolor = { GraphicConstants.LAYOUTCOLORS.BOXBORDER, GraphicConstants.LAYOUTCOLORS.BOXFILL },
 	textcolor = GraphicConstants.TYPECOLORS[HiddenPowerTypeList[HiddenPowerState+1]],
 	onclick = function()
 		HiddenPowerState = (HiddenPowerState + 1) % #HiddenPowerTypeList
@@ -60,7 +49,7 @@ HiddenPowerButton = {
 PCHealTrackingButton = {
 	type = ButtonType.singleButton,
 	visible = function() return Tracker.Data.selectedPlayer == 1 and Settings.tracker.SURVIVAL_RULESET end,
-	text = PCHealTrackingButtonStates[1],
+	text = "",
 	box = {
 		GraphicConstants.SCREEN_WIDTH + 89,
 		68,
@@ -68,11 +57,10 @@ PCHealTrackingButton = {
 		8
 	},
 	backgroundcolor = { GraphicConstants.LAYOUTCOLORS.BOXBORDER, GraphicConstants.LAYOUTCOLORS.BOXFILL },
-	textcolor = PCHealTrackingButtonColors[1],
-	onclick = function()
-		Program.PCHealTrackingButtonState = ((Program.PCHealTrackingButtonState + 1) % 2)
-		PCHealTrackingButton.text = PCHealTrackingButtonStates[Program.PCHealTrackingButtonState + 1]
-		PCHealTrackingButton.textcolor = PCHealTrackingButtonColors[Program.PCHealTrackingButtonState + 1]
+	textcolor = 0xFF00AAFF,
+	togglecolor = GraphicConstants.LAYOUTCOLORS.INCREASE,
+	onclick = function() 
+		Program.PCHealTrackingButtonState = not Program.PCHealTrackingButtonState 
 	end
 }
 
@@ -192,5 +180,40 @@ Buttons = {
 		end
 	},
 	HiddenPowerButton,
-	PCHealTrackingButton
+	PCHealTrackingButton,
+	{ -- PC Heal Increment Button
+		type = ButtonType.singleButton,
+		visible = function() return Tracker.Data.selectedPlayer == 1 and Settings.tracker.SURVIVAL_RULESET end,
+		text = "",
+		box = {
+			GraphicConstants.SCREEN_WIDTH + 67,
+			67,
+			6,
+			4
+		},
+		drawChevron = function(x, y, w, h, t) 
+			Drawing.drawChevronUp(x, y - 1, w, h, t, GraphicConstants.LAYOUTCOLORS.NEUTRAL)
+		end,
+		onclick = function() 
+			Tracker.Data.centerHeals = Tracker.Data.centerHeals + 1
+		end
+	},
+	{ -- PC Heal Decrement Button
+		type = ButtonType.singleButton,
+		visible = function() return Tracker.Data.selectedPlayer == 1 and Settings.tracker.SURVIVAL_RULESET end,
+		text = "",
+		box = {
+			GraphicConstants.SCREEN_WIDTH + 67,
+			73,
+			6,
+			4
+		},
+		drawChevron = function(x, y, w, h, t) 
+			return Drawing.drawChevronDown(x, y - 3, w, h, t, GraphicConstants.LAYOUTCOLORS.NEUTRAL)
+		end,
+		onclick = function() 
+			Tracker.Data.centerHeals = Tracker.Data.centerHeals - 1
+			if Tracker.Data.centerHeals < 0 then Tracker.Data.centerHeals = 0 end
+		end
+	}
 }

--- a/ironmon_tracker/Buttons.lua
+++ b/ironmon_tracker/Buttons.lua
@@ -23,6 +23,16 @@ StatButtonColors = {
 	GraphicConstants.LAYOUTCOLORS.INCREASE
 }
 
+PCHealTrackingButtonStates = {
+	"x",
+	"+"
+}
+
+PCHealTrackingButtonColors = {
+	GraphicConstants.LAYOUTCOLORS.DECREASE,
+	GraphicConstants.LAYOUTCOLORS.INCREASE
+}
+
 local buttonXOffset = 129
 
 local HiddenPowerState = 0
@@ -44,6 +54,25 @@ HiddenPowerButton = {
 		local newType = HiddenPowerTypeList[HiddenPowerState + 1]
 		HiddenPowerButton.textcolor = GraphicConstants.TYPECOLORS[newType]
 		Tracker.Data.currentHiddenPowerType = newType
+	end
+}
+
+PCHealTrackingButton = {
+	type = ButtonType.singleButton,
+	visible = function() return Tracker.Data.selectedPlayer == 1 and Settings.tracker.SURVIVAL_RULESET end,
+	text = PCHealTrackingButtonStates[1],
+	box = {
+		GraphicConstants.SCREEN_WIDTH + 89,
+		68,
+		8,
+		8
+	},
+	backgroundcolor = { GraphicConstants.LAYOUTCOLORS.BOXBORDER, GraphicConstants.LAYOUTCOLORS.BOXFILL },
+	textcolor = PCHealTrackingButtonColors[1],
+	onclick = function()
+		Program.PCHealTrackingButtonState = ((Program.PCHealTrackingButtonState + 1) % 2)
+		PCHealTrackingButton.text = PCHealTrackingButtonStates[Program.PCHealTrackingButtonState + 1]
+		PCHealTrackingButton.textcolor = PCHealTrackingButtonColors[Program.PCHealTrackingButtonState + 1]
 	end
 }
 
@@ -162,5 +191,6 @@ Buttons = {
 			Tracker.TrackStatPrediction(Tracker.Data.selectedPokemon.pokemonID, Program.StatButtonState)
 		end
 	},
-	HiddenPowerButton
+	HiddenPowerButton,
+	PCHealTrackingButton
 }

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -240,7 +240,7 @@ function Drawing.drawButtons()
 	for i = 1, table.getn(Buttons), 1 do
 		if Buttons[i].visible() then
 			if Buttons[i].type == ButtonType.singleButton then
-				if Buttons[i].backgroundcolor then
+				if Buttons[i].backgroundcolor ~= nil then
 					-- Only draw border boxes where there are colors for one
 					gui.drawRectangle(Buttons[i].box[1], Buttons[i].box[2], Buttons[i].box[3], Buttons[i].box[4], Buttons[i].backgroundcolor[1], Buttons[i].backgroundcolor[2])
 				end

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -253,10 +253,6 @@ function Drawing.drawButtons()
 					gui.drawLine(Buttons[i].box[1], Buttons[i].box[2], Buttons[i].box[1] + Buttons[i].box[3], Buttons[i].box[2] + Buttons[i].box[4], Buttons[i].togglecolor)
 					gui.drawLine(Buttons[i].box[1], Buttons[i].box[2] + Buttons[i].box[4], Buttons[i].box[1] + Buttons[i].box[3], Buttons[i].box[2], Buttons[i].togglecolor)
 				end
-				if Buttons[i].drawChevron ~= nil then
-					-- Manual tracking buttons
-					Buttons[i].drawChevron(Buttons[i].box[1], Buttons[i].box[2], Buttons[i].box[3], Buttons[i].box[4] - 1, 1)
-				end
 			end
 		end
 	end

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -311,7 +311,8 @@ function Drawing.DrawTracker(monToDraw, monIsEnemy, targetMon)
 		Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 6, 67, string.format("%.0f%%", Tracker.Data.healingItems.healing) .. " HP (" .. Tracker.Data.healingItems.numHeals .. ")", GraphicConstants.LAYOUTCOLORS.INCREASE)
 		if (Settings.tracker.SURVIVAL_RULESET) then
 			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 57, "PC Heals:", GraphicConstants.LAYOUTCOLORS.NEUTRAL)
-			Drawing.drawNumber(GraphicConstants.SCREEN_WIDTH + 75, 67, Tracker.Data.centerHeals, 2, Utils.inlineIf(Tracker.Data.centerHeals < 5, GraphicConstants.LAYOUTCOLORS.INCREASE, Utils.inlineIf(Tracker.Data.centerHeals < 10, GraphicConstants.LAYOUTCOLORS.HIGHLIGHT, GraphicConstants.LAYOUTCOLORS.DECREASE)))
+			local healNumberSpacing = (2 - string.len(tostring(Tracker.Data.centerHeals))) * 5 + 75
+			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + healNumberSpacing, 67, Tracker.Data.centerHeals, Utils.inlineIf(Tracker.Data.centerHeals < 5, GraphicConstants.LAYOUTCOLORS.INCREASE, Utils.inlineIf(Tracker.Data.centerHeals < 10, GraphicConstants.LAYOUTCOLORS.HIGHLIGHT, GraphicConstants.LAYOUTCOLORS.DECREASE)))
 		end
 	end
 

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -246,7 +246,6 @@ function Drawing.drawButtons()
 				end
 				local extraY = 1
 				if Buttons[i].text == "--" then extraY = 0 end
-				if Buttons[i].text == "^" then extraY = 2 end
 				Drawing.drawText(Buttons[i].box[1], Buttons[i].box[2] + (Buttons[i].box[4] - 12) / 2 + extraY, Buttons[i].text, Buttons[i].textcolor)
 				-- PC Heal Buttons for survival mode
 				if Buttons[i] == PCHealTrackingButton and Program.PCHealTrackingButtonState then

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -243,9 +243,14 @@ function Drawing.drawButtons()
 				if Buttons[i] ~= HiddenPowerButton then
 					gui.drawRectangle(Buttons[i].box[1], Buttons[i].box[2], Buttons[i].box[3], Buttons[i].box[4], Buttons[i].backgroundcolor[1], Buttons[i].backgroundcolor[2])
 				end
+				local extraX = 0
 				local extraY = 1
+				if Buttons[i].text == "x" then
+					extraX = 1
+					extraY = 0
+				end
 				if Buttons[i].text == "--" then extraY = 0 end
-				Drawing.drawText(Buttons[i].box[1], Buttons[i].box[2] + (Buttons[i].box[4] - 12) / 2 + extraY, Buttons[i].text, Buttons[i].textcolor)
+				Drawing.drawText(Buttons[i].box[1] + extraX, Buttons[i].box[2] + (Buttons[i].box[4] - 12) / 2 + extraY, Buttons[i].text, Buttons[i].textcolor)
 			end
 		end
 	end
@@ -306,7 +311,7 @@ function Drawing.DrawTracker(monToDraw, monIsEnemy, targetMon)
 		Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 6, 67, string.format("%.0f%%", Tracker.Data.healingItems.healing) .. " HP (" .. Tracker.Data.healingItems.numHeals .. ")", GraphicConstants.LAYOUTCOLORS.INCREASE)
 		if (Settings.tracker.SURVIVAL_RULESET) then
 			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 57, "PC Heals:", GraphicConstants.LAYOUTCOLORS.NEUTRAL)
-			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 85, 67, Tracker.Data.centerHeals, Utils.inlineIf(Tracker.Data.centerHeals < 5, GraphicConstants.LAYOUTCOLORS.INCREASE, Utils.inlineIf(Tracker.Data.centerHeals < 10, GraphicConstants.LAYOUTCOLORS.HIGHLIGHT, GraphicConstants.LAYOUTCOLORS.DECREASE)))
+			Drawing.drawNumber(GraphicConstants.SCREEN_WIDTH + 75, 67, Tracker.Data.centerHeals, 2, Utils.inlineIf(Tracker.Data.centerHeals < 5, GraphicConstants.LAYOUTCOLORS.INCREASE, Utils.inlineIf(Tracker.Data.centerHeals < 10, GraphicConstants.LAYOUTCOLORS.HIGHLIGHT, GraphicConstants.LAYOUTCOLORS.DECREASE)))
 		end
 	end
 

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -240,17 +240,24 @@ function Drawing.drawButtons()
 	for i = 1, table.getn(Buttons), 1 do
 		if Buttons[i].visible() then
 			if Buttons[i].type == ButtonType.singleButton then
-				if Buttons[i] ~= HiddenPowerButton then
+				if Buttons[i].backgroundcolor then
+					-- Only draw border boxes where there are colors for one
 					gui.drawRectangle(Buttons[i].box[1], Buttons[i].box[2], Buttons[i].box[3], Buttons[i].box[4], Buttons[i].backgroundcolor[1], Buttons[i].backgroundcolor[2])
 				end
-				local extraX = 0
 				local extraY = 1
-				if Buttons[i].text == "x" then
-					extraX = 1
-					extraY = 0
-				end
 				if Buttons[i].text == "--" then extraY = 0 end
-				Drawing.drawText(Buttons[i].box[1] + extraX, Buttons[i].box[2] + (Buttons[i].box[4] - 12) / 2 + extraY, Buttons[i].text, Buttons[i].textcolor)
+				if Buttons[i].text == "^" then extraY = 2 end
+				Drawing.drawText(Buttons[i].box[1], Buttons[i].box[2] + (Buttons[i].box[4] - 12) / 2 + extraY, Buttons[i].text, Buttons[i].textcolor)
+				-- PC Heal Buttons for survival mode
+				if Buttons[i] == PCHealTrackingButton and Program.PCHealTrackingButtonState then
+					-- Auto-tracking toggle button
+					gui.drawLine(Buttons[i].box[1], Buttons[i].box[2], Buttons[i].box[1] + Buttons[i].box[3], Buttons[i].box[2] + Buttons[i].box[4], Buttons[i].togglecolor)
+					gui.drawLine(Buttons[i].box[1], Buttons[i].box[2] + Buttons[i].box[4], Buttons[i].box[1] + Buttons[i].box[3], Buttons[i].box[2], Buttons[i].togglecolor)
+				end
+				if Buttons[i].drawChevron ~= nil then
+					-- Manual tracking buttons
+					Buttons[i].drawChevron(Buttons[i].box[1], Buttons[i].box[2], Buttons[i].box[3], Buttons[i].box[4] - 1, 1)
+				end
 			end
 		end
 	end
@@ -311,6 +318,7 @@ function Drawing.DrawTracker(monToDraw, monIsEnemy, targetMon)
 		Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 6, 67, string.format("%.0f%%", Tracker.Data.healingItems.healing) .. " HP (" .. Tracker.Data.healingItems.numHeals .. ")", GraphicConstants.LAYOUTCOLORS.INCREASE)
 		if (Settings.tracker.SURVIVAL_RULESET) then
 			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + 60, 57, "PC Heals:", GraphicConstants.LAYOUTCOLORS.NEUTRAL)
+			-- Right-align the PC Heals number
 			local healNumberSpacing = (2 - string.len(tostring(Tracker.Data.centerHeals))) * 5 + 75
 			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + healNumberSpacing, 67, Tracker.Data.centerHeals, Utils.inlineIf(Tracker.Data.centerHeals < 5, GraphicConstants.LAYOUTCOLORS.INCREASE, Utils.inlineIf(Tracker.Data.centerHeals < 10, GraphicConstants.LAYOUTCOLORS.HIGHLIGHT, GraphicConstants.LAYOUTCOLORS.DECREASE)))
 		end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -7,6 +7,7 @@ Program = {
 	trainerPokemonTeam = {},
 	enemyPokemonTeam = {},
 	state = State.TRACKER,
+	PCHealTrackingButtonState = 0,
 }
 
 Program.tracker = {
@@ -273,8 +274,10 @@ function Program.HandleUpdatePoisonStepCounter()
 end
 
 function Program.HandleHealPlayerParty()
-	Tracker.Data.centerHeals = Tracker.Data.centerHeals + 1
-	Tracker.redraw = true
+	if Program.PCHealTrackingButtonState == 1 then
+		Tracker.Data.centerHeals = Tracker.Data.centerHeals + 1
+		Tracker.redraw = true
+	end
 end
 
 function Program.HandleWeHopeToSeeYouAgain()

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -7,7 +7,7 @@ Program = {
 	trainerPokemonTeam = {},
 	enemyPokemonTeam = {},
 	state = State.TRACKER,
-	PCHealTrackingButtonState = 0,
+	PCHealTrackingButtonState = false,
 }
 
 Program.tracker = {
@@ -274,10 +274,11 @@ function Program.HandleUpdatePoisonStepCounter()
 end
 
 function Program.HandleHealPlayerParty()
-	if Program.PCHealTrackingButtonState == 1 then
+	if Program.PCHealTrackingButtonState and Settings.tracker.SURVIVAL_RULESET then
 		Tracker.Data.centerHeals = Tracker.Data.centerHeals + 1
-		Tracker.redraw = true
 	end
+	-- Putting this outside the if so mon hp gets updated on PC heal
+	Tracker.redraw = true
 end
 
 function Program.HandleWeHopeToSeeYouAgain()

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -38,7 +38,7 @@ function Tracker.InitTrackerData()
 			healing = 0,
 			numHeals = 0,
 		},
-		centerHeals = 1,
+		centerHeals = 0,
 		notes = {},
 		currentHiddenPowerType = PokemonTypes.NORMAL,
 		romHash = nil,

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -38,7 +38,7 @@ function Tracker.InitTrackerData()
 			healing = 0,
 			numHeals = 0,
 		},
-		centerHeals = -1,
+		centerHeals = 1,
 		notes = {},
 		currentHiddenPowerType = PokemonTypes.NORMAL,
 		romHash = nil,


### PR DESCRIPTION
Added a little button that disables/enables the auto-tracking for PC Heals in Survival mode. It will only automatically increment while the button is showing "+" (Ideally a checkmark for full clarity but couldn't figure that out lol)

It's only toggleable via click currently (so no controller support yet)

Not the ideal end-scenario and not incredibly pretty but a quick temporary fix for #79 that would at least let the player delay the tracking until when the PC heals rule applies.

I'm also happy to work on adding buttons to adjust the count manually (my current thought is to have up/down chevrons/arrows (or similar) to the left of the number for this) and to improve this functionality, but submitting this now so that there's at least something if i don't get the rest done soon

Example Image: 
![image](https://user-images.githubusercontent.com/106463662/173559031-c09a22e0-68a7-46d6-98c4-63375454ba77.png)

(In addition i also restored the empty ROMS_FOLDER setting in Settings.ini as i noticed some users in the discord where confused about where to add it when it was just blank, i'm not sure if this change was to fix something though so lemme know if it's an issue)
