### PR TITLE
Fixing Weight-calc bug and cleaning up ReadMe

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -2,7 +2,7 @@
 -- Created by besteon, based on the PokemonBizhawkLua project by MKDasher
 
 -- The latest version of the tracker. Should be updated with each PR.
-TRACKER_VERSION = "0.3.4"
+TRACKER_VERSION = "0.3.5"
 
 -- A frequently used placeholder when a data field is not applicable
 PLACEHOLDER = "---" -- TODO: Consider moving into a better global constant location? Placed here for now to ensure it is available to all subscripts.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ If you want to use your controller to toggle stat prediction markers on opponent
 - **Stat modifying moves**: If your opponent or you use a stat modifying move, like `Growl`, up and down chevrons are displayed next to the affected stat on the target. Up to three chevrons are displayed, and change color when the fourth, fifth, and sixth stack are applied.
 - **Enemy moveset**: Enemy Pokémon moves are unknown AND they change as the various Pokémon level up throughout the game! The tracker will display moves a Pokémon has as they use them, along with the basic PP, power, and accuracy information. When you encounter the same Pokémon type later in the game, old moves are marked with a `*` at the end of the name. This allows you to know that the move may still be known or may be replaced by a new move.
 - **Stat Prediction**: Enemy Pokémon stats are unknown, but you can mark a prediction on which stats may be high or low by adding a + or - icon to the appropriate stat. This is accomplished on the enemy Pokémon by cycling through the stats with the L button and toggling the prediction with the R button.
-- **Quick loading seeds**: You can create a bunch of seeds ahead of time, and then use a button combination to load the next seed. Seeds must be in a numerical order without leading zeroes.
-  - _For example:_ you can start at 13 with a file name like `kaizo13.gba`. Pressing the button combination would then load `kaizo14.gba`. Press it again and `kaizo15.gba` is loaded. If you tried `kaizo00014.gba`, the quick load feature won't work. Remove the leading zeroes.
+- **Quick loading seeds**: You can create a bunch of seeds ahead of time, and then use a button combination to load the next seed. Seeds must be in a numerical order.
+  - _For example:_ you can start at 13 with a file name like `kaizo13.gba`. Pressing the button combination would then load `kaizo14.gba`. Press it again and `kaizo15.gba` is loaded.
 - **Notes**: Click on the bottom bar to leave a note about the Pokémon you are facing!
 - **Move effectiveness**: Moves that are super effective or not very effective against the opposing Pokémon will display one or two chevrons next to the move's power stat. Moves that are completely ineffective will display a red `X`.
 - **Attack type icons**: Icons for moves that are physical or special attack types can be displayed next to the move name.
@@ -78,6 +78,6 @@ Fix: Only update the tracker between runs when you can make a new savestate.
 
 Error: `NullHawk does not implement memory domains NLua.Exceptions.LuaException: unprotected error in call to Lua API (0)`
 
-Cause: Your roms must not have spaces in the names, or the `ROMS_FOLDER` path specified in `Settings.ini` is not correct. Your rom number also can't have leading zeros, such as Kaizo001.gba, Kaizo002.gba, etc. They must be Kaizo1.gba, Kaizo2.gba, etc.
+Cause: The `ROMS_FOLDER` path specified in `Settings.ini` is not correct, or there is no next rom available in the sequence.
 
-Fix: Rename your roms so they don't have spaces in the names.
+Fix: Make sure you have specified a `ROMS_FOLDER` location. This can be done through the gear icon on the tracker itself.

--- a/ironmon_tracker/PokemonData.lua
+++ b/ironmon_tracker/PokemonData.lua
@@ -477,7 +477,7 @@ PokemonData = {
 		evolution = "28",
 		bst = "290",
 		movelvls = { { 11, 20, 28, 35, 41, 46, 50 }, { 10, 18, 25, 31, 36, 40, 43, 45 } },
-		weight = 66.6
+		weight = 4.2
 	},
 	{
 		name = "Persian",

--- a/ironmon_tracker/PokemonData.lua
+++ b/ironmon_tracker/PokemonData.lua
@@ -525,7 +525,7 @@ PokemonData = {
 		evolution = EvolutionTypes.FIRE,
 		bst = "350",
 		movelvls = { { 7, 13, 19, 25, 31, 37, 43, 49 }, { 7, 13, 19, 25, 31, 37, 43, 49 } },
-		weight = 22.7
+		weight = 19.0
 	},
 	{
 		name = "Arcanine",

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -69,16 +69,17 @@ function Utils.isSTAB(move, pkmnData)
 	return false
 end
 
+-- For Low Kick & Grass Knot. Weight in kg.
 function Utils.calculateWeightBasedDamage(weight)
-	if weight < 10.0 then
+	if weight <= 10.0 then
 		return "20"
-	elseif weight < 25.0 then
+	elseif weight <= 25.0 then
 		return "40"
-	elseif weight < 50.0 then
+	elseif weight <= 50.0 then
 		return "60"
-	elseif weight < 100.0 then
+	elseif weight <= 100.0 then
 		return "80"
-	elseif weight < 200.0 then
+	elseif weight <= 200.0 then
 		return "100"
 	else
 		return "120"

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -69,17 +69,17 @@ function Utils.isSTAB(move, pkmnData)
 	return false
 end
 
--- For Low Kick & Grass Knot. Weight in kg.
+-- For Low Kick & Grass Knot. Weight in kg. Bounds are inclusive per decompiled code.
 function Utils.calculateWeightBasedDamage(weight)
-	if weight <= 10.0 then
+	if weight < 10.0 then
 		return "20"
-	elseif weight <= 25.0 then
+	elseif weight < 25.0 then
 		return "40"
-	elseif weight <= 50.0 then
+	elseif weight < 50.0 then
 		return "60"
-	elseif weight <= 100.0 then
+	elseif weight < 100.0 then
 		return "80"
-	elseif weight <= 200.0 then
+	elseif weight < 200.0 then
 		return "100"
 	else
 		return "120"


### PR DESCRIPTION
This PR covers three things:

1. There is a minor bug with the weight calculation. It uses less-than comparison instead of less-than-or-equal-to. Calculating base power based on target's weight uses <= according to [The Serebii.net chart](https://www.serebii.net/games/gklk.shtml).
2. Meowth's weight is incorrect. I don't know how this is/was calculated. It should be 4.2kg not 66.6kg. [Source](https://bulbapedia.bulbagarden.net/wiki/Meowth_(Pok%C3%A9mon)).
3. Minor cleanup with the ReadMe instructions and error FAQ. This is from a few updates ago that allows file names to be less strict (no leading zero requirement).