### PR TITLE
Tracker Hotfixes

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -50,13 +50,12 @@ Main.LoadNextSeed = false
 
 -- Main loop
 function Main.Run()
-	print("Checking for open ROM before loading...")
+	print("Loading...")
 	local romLoaded = false
 	while not romLoaded do
 		if gameinfo.getromname() ~= "Null" then romLoaded = true end
 		emu.frameadvance()
 	end
-	print("Loading...")
 
 	Options.buildTrackerOptionsButtons()
 	GameSettings.initialize()
@@ -126,9 +125,7 @@ function Main.LoadNext()
 
 	if Settings.config.ROMS_FOLDER == nil or Settings.config.ROMS_FOLDER == "" then
 		print("ROMS_FOLDER unspecified. Set this in Settings.ini to automatically switch ROM.")
-		Main.LoadNextSeed = false
-		Main.Run()
-		return
+		Main.CloseROM()
 	end
 
 	local romname = gameinfo.getromname()
@@ -138,9 +135,8 @@ function Main.LoadNext()
 	if romprefix == nil then romprefix = "" end
 
 	if romnumber == nil then
-		print("Current ROM does not have any numbers in its name, unable to load next seed.\nReloaded current ROM: " .. romname)
-		Main.LoadNextSeed = false
-		Main.Run()
+		print("Unable to load next ROM file: no numbers in current ROM name.\nClosing current ROM: " .. romname)
+		Main.CloseROM()
 	end
 
 	-- Increment to the next ROM and determine its full file path
@@ -158,9 +154,8 @@ function Main.LoadNext()
 		filecheck = io.open(nextrompath,"r")
 		if filecheck == nil then
 			-- This means there doesn't exist a ROM file with spaces or underscores
-			print("Unable to locate next ROM file to load.\nReloaded current ROM: " .. romname)
-			Main.LoadNextSeed = false
-			Main.Run()
+			print("Unable to locate next ROM file to load.\nClosing current ROM: " .. romname)
+			Main.CloseROM()
 		else
 			io.close(filecheck)
 		end
@@ -171,8 +166,14 @@ function Main.LoadNext()
 	print("Loading next ROM: " .. nextromname)
 	client.openrom(nextrompath)
 	client.SetSoundOn(true)
+	Main.LoadNextSeed = false
+	Main.Run()
 
+end
+
+function Main.CloseROM()
 	if gameinfo.getromname() ~= "Null" then
+		client.closerom()
 		Main.LoadNextSeed = false
 		Main.Run()
 	end

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -10,6 +10,7 @@ PLACEHOLDER = "---" -- TODO: Consider moving into a better global constant locat
 print("\nIronmon-Tracker v" .. TRACKER_VERSION)
 
 -- Check the version of BizHawk that is running
+-- Need to also check that client.getversion is an existing function, older Bizhawk versions don't have it
 if client.getversion == nil or client.getversion() ~= "2.8" then
 	print("This version of BizHawk is not supported. Please update to version 2.8 or higher.")
 	-- Bounce out... Don't pass Go! Don't collect $200.

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -10,7 +10,7 @@ PLACEHOLDER = "---" -- TODO: Consider moving into a better global constant locat
 print("\nIronmon-Tracker v" .. TRACKER_VERSION)
 
 -- Check the version of BizHawk that is running
-if string.sub(client.getversion(), 1) ~= "2.8" then
+if client.getversion == nil or client.getversion() ~= "2.8" then
 	print("This version of BizHawk is not supported. Please update to version 2.8 or higher.")
 	-- Bounce out... Don't pass Go! Don't collect $200.
 	return
@@ -60,7 +60,6 @@ function Main.Run()
 
 	Options.buildTrackerOptionsButtons()
 	GameSettings.initialize()
-
 	if GameSettings.game == 0 then
 		client.SetGameExtraPadding(0, 0, 0, 0)
 		while true do

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -24,6 +24,9 @@ INI = dofile(DATA_FOLDER .. "/Inifile.lua")
 -- Need to manually read the file to work around a bug in the ini parser, which
 -- does not correctly handle that the last iteration over lines() returns nil
 Settings = INI.parse(io.open("Settings.ini"):read("*a"), "memory")
+-- If ROMS_FOLDER is left empty, Inifile.lua doesn't add it to the settings table, resulting in the ROMS_FOLDER 
+-- being deleted entirely from Settings.ini if another setting is toggled in the tracker options menu
+if Settings.config.ROMS_FOLDER == nil then Settings.config.ROMS_FOLDER = "" end
 
 -- Import all scripts before starting the main loop
 dofile(DATA_FOLDER .. "/PokemonData.lua")

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -49,12 +49,11 @@ Main.LoadNextSeed = false
 
 -- Main loop
 function Main.Run()
-	print("Waiting 5s before loading...")
-	local frames = 0
-	local waitBeforeHook = 300
-	while frames < waitBeforeHook do
+	print("Waiting for open ROM before loading...")
+	local romLoaded = false
+	while not romLoaded do
+		if gameinfo.getromname() ~= "Null" then romLoaded = true end
 		emu.frameadvance()
-		frames = frames + 1
 	end
 	print("Loading...")
 

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -24,7 +24,10 @@ DATA_FOLDER = "ironmon_tracker"
 INI = dofile(DATA_FOLDER .. "/Inifile.lua")
 -- Need to manually read the file to work around a bug in the ini parser, which
 -- does not correctly handle that the last iteration over lines() returns nil
-Settings = INI.parse(io.open("Settings.ini"):read("*a"), "memory")
+local file = io.open("Settings.ini")
+assert(file ~= nil)
+Settings = INI.parse(file:read("*a"), "memory")
+io.close(file)
 -- If ROMS_FOLDER is left empty, Inifile.lua doesn't add it to the settings table, resulting in the ROMS_FOLDER 
 -- being deleted entirely from Settings.ini if another setting is toggled in the tracker options menu
 if Settings.config.ROMS_FOLDER == nil then Settings.config.ROMS_FOLDER = "" end

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -49,7 +49,7 @@ Main.LoadNextSeed = false
 
 -- Main loop
 function Main.Run()
-	print("Waiting for open ROM before loading...")
+	print("Checking for open ROM before loading...")
 	local romLoaded = false
 	while not romLoaded do
 		if gameinfo.getromname() ~= "Null" then romLoaded = true end

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -124,21 +124,24 @@ function Main.LoadNext()
 	userdata.clear()
 	print "Reset tracker"
 
-	if Settings.config.ROMS_FOLDER == nil then
+	if Settings.config.ROMS_FOLDER == nil or Settings.config.ROMS_FOLDER == "" then
 		print("ROMS_FOLDER unspecified. Set this in Settings.ini to automatically switch ROM.")
 		Main.LoadNextSeed = false
 		Main.Run()
 		return
 	end
 
-	client.SetSoundOn(false)
 	local romname = gameinfo.getromname()
-	client.closerom()
-	
 	-- Split the ROM name into its prefix and numerical values
 	local romprefix = string.match(romname, '[^0-9]+')
 	local romnumber = string.match(romname, '[0-9]+')
 	if romprefix == nil then romprefix = "" end
+
+	if romnumber == nil then
+		print("Current ROM does not have any numbers in its name, unable to load next seed.\nReloaded current ROM: " .. romname)
+		Main.LoadNextSeed = false
+		Main.Run()
+	end
 
 	-- Increment to the next ROM and determine its full file path
 	local nextromname = string.format(romprefix .. "%0" .. string.len(romnumber) .. "d", romnumber + 1)
@@ -155,7 +158,7 @@ function Main.LoadNext()
 		filecheck = io.open(nextrompath,"r")
 		if filecheck == nil then
 			-- This means there doesn't exist a ROM file with spaces or underscores
-			print("Unable to locate next ROM file to load. Current ROM: " .. romname)
+			print("Unable to locate next ROM file to load.\nReloaded current ROM: " .. romname)
 			Main.LoadNextSeed = false
 			Main.Run()
 		else
@@ -163,6 +166,9 @@ function Main.LoadNext()
 		end
 	end
 
+	client.SetSoundOn(false)
+	client.closerom()
+	print("Loading next ROM: " .. nextromname)
 	client.openrom(nextrompath)
 	client.SetSoundOn(true)
 

--- a/ironmon_tracker/Buttons.lua
+++ b/ironmon_tracker/Buttons.lua
@@ -29,7 +29,7 @@ local HiddenPowerState = 0
 
 HiddenPowerButton = {
 	type = ButtonType.singleButton,
-	visible = function() return Tracker.Data.selectedPlayer == 1 and Utils.playerHasMove("Hidden Power") end,
+	visible = function() return Tracker.Data.selectedPlayer == 1 and Utils.playerHasMove("Hidden Power") and Tracker.Data.needCheckSummary == 0 end,
 	text = "Hidden Power",
 	box = {
 		0,

--- a/ironmon_tracker/Data.lua
+++ b/ironmon_tracker/Data.lua
@@ -398,6 +398,7 @@ MiscData = {
 		"White Smoke",
 		"Pure Power",
 		"Shell Armor",
+		"Cacophony", -- Unused in game but still takes this slot
 		"Air Lock"
 	}
 }

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -53,6 +53,7 @@ function Drawing.drawNumber(x, y, number, spacing, color, style)
 
 	if Settings.tracker.RIGHT_JUSTIFIED_NUMBERS then
 		new_spacing = (spacing - string.len(tostring(number))) * 5
+		if number == "---" then new_spacing = 8 end
 	end
 
 	gui.drawText(x + 1 + new_spacing, y + 1, number, "black", nil, 9, "Franklin Gothic Medium", style)
@@ -549,9 +550,9 @@ function Drawing.DrawTracker(monToDraw, monIsEnemy, targetMon)
 			else
 				newPower = movePower
 			end
-			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + powerOffset, moveStartY + (distanceBetweenMoves * (moveIndex - 1)), newPower, stabColors[moveIndex])
+			Drawing.drawNumber(GraphicConstants.SCREEN_WIDTH + powerOffset, moveStartY + (distanceBetweenMoves * (moveIndex - 1)), newPower, 3, stabColors[moveIndex])
 		else
-			Drawing.drawText(GraphicConstants.SCREEN_WIDTH + powerOffset, moveStartY + (distanceBetweenMoves * (moveIndex - 1)), movePower, stabColors[moveIndex])
+			Drawing.drawNumber(GraphicConstants.SCREEN_WIDTH + powerOffset, moveStartY + (distanceBetweenMoves * (moveIndex - 1)), movePower, 3, stabColors[moveIndex])
 		end
 	end
 

--- a/ironmon_tracker/Inifile.lua
+++ b/ironmon_tracker/Inifile.lua
@@ -176,7 +176,10 @@ function inifile.save(name, t, backend)
 		end
 	end
 
-	return backends[backend].write(name, table.concat(contents, "\n"))
+	local file = io.open(name,"w")
+	assert(file~=nil)
+	file:write(table.concat(contents, "\n"))
+	io.close(file)
 end
 
 return inifile

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -21,7 +21,7 @@ function Tracker.InitTrackerData()
 			ability = 0
 		},
 		inBattle = 0,
-		needCheckSummary = 0,
+		needCheckSummary = Utils.inlineIf(Settings.tracker.MUST_CHECK_SUMMARY, 1, 0),
 		selectedPlayer = 1,
 		selectedSlot = 1,
 		targetPlayer = 2,
@@ -232,9 +232,6 @@ function Tracker.loadData()
 		end
 	else
 		Tracker.Data = Tracker.InitTrackerData()
-		if Settings.tracker.MUST_CHECK_SUMMARY == true then
-			Tracker.Data.needCheckSummary = 1
-		end
 	end
 
 	Tracker.Data.romHash = gameinfo.getromhash()


### PR DESCRIPTION
fixes #73 

This was in fact an off-by-one error as expected, after looking at the abilities list in the decomp code [here](https://github.com/pret/pokefirered/blob/master/src/data/text/abilities.h) we can see that the ability "Cacophony" occupies the ability slot between shell armor and air lock. 

This ability is an unused soundproof clone meant for the whismur line, bulbapedia seems to have just removed its id in their list of abilities and adjusted air lock onwards accordingly however the game seems to still have a slot/id reserved for it (sBattlerAblities returns 77 for Air Lock but bulbapedia assigns 76 as the id for it). Therefore I went for a simple solution of adding cacophony in the ability data to allow Air Lock to be indexed correctly in the tracker.