### PR TITLE
Fixing visual issue with using special character

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project is based on [MKDasher's PokemonBizhawkLua project](https://github.c
    - If you are feeling adventurous and wish to help us in finding bugs, you are more than welcome to clone the main branch. If the tracker crashes, please provide the log dump from the Lua Console to us via Discord or the [Issues](https://github.com/besteon/Ironmon-Tracker/issues) tab.
 2. Unzip the project anywhere you like. We recommend extracting the full folder and all of its contents directly into the `Lua` folder where you installed BizHawk. Note: The `ironmon_tracker` folder must be in the same directory as `Ironmon_Tracker.lua`.
 3. Load your ROM in [Bizhawk](https://tasvideos.org/BizHawk/ReleaseHistory) (use **version v2.8** or later for maximum compatibility)
-4. Open the Lua Console in the Bizhawk program: Tools -> Lua Console). Then click File -> Open Session... and open `Ironmon_Tracker.lua` in the location you extracted it to.
+4. Open the Lua Console in the Bizhawk program: Tools -> Lua Console). Then click the little folder icon to "Open a file" and select the `Ironmon_Tracker.lua` file in the location you extracted it to. Be careful not to click the New file icon.
    - If you installed the tracker in Bizhawk's `Lua` folder, this location is shown by default and you should see the `Ironmon_Tracker.lua` file right away.
 5. Configure the settings for the Tracker by clicking the gear/cog icon near the top of the tracker window. From here, provide a location where you keep your ROMs by clicking on the `ROMS_FOLDER` setting. Additionally, you can customize the tracker's look-and-feel through the `Customize Theme` button.
 

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -816,7 +816,7 @@ function Drawing.drawInfoScreen()
 			Drawing.drawImageAsPixels(ImageTypes.SPECIAL, offsetX + 130, botOffsetY - linespacing - 13, boxInfoTopShadow)
 		elseif moveCat == MoveCategories.STATUS then
 			categoryInfo = categoryInfo .. "Status"
-		else categoryInfo = categoryInfo .. "—" end
+		else categoryInfo = categoryInfo .. "---" end
 		Drawing.drawText(offsetX, offsetY, "Category:", GraphicConstants.THEMECOLORS["Default text"], boxInfoTopShadow)
 		Drawing.drawText(offsetColumnX, offsetY, categoryInfo, GraphicConstants.THEMECOLORS["Default text"], boxInfoTopShadow)
 		offsetY = offsetY + linespacing
@@ -828,7 +828,7 @@ function Drawing.drawInfoScreen()
 		offsetY = offsetY + linespacing
 
 		-- PP
-		local ppInfo = Utils.inlineIf(move.pp == NOPP, "—", move.pp)
+		local ppInfo = Utils.inlineIf(move.pp == NOPP, "---", move.pp)
 		Drawing.drawText(offsetX, offsetY, "PP:", GraphicConstants.THEMECOLORS["Default text"], boxInfoTopShadow)
 		Drawing.drawText(offsetColumnX, offsetY, ppInfo, GraphicConstants.THEMECOLORS["Default text"], boxInfoTopShadow)
 		offsetY = offsetY + linespacing
@@ -837,7 +837,7 @@ function Drawing.drawInfoScreen()
 		-- local isStab = Utils.isSTAB(move, PokemonData[pokemonViewed.pokemonID + 1].type)
 		local powerInfo = move.power
 		if move.power == NOPOWER then
-			powerInfo = "—"
+			powerInfo = "---"
 		-- elseif isStab then
 		-- 	Drawing.drawText(offsetColumnX + 20, offsetY, "(" .. (tonumber(move.power) * 1.5) .. ")", GraphicConstants.THEMECOLORS["Positive text"], boxInfoTopShadow)
 		end

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -846,7 +846,7 @@ function Drawing.drawInfoScreen()
 		offsetY = offsetY + linespacing
 
 		-- ACCURACY
-		local accuracyInfo = Utils.inlineIf(move.accuracy == PLACEHOLDER, "—", move.accuracy .. "%")
+		local accuracyInfo = Utils.inlineIf(move.accuracy == PLACEHOLDER, "---", move.accuracy .. "%")
 		Drawing.drawText(offsetX, offsetY, "Accuracy:", GraphicConstants.THEMECOLORS["Default text"], boxInfoTopShadow)
 		Drawing.drawText(offsetColumnX, offsetY, accuracyInfo, GraphicConstants.THEMECOLORS["Default text"], boxInfoTopShadow)
 		offsetY = offsetY + linespacing

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -225,7 +225,7 @@ function Options.openRomPickerWindow()
 end
 
 function Options.openEditControlsWindow()
-	local form = forms.newform(435, 180, "Controller Inputs", function() return end)
+	local form = forms.newform(435, 215, "Controller Inputs", function() return end)
 	forms.label(form, "Edit controller inputs for the tracker. Available inputs: A, B, L, R, Start, Select", 39, 10, 410, 20)
 
 	local inputTextboxes = {}


### PR DESCRIPTION
Move data was using "—" to display blank power/accuracy, but should have been using three "-" instead.