### PR TITLE
Ruby/Sapphire Summary Check Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ This project is based on [MKDasher's PokemonBizhawkLua project](https://github.c
    - **IMPORTANT**: _Run BizHawk once and **close** it_, then start it again before continuing! This ensures that BizHawk sets itself up properly on your system. Otherwise, the tracker may get some odd errors when trying to start it during your first use of BizHawk.
 1. **Download** the project from the [releases](https://github.com/besteon/Ironmon-Tracker/releases/latest) section. The main branch has additional changes and may not be stable.
    - If you are feeling adventurous and wish to help us in finding bugs, you are more than welcome to clone the main branch. If the tracker crashes, please provide the log dump from the Lua Console to us via Discord or the [Issues](https://github.com/besteon/Ironmon-Tracker/issues) tab.
-2. Unzip the project anywhere you like. We recommend extracting the full folder and all of its contents directly into the `Lua` folder where you installed BizHawk. Note: The `ironmon_tracker` folder must be in the same directory as `Ironmon_Tracker.lua`.
+2. Unzip the project anywhere you like. We recommend extracting the full folder and all of its contents directly into the `Lua` folder where you installed BizHawk. Note: The `ironmon_tracker` folder must be in the same directory as `Ironmon-Tracker.lua`.
 3. Load your ROM in [Bizhawk](https://tasvideos.org/BizHawk/ReleaseHistory) (use **version v2.8** or later for maximum compatibility)
-4. Open the Lua Console in the Bizhawk program: Tools -> Lua Console). Then click File -> Open Session... and open `Ironmon_Tracker.lua` in the location you extracted it to.
-   - If you installed the tracker in Bizhawk's `Lua` folder, this location is shown by default and you should see the `Ironmon_Tracker.lua` file right away.
+4. Open the Lua Console in the Bizhawk program: Tools -> Lua Console). Then click File -> Open Session... and open `Ironmon-Tracker.lua` in the location you extracted it to.
+   - If you installed the tracker in Bizhawk's `Lua` folder, this location is shown by default and you should see the `Ironmon-Tracker.lua` file right away.
 5. Configure the settings for the Tracker by clicking the gear/cog icon near the top of the tracker window. From here, provide a location where you keep your ROMs by clicking on the `ROMS_FOLDER` setting. Additionally, you can customize the tracker's look-and-feel through the `Customize Theme` button.
 
 If you want to use your controller to toggle stat prediction markers on opponent Pokémon, set Button Mode in the in-game options to LR to prevent help menu from displaying.

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -5,10 +5,8 @@ GameSettings = {
 	pstats = 0,
 	estats = 0,
 
-	summaryCheckValue = 0, -- The value to check sMonSummaryScreen against (for Ruby/Sapphire)
-
 	sMonSummaryScreen = 0x00000000,
-	sSpecialFlags = 0x00000000, -- [3 = In catching turtorial, 0 = Not in catching turtorial]
+	sSpecialFlags = 0x00000000, -- [3 = In catching tutorial, 0 = Not in catching tutorial]
 	sBattlerAbilities = 0x00000000,
 	gBattlerAttacker = 0x00000000,
 	gBattlerPartyIndexesSelfSlotOne = 0x00000000,
@@ -20,8 +18,8 @@ GameSettings = {
 	gBattleOutcome = 0x00000000, -- [0 = In battle, 1 = Won the match, 2 = Lost the match, 4 = Fled, 7 = Caught]
 
 	gSaveBlock1 = 0x00000000,
-	gSaveBlock2ptr = 0x00000000,
-	bagEncryptionKeyOffset = 0x00,
+	gSaveBlock2ptr = 0x00000000, -- Currently not needed in Ruby/Sapphire
+	bagEncryptionKeyOffset = 0x00, -- Not needed in Ruby/Sapphire
 	bagPocket_Items = 0x0,
 	bagPocket_Berries = 0x0,
 	bagPocket_Items_Size = 0,
@@ -122,8 +120,7 @@ function GameSettings.setGameAsRuby(gameversion)
 	if gameversion == 0x00410000 then
 		print("ROM Detected: Pokemon Ruby v1.0")
 
-		GameSettings.summaryCheckValue = 69 --nice
-		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
+		GameSettings.sMonSummaryScreen = 0x02000000 + 0x18000 + 0x76 -- pssData (gSharedMem + 0x18000) + lastpage offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank
 		GameSettings.gBattlerAttacker = 0x02024c07
@@ -135,8 +132,6 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
-		GameSettings.gSaveBlock2ptr = 0x00000000
-		GameSettings.bagEncryptionKeyOffset = 0x00
 		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
 		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
 		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
@@ -144,8 +139,7 @@ function GameSettings.setGameAsRuby(gameversion)
 	elseif gameversion == 0x01400000 then
 		print("ROM Detected: Pokemon Ruby v1.1")
 
-		GameSettings.summaryCheckValue = 101
-		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
+		GameSettings.sMonSummaryScreen = 0x02000000 + 0x18000 + 0x76 -- pssData (gSharedMem + 0x18000) + lastpage offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank
 		GameSettings.gBattlerAttacker = 0x02024c07
@@ -157,8 +151,6 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
-		GameSettings.gSaveBlock2ptr = 0x00000000
-		GameSettings.bagEncryptionKeyOffset = 0x00
 		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
 		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
 		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
@@ -166,8 +158,7 @@ function GameSettings.setGameAsRuby(gameversion)
 	elseif gameversion == 0x023F0000 then
 		print("ROM Detected: Pokemon Ruby v1.2")
 
-		GameSettings.summaryCheckValue = 101
-		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
+		GameSettings.sMonSummaryScreen = 0x02000000 + 0x18000 + 0x76 -- pssData (gSharedMem + 0x18000) + lastpage offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank
 		GameSettings.gBattlerAttacker = 0x02024c07
@@ -179,8 +170,6 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
-		GameSettings.gSaveBlock2ptr = 0x00000000
-		GameSettings.bagEncryptionKeyOffset = 0x00
 		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
 		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
 		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
@@ -193,8 +182,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 	if gameversion == 0x00550000 then
 		print("ROM Detected: Pokemon Sapphire v1.0")
 
-		GameSettings.summaryCheckValue = 69
-		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
+		GameSettings.sMonSummaryScreen = 0x02000000 + 0x18000 + 0x76 -- pssData (gSharedMem + 0x18000) + lastpage offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank
 		GameSettings.gBattlerAttacker = 0x02024c07
@@ -206,8 +194,6 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
-		GameSettings.gSaveBlock2ptr = 0x00000000
-		GameSettings.bagEncryptionKeyOffset = 0x00
 		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
 		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
 		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
@@ -215,8 +201,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 	elseif gameversion == 0x1540000 then
 		print("ROM Detected: Pokemon Sapphire v1.1")
 
-		GameSettings.summaryCheckValue = 101
-		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
+		GameSettings.sMonSummaryScreen = 0x02000000 + 0x18000 + 0x76 -- pssData (gSharedMem + 0x18000) + lastpage offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank
 		GameSettings.gBattlerAttacker = 0x02024c07
@@ -228,8 +213,6 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
-		GameSettings.gSaveBlock2ptr = 0x00000000
-		GameSettings.bagEncryptionKeyOffset = 0x00
 		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
 		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
 		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire
@@ -237,8 +220,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 	elseif gameversion == 0x02530000 then
 		print("ROM Detected: Pokemon Sapphire v1.2")
 
-		GameSettings.summaryCheckValue = 101
-		GameSettings.sMonSummaryScreen = 0x03001770 + 0x004 -- gMain + callback2 offset
+		GameSettings.sMonSummaryScreen = 0x02000000 + 0x18000 + 0x76 -- pssData (gSharedMem + 0x18000) + lastpage offset
 		GameSettings.sSpecialFlags = 0x0202e8e2 -- gUnknown_0202E8E2
 		GameSettings.sBattlerAbilities = 0x0203926c -- gAbilitiesPerBank
 		GameSettings.gBattlerAttacker = 0x02024c07
@@ -250,8 +232,6 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
-		GameSettings.gSaveBlock2ptr = 0x00000000
-		GameSettings.bagEncryptionKeyOffset = 0x00
 		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
 		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
 		GameSettings.bagPocket_Items_Size = 20 -- TODO: Unsure if these two values are accurate for Ruby/Sapphire

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -96,14 +96,8 @@ function Program.updateTrackedAndCurrentData()
 			-- Check for if summary screen is being shown
 			if not Tracker.Data.hasCheckedSummary then
 				local summaryCheck = Memory.readbyte(GameSettings.sMonSummaryScreen)
-				if GameSettings.game == 1 then -- Ruby/Sapphire uses a different memory address and checks for a specific value
-					if summaryCheck == GameSettings.summaryCheckValue then
-						Tracker.Data.hasCheckedSummary = true
-					end
-				else
-					if summaryCheck ~= 0 then
-						Tracker.Data.hasCheckedSummary = true
-					end
+				if summaryCheck ~= 0 then
+					Tracker.Data.hasCheckedSummary = true
 				end
 			end
 		end


### PR DESCRIPTION
Previously I implemented a check for the main callback2 function which took a seemingly unique value when in the summary screen of Ruby/Sapphire, however turns out the same value pops up during the initial copyright screen, so the tracker would immediately think the summary was checked

Upon revisiting the [ShowPokemonSummaryScreen function](https://github.com/pret/pokeruby/blob/2162e948d1889cbf5c651b9747dab1194323f2da/src/pokemon_summary_screen.c#L582) in the decomp code, I took a further look at the pssData variable. 

This variable is unique to the summary screen ("pss" = pokemon summary screen) and is stored in gSharedMem [here](https://github.com/pret/pokeruby/blob/a3228d4c86494ee25aff60fc037805ddc1d47d32/include/ewram.h#L130). This got rewritten as sMonSummaryScreen in FRLG/Emerald which functions roughly the same from what I gather

I went with the lastpage value stored in pssData [here](https://github.com/pret/pokeruby/blob/a3228d4c86494ee25aff60fc037805ddc1d47d32/include/pokemon_summary_screen.h#L48) for consistency as it is always set to the contest moves page regardless of where the summary screen is opened from.

This value stays at zero until the summary screen is opened, then takes the value of 3 (index of the contest moves page), so the check for the memory address value can be the exact same as it is for FRLG and Emerald

Current (albeit very minor) issue: 
  - This value remains at 3 permanently, it doesn't get reset, therefore if someone were to toggle the "hide stats until summary shown" setting off and back on, the stats won't be hidden.
  - This also prevents functionality of hiding stats on a new pokemon that has just been swapped to the lead slot until its summary is checked. 
  - To note this issue also happens with sMonSummaryScreen in Emerald however it doesn't seem to be an issue in FRLG

This isn't a very big issue tbf, just noting the behaviour