### PR TITLE
Fix Catch Trace and Catch Evo bugs

### DIFF
--- a/ironmon_tracker/Buttons.lua
+++ b/ironmon_tracker/Buttons.lua
@@ -297,7 +297,7 @@ function Buttons.openAbilityNoteWindow()
 		end
 
 		client.unpause()
-		Program.waitToDrawFrames = 0
+		Program.frames.waitToDraw = 0
 		forms.destroy(abilityForm)
 	end, 65, 95, 85, 25)
 	forms.button(abilityForm, "Clear", function()

--- a/ironmon_tracker/ColorPicker.lua
+++ b/ironmon_tracker/ColorPicker.lua
@@ -67,7 +67,7 @@ function ColorPicker:setColor()
 	GraphicConstants.THEMECOLORS[self.colorkey] = tonumber(self.color)
 	Theme.updated = true
 	Theme.redraw = true
-	Program.waitToDrawFrames = 0
+	Program.frames.waitToDraw = 0
 end
 
 function ColorPicker:RGB_to_Hex()
@@ -164,7 +164,7 @@ function ColorPicker:show()
 
 	-- Changes the tracker screen back to the main screen so you can see theme updates live
 	Program.state = State.TRACKER
-	Program.waitToDrawFrames = 0
+	Program.frames.waitToDraw = 0
 end
 
 function ColorPicker:onClick() 
@@ -181,7 +181,7 @@ function ColorPicker:onClose()
 	GraphicConstants.THEMECOLORS[self.colorkey] = tonumber(self.originalColor)
 	Theme.updated = true
 	Theme.redraw = true
-	Program.waitToDrawFrames = 0
+	Program.frames.waitToDraw = 0
 	Program.state = State.THEME
 	Input.currentColorPicker = nil
 	forms.destroyall()
@@ -267,7 +267,7 @@ function ColorPicker:convertHSVtoColorPicker()
 	GraphicConstants.THEMECOLORS[self.colorkey] = tonumber(self.color)
 	Theme.updated = true
 	Theme.redraw = true
-	Program.waitToDrawFrames = 0
+	Program.frames.waitToDraw = 0
 end
 
 function ColorPicker:HSV_to_RGB()

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -768,7 +768,7 @@ function Drawing.drawInfoScreen()
 		local moveId = InfoScreen.infoLookup -- moveId = 1 is blank move data
 		if moveId <= 1 or moveId > 355 then
 			Program.state = State.TRACKER
-			Program.waitToDrawFrames = 0
+			Program.frames.waitToDraw = 0
 			return
 		end
 

--- a/ironmon_tracker/InfoScreen.lua
+++ b/ironmon_tracker/InfoScreen.lua
@@ -24,7 +24,7 @@ InfoScreen.closeButton = {
 	boxColors = { "Lower box border", "Lower box background" },
 	onClick = function()
 		Program.state = State.TRACKER
-		Program.waitToDrawFrames = 0
+		Program.frames.waitToDraw = 0
 	end
 }
 -- InfoScreen.closeButton = {

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -25,17 +25,17 @@ function Input.update()
 				Tracker.Data.isViewingOwn = not Tracker.Data.isViewingOwn
 			end
 
-			Program.waitToDrawFrames = 0
+			Program.frames.waitToDraw = 0
 		end
 
 		-- "Options.CONTROLS["Cycle through stats"]" pressed, display box over next stat
 		if joypadButtons[Options.CONTROLS["Cycle through stats"]] and Input.joypad[Options.CONTROLS["Cycle through stats"]] ~= joypadButtons[Options.CONTROLS["Cycle through stats"]] then
 			Tracker.controller.statIndex = (Tracker.controller.statIndex % 6) + 1
 			Tracker.controller.framesSinceInput = 0
-			Program.waitToDrawFrames = 0
+			Program.frames.waitToDraw = 0
 		else
 			if Tracker.controller.framesSinceInput == Tracker.controller.boxVisibleFrames - 1 then
-				Program.waitToDrawFrames = 0
+				Program.frames.waitToDraw = 0
 			end
 			if Tracker.controller.framesSinceInput < Tracker.controller.boxVisibleFrames then
 				Tracker.controller.framesSinceInput = Tracker.controller.framesSinceInput + 1
@@ -91,7 +91,7 @@ function Input.update()
 				if pokemon ~= nil then
 					Tracker.TrackStatMarkings(pokemon.pokemonID, Program.StatButtonState)
 				end
-				Program.waitToDrawFrames = 0
+				Program.frames.waitToDraw = 0
 			end
 		end
 
@@ -108,7 +108,7 @@ function Input.check(xmouse, ymouse)
 				if Buttons[i].type == ButtonType.singleButton and Buttons[i].text ~= "Hidden Power" then -- Move HP clicking logic to info screen
 					if Input.isInRange(xmouse, ymouse, Buttons[i].box[1], Buttons[i].box[2], Buttons[i].box[3], Buttons[i].box[4]) then
 						Buttons[i].onclick()
-						Program.waitToDrawFrames = 0
+						Program.frames.waitToDraw = 0
 					end
 				end
 			end
@@ -119,7 +119,7 @@ function Input.check(xmouse, ymouse)
 			if button.visible() then
 				if Input.isInRange(xmouse, ymouse, button.box[1], button.box[2], button.box[3], button.box[4]) then
 					button:onclick()
-					Program.waitToDrawFrames = 0
+					Program.frames.waitToDraw = 0
 				end
 			end
 		end
@@ -127,7 +127,7 @@ function Input.check(xmouse, ymouse)
 		-- settings gear
 		if Input.isInRange(xmouse, ymouse, GraphicConstants.SCREEN_WIDTH + 101 - 8, 7, 7, 7) then
 			Options.redraw = true
-			Program.waitToDrawFrames = 0
+			Program.frames.waitToDraw = 0
 			Program.state = State.SETTINGS
 		end
 
@@ -179,7 +179,7 @@ function Input.check(xmouse, ymouse)
 					local pokemon = Tracker.getPokemon(Tracker.Data.otherViewSlot, false)
 					if formInput ~= nil and pokemon ~= nil then
 						Tracker.TrackNote(pokemon.pokemonID, formInput)
-						Program.waitToDrawFrames = 0
+						Program.frames.waitToDraw = 0
 					end
 					forms.destroy(Input.noteForm)
 					Input.noteForm = nil

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -60,7 +60,7 @@ Options.closeButton = {
 		Options.saveOptions()
 
 		Program.state = State.TRACKER
-		Program.waitToDrawFrames = 0
+		Program.frames.waitToDraw = 0
 	end
 }
 
@@ -90,7 +90,7 @@ Options.themeButton = {
 		-- Navigate to the Theme Customization menu
 		Program.state = State.THEME
 		Theme.redraw = true
-		Program.waitToDrawFrames = 0
+		Program.frames.waitToDraw = 0
 	end
 }
 
@@ -126,7 +126,7 @@ function Options.buildTrackerOptionsButtons()
 				
 				Options.updated = true
 				Options.redraw = true
-				Program.waitToDrawFrames = 0
+				Program.frames.waitToDraw = 0
 			end
 		}
 		table.insert(Options.optionsButtons, button)
@@ -175,7 +175,7 @@ function Options.loadOptions()
 	end
 
 	Options.redraw = true
-	Program.waitToDrawFrames = 0
+	Program.frames.waitToDraw = 0
 end
 
 -- Saves all in-memory Options and Theme elements into the Settings object, to be written to Settings.ini
@@ -221,7 +221,7 @@ function Options.openRomPickerWindow()
 
 	Options.updated = true
 	Options.redraw = true
-	Program.waitToDrawFrames = 0
+	Program.frames.waitToDraw = 0
 end
 
 function Options.openEditControlsWindow()

--- a/ironmon_tracker/Theme.lua
+++ b/ironmon_tracker/Theme.lua
@@ -88,7 +88,7 @@ Theme.moveTypeEnableButton = {
 		GraphicConstants.MOVE_TYPES_ENABLED = Settings.theme["MOVE_TYPES_ENABLED"]
 		Theme.redraw = true
 		Theme.updated = true
-		Program.waitToDrawFrames = 0
+		Program.frames.waitToDraw = 0
 	end
 }
 
@@ -140,7 +140,7 @@ function Theme.loadTheme()
 	end
 
 	Theme.redraw = true
-	Program.waitToDrawFrames = 0
+	Program.frames.waitToDraw = 0
 end
 
 -- Imports a theme config string into the Tracker, reloads all Tracker visuals, and flags to update Settings.ini
@@ -262,7 +262,7 @@ function Theme.tryRestoreDefaultTheme()
 		Theme.restoreDefaultsButton.confirmReset = true
 
 		Theme.redraw = true
-		Program.waitToDrawFrames = 0
+		Program.frames.waitToDraw = 0
 	end
 end
 
@@ -276,6 +276,6 @@ function Theme.closeMenuAndSave()
 
 	-- Inform the Tracker Program to load the Options screen
 	Options.redraw = true
-	Program.waitToDrawFrames = 0
+	Program.frames.waitToDraw = 0
 	Program.state = State.SETTINGS
 end

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -329,7 +329,7 @@ function Tracker.loadData()
 	end
 
 	Tracker.Data.romHash = gameinfo.getromhash()
-	Program.waitToDrawFrames = 0
+	Program.frames.waitToDraw = 0
 end
 
 function Tracker.Clear()


### PR DESCRIPTION
Fixes #102 

This fixes an issue where catching a Pokemon with Trace records its ability as the "traced ability" and not actually the ability Trace.

Unrelated, this fixes an issue where catching a pokemon and then immediately evolving it won't remove it's old ability, because the personality values still matched.

Finally, doing some small renaming for frame updates. And saving tracker data after ever battle.