### PR TITLE
Relative form location

### DIFF
--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -959,3 +959,13 @@ function Drawing.drawImageAsPixels(imageType, x, y, imageShadow)
 		end
 	end
 end
+
+--sets the form location relative to the game window
+--this function does what the built in forms.setlocation function supposed to do
+--currently that function is bugged and should be fixed in 2.9
+function Drawing.setFormLocation(handel,x,y)
+	local ribbonHight = 64 -- so we are below the ribbon menu 
+	local actualLocation = client.transformPoint(x,y)
+	forms.setproperty(Input.noteForm, "Left", client.xpos() + actualLocation['x'] )
+	forms.setproperty(Input.noteForm, "Top", client.ypos() + actualLocation['y'] + ribbonHight)
+end

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -959,13 +959,3 @@ function Drawing.drawImageAsPixels(imageType, x, y, imageShadow)
 		end
 	end
 end
-
---sets the form location relative to the game window
---this function does what the built in forms.setlocation function supposed to do
---currently that function is bugged and should be fixed in 2.9
-function Drawing.setFormLocation(handel,x,y)
-	local ribbonHight = 64 -- so we are below the ribbon menu 
-	local actualLocation = client.transformPoint(x,y)
-	forms.setproperty(Input.noteForm, "Left", client.xpos() + actualLocation['x'] )
-	forms.setproperty(Input.noteForm, "Top", client.ypos() + actualLocation['y'] + ribbonHight)
-end

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -176,7 +176,7 @@ function Input.check(xmouse, ymouse)
 				Input.noteForm = forms.newform(465, 125, "Leave a Note", function() Input.noteForm = nil end)
 				local formWidth = client.screenwidth() - actualGameSize['x'] + 15
 				forms.setproperty(Input.noteForm,"Width",formWidth)
-				Drawing.setFormLocation(Input.noteForm,GraphicConstants.SCREEN_WIDTH,50)
+				Utils.setFormLocation(Input.noteForm,GraphicConstants.SCREEN_WIDTH,50)
 				forms.label(Input.noteForm, "Enter a note for " .. pokemonName .. " (70 char. max):", 9, 10, 300, 20)
 				local noteTextBox = forms.textbox(Input.noteForm, Tracker.getNote(pokemon.pokemonID), 430, 20, nil, 10, 30)
 				forms.setproperty(noteTextBox,"Width",formWidth - 40)

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -170,11 +170,17 @@ function Input.check(xmouse, ymouse)
 				if pokemon ~= nil then
 					pokemonName = PokemonData[pokemon.pokemonID + 1].name
 				end
-				
+				--forms buttons and textbox initial  width is wrong width its being set in setproperty Width
+				--had to change it after the initial value because the built in functions use UIHelper.Scale which mess everything
+				local actualGameSize = client.transformPoint(GraphicConstants.SCREEN_WIDTH,0)
 				Input.noteForm = forms.newform(465, 125, "Leave a Note", function() Input.noteForm = nil end)
+				local formWidth = client.screenwidth() - actualGameSize['x'] + 15
+				forms.setproperty(Input.noteForm,"Width",formWidth)
+				Drawing.setFormLocation(Input.noteForm,GraphicConstants.SCREEN_WIDTH,50)
 				forms.label(Input.noteForm, "Enter a note for " .. pokemonName .. " (70 char. max):", 9, 10, 300, 20)
 				local noteTextBox = forms.textbox(Input.noteForm, Tracker.getNote(pokemon.pokemonID), 430, 20, nil, 10, 30)
-				forms.button(Input.noteForm, "Save", function()
+				forms.setproperty(noteTextBox,"Width",formWidth - 40)
+				local btn = forms.button(Input.noteForm, "Save", function()
 					local formInput = forms.gettext(noteTextBox)
 					local pokemon = Tracker.getPokemon(Tracker.Data.otherViewSlot, false)
 					if formInput ~= nil and pokemon ~= nil then
@@ -184,6 +190,8 @@ function Input.check(xmouse, ymouse)
 					forms.destroy(Input.noteForm)
 					Input.noteForm = nil
 				end, 187, 55)
+				local defualtBtnWidth = 75
+				forms.setproperty(btn,"Left",formWidth / 2 - defualtBtnWidth/2)
 			end
 		end
 	-- Info Screen mouse input regions

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -273,3 +273,13 @@ function Utils.getWordWrapLines(str, limit)
 	
 	return lines
 end
+
+--sets the form location relative to the game window
+--this function does what the built in forms.setlocation function supposed to do
+--currently that function is bugged and should be fixed in 2.9
+function Utils.setFormLocation(handle,x,y)
+	local ribbonHight = 64 -- so we are below the ribbon menu 
+	local actualLocation = client.transformPoint(x,y)
+	forms.setproperty(handle, "Left", client.xpos() + actualLocation['x'] )
+	forms.setproperty(handle, "Top", client.ypos() + actualLocation['y'] + ribbonHight)
+end


### PR DESCRIPTION
added function that allows you to set form relative to the top left of the game screen 
second commit uses this function to open the note form at logical for me location and made the note resize to match tracker size when it changes 