### PR TITLE
fixed note width to be closer to tracker width

### DIFF
--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -174,9 +174,9 @@ function Input.check(xmouse, ymouse)
 				--had to change it after the initial value because the built in functions use UIHelper.Scale which mess everything
 				local actualGameSize = client.transformPoint(GraphicConstants.SCREEN_WIDTH,0)
 				Input.noteForm = forms.newform(465, 125, "Leave a Note", function() Input.noteForm = nil end)
-				local formWidth = client.screenwidth() - actualGameSize['x'] + 15
+				local formWidth = client.screenwidth() - actualGameSize['x']  - client.borderwidth() - 5
 				forms.setproperty(Input.noteForm,"Width",formWidth)
-				Utils.setFormLocation(Input.noteForm,GraphicConstants.SCREEN_WIDTH,50)
+				Utils.setFormLocation(Input.noteForm,GraphicConstants.SCREEN_WIDTH + 5,50)
 				forms.label(Input.noteForm, "Enter a note for " .. pokemonName .. " (70 char. max):", 9, 10, 300, 20)
 				local noteTextBox = forms.textbox(Input.noteForm, Tracker.getNote(pokemon.pokemonID), 430, 20, nil, 10, 30)
 				forms.setproperty(noteTextBox,"Width",formWidth - 40)


### PR DESCRIPTION
this fixes an issue with the width of the note form that doesn't match tracker width if someone resized the screen only in width 

before fix it would look like this:
<img src="https://user-images.githubusercontent.com/109386070/179362128-9ccad05d-5b1d-444c-9156-0b84aa71e26b.png" width=50% height=50%>

after fix it looks like this 
<img src="https://user-images.githubusercontent.com/109386070/179362431-7f4d8d83-9d58-45e3-bb8e-ea370272aeb4.png" width=50% height=50%>

this doesn't fix the issue completely the main problem is there is no way to get the actual tracker size that is drawn with gui.drawRectangle after the scaling so if you would resize the game you could notice that the form doesn't match the tracker size completely
