### PR TITLE
PC Heals update fix

### DIFF
--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -47,7 +47,7 @@ function Program.main()
 			Program.frames.waitToDraw = 30
 
 			-- Update current PC Heal count if auto-tracked
-			if Options["Track PC Heals"] and Program.PCHealTrackingButtonState then
+			if Options["Track PC Heals"] then
 				Program.updatePCHeals()
 			end
 
@@ -501,19 +501,21 @@ function Program.updatePCHeals()
 
 	local combinedHeals = gameStat_UsedPokecenter + gameStat_RestedAtHome
 
-	-- Determine if the tracked heals need to be updated
 	if combinedHeals ~= Tracker.Data.gameStatsHeals then
-		local healsToUpdate = combinedHeals - Tracker.Data.gameStatsHeals
-		if Options["PC heals count downward"] then
-			-- Automatically count down
-			Tracker.Data.centerHeals = Tracker.Data.centerHeals - healsToUpdate
-			if Tracker.Data.centerHeals < 0 then Tracker.Data.centerHeals = 0 end
-		else
-			-- Automatically count up
-			Tracker.Data.centerHeals = Tracker.Data.centerHeals + healsToUpdate
-			if Tracker.Data.centerHeals > 99 then Tracker.Data.centerHeals = 99 end
-		end
+		-- Update the local tally if there is a new heal
 		Tracker.Data.gameStatsHeals = combinedHeals
+		if Program.PCHealTrackingButtonState then
+			-- Only change the displayed count when the auto-tracking is enabled
+			if Options["PC heals count downward"] then
+				-- Automatically count down
+				Tracker.Data.centerHeals = Tracker.Data.centerHeals - 1
+				if Tracker.Data.centerHeals < 0 then Tracker.Data.centerHeals = 0 end
+			else
+				-- Automatically count up
+				Tracker.Data.centerHeals = Tracker.Data.centerHeals + 1
+				if Tracker.Data.centerHeals > 99 then Tracker.Data.centerHeals = 99 end
+			end
+		end
 	end
 end
 

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -46,10 +46,7 @@ function Program.main()
 		if Program.frames.waitToDraw == 0 then
 			Program.frames.waitToDraw = 30
 
-			-- Update current PC Heal count if auto-tracked
-			if Options["Track PC Heals"] then
-				Program.updatePCHeals()
-			end
+			Program.updatePCHeals()
 
 			local ownersPokemon = Tracker.getPokemon(Tracker.Data.ownViewSlot, true)
 			local opposingPokemon = Tracker.getPokemon(Tracker.Data.otherViewSlot, false)
@@ -474,7 +471,7 @@ function Program.updateButtons(state)
 end
 
 function Program.updatePCHeals()
-	-- Auto-tracking of PC heals
+	-- Updates PC Heal tallies and handles auto-tracking PC Heal counts when the option is on
 	local gameStatsAddr = 0x0
 	if GameSettings.game == 1 then
 		-- Ruby/Sapphire doesn't have gSaveBlock1Ptr and just uses gSaveBlock1 directly
@@ -504,8 +501,8 @@ function Program.updatePCHeals()
 	if combinedHeals ~= Tracker.Data.gameStatsHeals then
 		-- Update the local tally if there is a new heal
 		Tracker.Data.gameStatsHeals = combinedHeals
-		if Program.PCHealTrackingButtonState then
-			-- Only change the displayed count when the auto-tracking is enabled
+		-- Only change the displayed PC Heals count when the option is on and auto-tracking is enabled
+		if Options["Track PC Heals"] and Program.PCHealTrackingButtonState then
 			if Options["PC heals count downward"] then
 				-- Automatically count down
 				Tracker.Data.centerHeals = Tracker.Data.centerHeals - 1


### PR DESCRIPTION
Small fix to prevent PC Heals count being incorrectly updated due to the player healing while the auto-tracking is turned off

The tallies always get updated so it can correctly register a new PC heal when the PC Heals option and auto-tracking is turned on, but with this fix should no longer "adjust" the value as soon as the option is enabled