### PR TITLE
Fixing Focus Punch track on chargeup

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -80,7 +80,6 @@ function Main.Run()
 		client.SetGameExtraPadding(0, GraphicConstants.UP_GAP, GraphicConstants.RIGHT_GAP, GraphicConstants.DOWN_GAP)
 		gui.defaultTextBackground(0)
 
-		event.onloadstate(Tracker.loadData, "OnLoadState")
 		event.onexit(Program.HandleExit, "HandleExit")
 
 		while Main.LoadNextSeed == false do

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -16,6 +16,7 @@ GameSettings = {
 	gBattlerPartyIndexesEnemySlotTwo = 0x00000000,
 	gBattleMons = 0x00000000,
 	gBattlescriptCurrInstr = 0x00000000,
+	BattleScript_FocusPunchSetUp = 0x00000000,
 	gBattleOutcome = 0x00000000, -- [0 = In battle, 1 = Won the match, 2 = Lost the match, 4 = Fled, 7 = Caught]
 
 	gSaveBlock1 = 0x00000000,
@@ -261,6 +262,7 @@ function GameSettings.setGameAsEmerald(gameversion)
 	GameSettings.gBattlerPartyIndexesEnemySlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x6
 	GameSettings.gBattleMons = 0x02024084
 	GameSettings.gBattlescriptCurrInstr = 0x02024214
+	GameSettings.BattleScript_FocusPunchSetUp = 0x082db1ff + 0x10 -- TODO: offset for this game is untested
 	GameSettings.gBattleOutcome = 0x0202433a
 
 	GameSettings.gSaveBlock1 = 0x02025a00
@@ -317,6 +319,7 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.gBattlerPartyIndexesEnemySlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x6
 		GameSettings.gBattleMons = 0x02023be4
 		GameSettings.gBattlescriptCurrInstr = 0x02023d74
+		GameSettings.BattleScript_FocusPunchSetUp = 0x081d9085 + 0x10 -- TODO: offset for this game is untested
 		GameSettings.gBattleOutcome = 0x02023e8a
 
 		GameSettings.gSaveBlock1 = 0x0202552c
@@ -384,6 +387,7 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.gBattlerPartyIndexesEnemySlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x6
 		GameSettings.gBattleMons = 0x02023be4
 		GameSettings.gBattlescriptCurrInstr = 0x02023d74
+		GameSettings.BattleScript_FocusPunchSetUp = 0x081d9015 + 0x10
 		GameSettings.gBattleOutcome = 0x02023e8a
 
 		GameSettings.gSaveBlock1 = 0x0202552c
@@ -441,6 +445,7 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.gBattlerPartyIndexesEnemySlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x6
 		GameSettings.gBattleMons = 0x02023be4
 		GameSettings.gBattlescriptCurrInstr = 0x02023d74
+		GameSettings.BattleScript_FocusPunchSetUp = 0x081d9061 + 0x10 -- TODO: offset for this game is untested
 		GameSettings.gBattleOutcome = 0x02023e8a
 
 		GameSettings.gSaveBlock1 = 0x0202552c
@@ -494,6 +499,7 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.gBattlerPartyIndexesEnemySlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x6
 		GameSettings.gBattleMons = 0x02023be4
 		GameSettings.gBattlescriptCurrInstr = 0x02023d74
+		GameSettings.BattleScript_FocusPunchSetUp = 0x081d8ff1 + 0x10 -- TODO: offset for this game is untested
 		GameSettings.gBattleOutcome = 0x02023e8a
 
 		GameSettings.gSaveBlock1 = 0x0202552c

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -405,6 +405,15 @@ function Program.updateBattleDataFromMemory()
 				Program.handleAttackMove(move.id, Tracker.Data.otherViewSlot, false)
 			end
 		end
+
+		if GameSettings.gBattlescriptCurrInstr ~= 0x00000000 and GameSettings.BattleScript_FocusPunchSetUp ~= 0x00000000 then
+			local battleMsg = Memory.readdword(GameSettings.gBattlescriptCurrInstr)
+			
+			-- Manually track Focus Punch, since PP isn't deducted if the mon charges the move but then dies
+			if battleMsg == GameSettings.BattleScript_FocusPunchSetUp then
+				Program.handleAttackMove(264 + 1, Tracker.Data.otherViewSlot, false)
+			end
+		end
 	end
 end
 

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -313,7 +313,7 @@ function Tracker.loadData(filepath)
 	-- Loose safety check to ensure a valid data file is loaded
 	local trackerData = nil
 	if filepath:sub(-5):lower() ~= GameSettings.fileExtension then
-		print("[ERROR] Unable to load Tracker data from selected file.")
+		print("[ERROR] Unable to load Tracker data from selected file: " .. filepath)
 	else
 		trackerData = Utils.readTableFromFile(filepath)
 	end


### PR DESCRIPTION
Fixes #18 

Focus Punch is a weird move in that it doesn't deplete PP when it's charging up, but only if the Pokemon gets a turn to execute the move (or flinch). If the Pokemon dies, then punch is never tracked.

This fix checks the battle messages to see if the charge up animation occurs, and if so it tracks the move then and there. Confirmed to work in FireRed 1.0, unsure if it works in other versions.

Bonus Fix: Since tracker data is no longer kept in the save state, removing the event hook for that.