### PR TITLE
Fix heal count

### DIFF
--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -25,8 +25,8 @@ GameSettings = {
 	gameStatsOffset = 0x0,
 	EncryptionKeyOffset = 0x00, -- Doesn't exist in Ruby/Sapphire
 	badgeOffset = 0x0,
-	bagPocket_Items = 0x0,
-	bagPocket_Berries = 0x0,
+	bagPocket_Items_offset = 0x0,
+	bagPocket_Berries_offset = 0x0,
 	bagPocket_Items_Size = 0,
 	bagPocket_Berries_Size = 0,
 }
@@ -139,8 +139,8 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
 		GameSettings.badgeOffset = 0x1220 + 0x100 -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_offset = 0x560
+		GameSettings.bagPocket_Berries_offset = 0x740
 		GameSettings.bagPocket_Items_Size = 20
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x01400000 then
@@ -160,8 +160,8 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
 		GameSettings.badgeOffset = 0x1220 + 0x100 -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_offset = 0x560
+		GameSettings.bagPocket_Berries_offset = 0x740
 		GameSettings.bagPocket_Items_Size = 20
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x023F0000 then
@@ -181,8 +181,8 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
 		GameSettings.badgeOffset = 0x1220 + 0x100 -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_offset = 0x560
+		GameSettings.bagPocket_Berries_offset = 0x740
 		GameSettings.bagPocket_Items_Size = 20
 		GameSettings.bagPocket_Berries_Size = 46
 	end
@@ -207,8 +207,8 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
 		GameSettings.badgeOffset = 0x1220 + 0x100 -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_offset = 0x560
+		GameSettings.bagPocket_Berries_offset = 0x740
 		GameSettings.bagPocket_Items_Size = 20
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x1540000 then
@@ -228,8 +228,8 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
 		GameSettings.badgeOffset = 0x1220 + 0x100 -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_offset = 0x560
+		GameSettings.bagPocket_Berries_offset = 0x740
 		GameSettings.bagPocket_Items_Size = 20
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x02530000 then
@@ -249,8 +249,8 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
 		GameSettings.badgeOffset = 0x1220 + 0x100 -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x740
+		GameSettings.bagPocket_Items_offset = 0x560
+		GameSettings.bagPocket_Berries_offset = 0x740
 		GameSettings.bagPocket_Items_Size = 20
 		GameSettings.bagPocket_Berries_Size = 46
 	end
@@ -278,8 +278,8 @@ function GameSettings.setGameAsEmerald(gameversion)
 	GameSettings.gameStatsOffset = 0x159C
 	GameSettings.EncryptionKeyOffset = 0xAC
 	GameSettings.badgeOffset = 0x1270 + 0x10C -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
-	GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x560
-	GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x790
+	GameSettings.bagPocket_Items_offset = 0x560
+	GameSettings.bagPocket_Berries_offset = 0x790
 	GameSettings.bagPocket_Items_Size = 30
 	GameSettings.bagPocket_Berries_Size = 46
 
@@ -336,8 +336,8 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.gameStatsOffset = 0x1200
 		GameSettings.EncryptionKeyOffset = 0xF20
 		GameSettings.badgeOffset = 0xEE0 + 0x104 -- [SaveBlock1's flags offset] + [Badge flag offset: (SYSTEM_FLAGS + FLAG_BADGE01_GET) / 8]
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x310
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x54c
+		GameSettings.bagPocket_Items_offset = 0x310
+		GameSettings.bagPocket_Berries_offset = 0x54c
 		GameSettings.bagPocket_Items_Size = 42
 		GameSettings.bagPocket_Berries_Size = 43
 
@@ -405,8 +405,8 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.gameStatsOffset = 0x1200
 		GameSettings.EncryptionKeyOffset = 0xF20
 		GameSettings.badgeOffset = 0xEE0 + 0x104 -- [SaveBlock1's flags offset] + [Badge flag offset: (SYSTEM_FLAGS + FLAG_BADGE01_GET) / 8]
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x310
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x54c
+		GameSettings.bagPocket_Items_offset = 0x310
+		GameSettings.bagPocket_Berries_offset = 0x54c
 		GameSettings.bagPocket_Items_Size = 42
 		GameSettings.bagPocket_Berries_Size = 43
 
@@ -464,8 +464,8 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.gameStatsOffset = 0x1200
 		GameSettings.EncryptionKeyOffset = 0xF20
 		GameSettings.badgeOffset = 0xEE0 + 0x104 -- [SaveBlock1's flags offset] + [Badge flag offset: (SYSTEM_FLAGS + FLAG_BADGE01_GET) / 8]
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x310
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x54c
+		GameSettings.bagPocket_Items_offset = 0x310
+		GameSettings.bagPocket_Berries_offset = 0x54c
 		GameSettings.bagPocket_Items_Size = 42
 		GameSettings.bagPocket_Berries_Size = 43
 
@@ -519,8 +519,8 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.gameStatsOffset = 0x1200
 		GameSettings.EncryptionKeyOffset = 0xF20
 		GameSettings.badgeOffset = 0xEE0 + 0x104 -- [SaveBlock1's flags offset] + [Badge flag offset: (SYSTEM_FLAGS + FLAG_BADGE01_GET) / 8]
-		GameSettings.bagPocket_Items = GameSettings.gSaveBlock1 + 0x310
-		GameSettings.bagPocket_Berries = GameSettings.gSaveBlock1 + 0x54c
+		GameSettings.bagPocket_Items_offset = 0x310
+		GameSettings.bagPocket_Berries_offset = 0x54c
 		GameSettings.bagPocket_Items_Size = 42
 		GameSettings.bagPocket_Berries_Size = 43
 

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -741,14 +741,12 @@ function Program.getHealingItemsFromMemory()
 	end
 
 	local healingItems = {}
-
+	local saveBlock1Addr = Utils.getSaveBlock1Addr()
 	local addressesToScan = {
-		GameSettings.bagPocket_Items,
-		GameSettings.bagPocket_Berries,
+		[saveBlock1Addr + GameSettings.bagPocket_Items_offset] = GameSettings.bagPocket_Items_Size,
+		[saveBlock1Addr + GameSettings.bagPocket_Berries_offset] = GameSettings.bagPocket_Berries_Size,
 	}
-
-	for _, address in pairs(addressesToScan) do
-		local size = Utils.inlineIf(address == GameSettings.bagPocket_Items, GameSettings.bagPocket_Items_Size, GameSettings.bagPocket_Berries_Size)
+	for address, size in pairs(addressesToScan) do
 		for i = 0, (size - 1), 1 do
 			--read 4 bytes at once, should be less expensive than reading two sets of 2 bytes.
 			local itemid_and_quantity = Memory.readdword(address + i * 0x4)

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -530,13 +530,12 @@ end
 
 function Program.updateBadgesObtainedFromMemory()
 	local badgeBits = nil
+	local saveblock1Addr = Utils.getSaveBlock1Addr()
 	if GameSettings.game == 1 then -- Ruby/Sapphire
-		badgeBits = Utils.getbits(Memory.readword(GameSettings.gSaveBlock1 + GameSettings.badgeOffset), 7, 8)
+		badgeBits = Utils.getbits(Memory.readword(saveblock1Addr + GameSettings.badgeOffset), 7, 8)
 	elseif GameSettings.game == 2 then -- Emerald
-		local saveblock1Addr = Memory.readdword(GameSettings.gSaveBlock1ptr)
 		badgeBits = Utils.getbits(Memory.readword(saveblock1Addr + GameSettings.badgeOffset), 7, 8)
 	elseif GameSettings.game == 3 then -- FireRed/LeafGreen
-		local saveblock1Addr = Memory.readdword(GameSettings.gSaveBlock1ptr)
 		badgeBits = Memory.readbyte(saveblock1Addr + GameSettings.badgeOffset)
 	end
 

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -357,3 +357,10 @@ function Utils.setFormLocation(handle,x,y)
 	forms.setproperty(handle, "Left", client.xpos() + actualLocation['x'] )
 	forms.setproperty(handle, "Top", client.ypos() + actualLocation['y'] + ribbonHight)
 end
+
+function Utils.getSaveBlock1Addr()
+	if GameSettings.game == 1 then -- Ruby/Sapphire dont have ptr
+		return GameSettings.gSaveBlock1
+	end
+	return Memory.readdword(GameSettings.gSaveBlock1ptr)
+end


### PR DESCRIPTION
this is a fix for issue #37  
added function that return the correct saveBlock1Adrress depending if current game is rs or efrlg 
used it to iterate over the bag now
changed badge check to use that function to be consistent

from now on if you need to read something from saveBlock1 use Utils.getSaveBlock1Addr() to get the correct address  