### PR TITLE
Feature: Click on the game screen while learning a new move for tracker info

### DIFF
--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -612,8 +612,11 @@ function Drawing.drawOptionsScreen()
 		Drawing.drawText(Options.buttons.romsFolder.box[1] + 54, Options.buttons.romsFolder.box[2], folderText, Theme.COLORS[Options.buttons.romsFolder.textColor], shadowcolor)
 	else
 		Drawing.drawImageAsPixels(Constants.PIXEL_IMAGES.NOTEPAD, Constants.SCREEN.WIDTH + 60, 7, shadowcolor)
-		Drawing.drawText(Options.buttons.romsFolder.box[1] + 65, Options.buttons.romsFolder.box[2], "(Click a file to set)", Theme.COLORS[Options.buttons.romsFolder.textColor], shadowcolor)
+		Drawing.drawText(Options.buttons.romsFolder.box[1] + 65, Options.buttons.romsFolder.box[2], "(Click a file to set)", Theme.COLORS["Intermediate text"], shadowcolor)
 	end
+
+	-- Draw version number, TODO: Someone add a fun easter egg for clicking on it multiple times
+	Drawing.drawText(Constants.SCREEN.WIDTH + 86, 142, "v." .. TRACKER_VERSION, Theme.COLORS["Default text"], shadowcolor)
 end
 
 function Drawing.drawThemeScreen()

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -18,6 +18,9 @@ GameSettings = {
 	gBattleMons = 0x00000000,
 	gBattlescriptCurrInstr = 0x00000000,
 	BattleScript_FocusPunchSetUp = 0x00000000,
+	BattleScript_LearnMoveLoop = 0x00000000,
+	BattleScript_LearnMoveReturn = 0x00000000,
+	gMoveToLearn = 0x00000000,
 	gBattleOutcome = 0x00000000, -- [0 = In battle, 1 = Won the match, 2 = Lost the match, 4 = Fled, 7 = Caught]
 
 	gSaveBlock1 = 0x00000000,
@@ -135,6 +138,10 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gBattlerPartyIndexesSelfSlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x4
 		GameSettings.gBattlerPartyIndexesEnemySlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x6
 		GameSettings.gBattleMons = 0x02024a80
+		GameSettings.gBattlescriptCurrInstr = 0x02024c10
+		GameSettings.BattleScript_LearnMoveLoop = 0x081d8f0f -- BattleScript_TryLearnMoveLoop
+		GameSettings.BattleScript_LearnMoveReturn = 0x081d8f61
+		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -156,6 +163,10 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gBattlerPartyIndexesSelfSlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x4
 		GameSettings.gBattlerPartyIndexesEnemySlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x6
 		GameSettings.gBattleMons = 0x02024a80
+		GameSettings.gBattlescriptCurrInstr = 0x02024c10
+		GameSettings.BattleScript_LearnMoveLoop = 0x081d8f27 -- BattleScript_TryLearnMoveLoop
+		GameSettings.BattleScript_LearnMoveReturn = 0x081d8f79
+		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -177,6 +188,10 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gBattlerPartyIndexesSelfSlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x4
 		GameSettings.gBattlerPartyIndexesEnemySlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x6
 		GameSettings.gBattleMons = 0x02024a80
+		GameSettings.gBattlescriptCurrInstr = 0x02024c10
+		GameSettings.BattleScript_LearnMoveLoop = 0x081d8f27 -- BattleScript_TryLearnMoveLoop
+		GameSettings.BattleScript_LearnMoveReturn = 0x081d8f79
+		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -203,6 +218,10 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gBattlerPartyIndexesSelfSlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x4
 		GameSettings.gBattlerPartyIndexesEnemySlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x6
 		GameSettings.gBattleMons = 0x02024a80
+		GameSettings.gBattlescriptCurrInstr = 0x02024c10
+		GameSettings.BattleScript_LearnMoveLoop = 0x081d8e9f -- BattleScript_TryLearnMoveLoop
+		GameSettings.BattleScript_LearnMoveReturn = 0x081d8ef1
+		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -224,6 +243,10 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gBattlerPartyIndexesSelfSlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x4
 		GameSettings.gBattlerPartyIndexesEnemySlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x6
 		GameSettings.gBattleMons = 0x02024a80
+		GameSettings.gBattlescriptCurrInstr = 0x02024c10
+		GameSettings.BattleScript_LearnMoveLoop = 0x081d8eb7 -- BattleScript_TryLearnMoveLoop
+		GameSettings.BattleScript_LearnMoveReturn = 0x081d8f09
+		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -245,6 +268,10 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gBattlerPartyIndexesSelfSlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x4
 		GameSettings.gBattlerPartyIndexesEnemySlotTwo = GameSettings.gBattlerPartyIndexesSelfSlotOne + 0x6
 		GameSettings.gBattleMons = 0x02024a80
+		GameSettings.gBattlescriptCurrInstr = 0x02024c10
+		GameSettings.BattleScript_LearnMoveLoop = 0x081d8eb7 -- BattleScript_TryLearnMoveLoop
+		GameSettings.BattleScript_LearnMoveReturn = 0x081d8f09
+		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -271,6 +298,9 @@ function GameSettings.setGameAsEmerald(gameversion)
 	GameSettings.gBattleMons = 0x02024084
 	GameSettings.gBattlescriptCurrInstr = 0x02024214
 	GameSettings.BattleScript_FocusPunchSetUp = 0x082db1ff + 0x10
+	GameSettings.BattleScript_LearnMoveLoop = 0x082dabd9 -- BattleScript_TryLearnMoveLoop
+	GameSettings.BattleScript_LearnMoveReturn = 0x082dac2b
+	GameSettings.gMoveToLearn = 0x020244e2
 	GameSettings.gBattleOutcome = 0x0202433a
 
 	GameSettings.gSaveBlock1 = 0x02025a00
@@ -329,6 +359,9 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.gBattleMons = 0x02023be4
 		GameSettings.gBattlescriptCurrInstr = 0x02023d74
 		GameSettings.BattleScript_FocusPunchSetUp = 0x081d9085 + 0x10 -- TODO: offset for this game is untested
+		GameSettings.BattleScript_LearnMoveLoop = 0x081d8a81
+		GameSettings.BattleScript_LearnMoveReturn = 0x081d8ad3
+		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 
 		GameSettings.gSaveBlock1 = 0x0202552c
@@ -398,6 +431,9 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.gBattleMons = 0x02023be4
 		GameSettings.gBattlescriptCurrInstr = 0x02023d74
 		GameSettings.BattleScript_FocusPunchSetUp = 0x081d9015 + 0x10
+		GameSettings.BattleScript_LearnMoveLoop = 0x081d8a11
+		GameSettings.BattleScript_LearnMoveReturn = 0x081d8a63
+		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 
 		GameSettings.gSaveBlock1 = 0x0202552c
@@ -457,6 +493,9 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.gBattleMons = 0x02023be4
 		GameSettings.gBattlescriptCurrInstr = 0x02023d74
 		GameSettings.BattleScript_FocusPunchSetUp = 0x081d9061 + 0x10 -- TODO: offset for this game is untested
+		GameSettings.BattleScript_LearnMoveLoop = 0x081d8a5d
+		GameSettings.BattleScript_LearnMoveReturn = 0x081d8aaf
+		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 
 		GameSettings.gSaveBlock1 = 0x0202552c
@@ -512,6 +551,9 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.gBattleMons = 0x02023be4
 		GameSettings.gBattlescriptCurrInstr = 0x02023d74
 		GameSettings.BattleScript_FocusPunchSetUp = 0x081d8ff1 + 0x10 -- TODO: offset for this game is untested
+		GameSettings.BattleScript_LearnMoveLoop = 0x081d89ed
+		GameSettings.BattleScript_LearnMoveReturn = 0x081d8a3f
+		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 
 		GameSettings.gSaveBlock1 = 0x0202552c

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -103,6 +103,21 @@ function Input.checkMouseInput(xmouse, ymouse)
 	elseif Program.state == State.THEME then
 		Input.checkButtonsClicked(xmouse, ymouse, Theme.buttons)
 	end
+
+	-- Check if mouse clicked on the game screen itself
+	-- Clicked on a new move learned, show info
+	if Input.isInRange(xmouse, ymouse, 0, Constants.SCREEN.HEIGHT - 45, Constants.SCREEN.WIDTH, 45) then
+		-- Only lookup/show move if not editing settings
+		if Program.state == State.TRACKER or Program.state == State.INFOSCREEN then
+			local moveId = Program.getLearnedMoveId()
+			if moveId ~= nil then
+				InfoScreen.infoLookup = moveId
+				InfoScreen.viewScreen = InfoScreen.SCREENS.MOVE_INFO
+				InfoScreen.redraw = true
+				Program.state = State.INFOSCREEN
+			end
+		end
+	end
 end
 
 --[[

--- a/ironmon_tracker/MoveData.lua
+++ b/ironmon_tracker/MoveData.lua
@@ -2584,7 +2584,7 @@ MoveData.Moves = {
 		pp = "5",
 		accuracy = Constants.BLANKLINE,
 		category = MoveData.Categories.STATUS,
-		summary = "Changes weather to Rain for 5 turns. Water moves boosted by 50% and Fire moves weakened by 50%. Thunder ignores accuracy and evasion.",
+		summary = "Changes weather to Rain for 5 turns. Water moves are boosted by 50% and Fire moves are weakened by 50%. Thunder ignores accuracy and evasion.",
 	},
 	{
 		id = "241",
@@ -2594,7 +2594,7 @@ MoveData.Moves = {
 		pp = "5",
 		accuracy = Constants.BLANKLINE,
 		category = MoveData.Categories.STATUS,
-		summary = "Changes weather to Sunny for 5 turns. Fire moves boosted by 50% and Water moves weakened by 50%. Thunder accuracy becomes 50%.",
+		summary = "Changes weather to Sunny for 5 turns. Fire moves are boosted by 50% and Water moves are weakened by 50%. Thunder accuracy becomes 50%.",
 	},
 	{
 		id = "242",

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -30,8 +30,8 @@ Options.buttons = {
 		type = Constants.BUTTON_TYPES.NO_BORDER,
 		text = "Roms folder: ",
 		textColor = "Default text",
-		clickableArea = { Constants.SCREEN.WIDTH + 6, 8, Constants.SCREEN.RIGHT_GAP - 12, 11 },
-		box = { Constants.SCREEN.WIDTH + 6, 8, 11, 11 },
+		clickableArea = { Constants.SCREEN.WIDTH + 6, 7, Constants.SCREEN.RIGHT_GAP - 12, 11 },
+		box = { Constants.SCREEN.WIDTH + 6, 7, 11, 11 },
 		onClick = function() Options.openRomPickerWindow() end
 	},
 	controls = {

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -335,22 +335,19 @@ function Program.updateBattleDataFromMemory()
 			Tracker.TrackEncounter(opposingPokemon.pokemonID, isWild)
 		end
 
-		-- ABILITIES: TODO: Not all games/versions supported
-		if GameSettings.gBattlescriptCurrInstr ~= 0x00000000 then
-			local battleMsg = Memory.readdword(GameSettings.gBattlescriptCurrInstr)
+		local battleMsg = Memory.readdword(GameSettings.gBattlescriptCurrInstr)
 
-			-- TODO: Hacky workaround when both active Pokemon share an ability, currently no way to know which triggered, so skip revealing anything
-			if opposingPokemon.abilityId ~= ownersPokemon.abilityId then
-				-- Only track the triggered ability if that ability belongs to the enemy Pokemon (matches its real ability)
-				if GameSettings.ABILITIES[battleMsg] == opposingPokemon.abilityId then
-					Tracker.TrackAbility(opposingPokemon.pokemonID, opposingPokemon.abilityId)
-				end
-			end
-
-			-- Also track the enemy's ability if the player's Pokemon triggered its Trace ability
-			if GameSettings.ABILITIES[battleMsg] == 36 and ownersPokemon.abilityId == 36 then -- 36 = Trace
+		-- TODO: Hacky workaround when both active Pokemon share an ability, currently no way to know which triggered, so skip revealing anything
+		if opposingPokemon.abilityId ~= ownersPokemon.abilityId then
+			-- Only track the triggered ability if that ability belongs to the enemy Pokemon (matches its real ability)
+			if GameSettings.ABILITIES[battleMsg] == opposingPokemon.abilityId then
 				Tracker.TrackAbility(opposingPokemon.pokemonID, opposingPokemon.abilityId)
 			end
+		end
+
+		-- Also track the enemy's ability if the player's Pokemon triggered its Trace ability
+		if GameSettings.ABILITIES[battleMsg] == 36 and ownersPokemon.abilityId == 36 then -- 36 = Trace
+			Tracker.TrackAbility(opposingPokemon.pokemonID, opposingPokemon.abilityId)
 		end
 
 		-- MOVES: Check if the opposing Pokemon used a move (it's missing pp from max), and if so track it
@@ -360,8 +357,7 @@ function Program.updateBattleDataFromMemory()
 			end
 		end
 
-		if GameSettings.gBattlescriptCurrInstr ~= 0x00000000 and GameSettings.BattleScript_FocusPunchSetUp ~= 0x00000000 then
-			local battleMsg = Memory.readdword(GameSettings.gBattlescriptCurrInstr)
+		if GameSettings.BattleScript_FocusPunchSetUp ~= 0x00000000 then
 			-- attackerValue = 0 or 2 for player mons and 1 or 3 for enemy mons (2,3 are doubles partners)
 			local attackerValue = Memory.readbyte(GameSettings.gBattlerAttacker)
 			
@@ -574,6 +570,18 @@ end
 function Program.HandleExit()
 	Drawing.clearGUI()
 	forms.destroyall()
+end
+
+function Program.getLearnedMoveId()
+	local battleMsg = Memory.readdword(GameSettings.gBattlescriptCurrInstr)
+
+	-- If the battle message relates to learning a new move, read in that move id
+	if GameSettings.BattleScript_LearnMoveLoop <= battleMsg and battleMsg <= GameSettings.BattleScript_LearnMoveReturn then
+		local moveToLearnId = Memory.readword(GameSettings.gMoveToLearn)
+		return moveToLearnId
+	else
+		return nil
+	end
 end
 
 -- Returns true only if the player hasn't completed the catching tutorial


### PR DESCRIPTION
Adding a feature that allows the user to click on the game screen itself. If their pokemon is in the process of learning a move, that move will show on the InfoScreen.

Also adding version number to Options screen (finally), and other minor visual updates.

![image](https://user-images.githubusercontent.com/4258818/180389211-176d4b47-f964-489d-8197-5e9632be48e1.png)
