### PR TITLE
Improved Error Messages

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -52,7 +52,7 @@ Main.LoadNextSeed = false
 -- Displays a given error message in a pop-up dialogue box
 function Main.DisplayError(errMessage)
 	client.pause()
-	local form = forms.newform(400, 130, "Woops, there's been an error!", function() return end)
+	local form = forms.newform(400, 130, "[v" .. TRACKER_VERSION .. "] Woops, there's been an error!", function() return end)
 	Utils.setFormLocation(form, 100, 50)
 	forms.label(form, errMessage,  18, 10, 400, 50)
 	forms.button(form, "Close", function()

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -58,7 +58,6 @@ function Main.DisplayError(errMessage)
 	forms.button(form, "Close", function()
 		client.unpause()
 		forms.destroy(form)
-		-- return
 	end, 155, 70)
 	return
 end

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -58,7 +58,7 @@ function Main.DisplayError(errMessage)
 	forms.button(form, "Close", function()
 		client.unpause()
 		forms.destroy(form)
-		return
+		-- return
 	end, 155, 70)
 	return
 end

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -9,7 +9,7 @@ print("\nIronmon-Tracker v" .. TRACKER_VERSION)
 -- Check the version of BizHawk that is running
 -- Need to also check that client.getversion is an existing function, older Bizhawk versions don't have it
 if client.getversion == nil or (client.getversion() ~= "2.8" and client.getversion() ~= "2.9") then
-	print("This version of BizHawk is not supported. Please update to version 2.8 or higher.")
+	print("This version of BizHawk is not supported.\nPlease update to version 2.8 or higher.")
 	-- Bounce out... Don't pass Go! Don't collect $200.
 	return
 end
@@ -48,6 +48,20 @@ dofile(DATA_FOLDER .. "/Tracker.lua")
 
 Main = {}
 Main.LoadNextSeed = false
+
+-- Displays a given error message in a pop-up dialogue box
+function Main.DisplayError(errMessage)
+	client.pause()
+	local form = forms.newform(400, 130, "Woops, there's been an error!", function() return end)
+	Utils.setFormLocation(form, 100, 50)
+	forms.label(form, errMessage,  18, 10, 400, 50)
+	forms.button(form, "Close", function()
+		client.unpause()
+		forms.destroy(form)
+		return
+	end, 155, 70)
+	return
+end
 
 -- Main loop
 function Main.Run()
@@ -88,11 +102,13 @@ end
 
 function Main.LoadNext()
 	Tracker.clearData()
-	print("Loading the next ROM. Tracker data has reset.")
+	print("Tracker data has been reset.\nAttempting to load next ROM...")
 
 	if Settings.config.ROMS_FOLDER == nil or Settings.config.ROMS_FOLDER == "" then
-		print("ROMS_FOLDER unspecified. Set this in the Tracker's options menu, or the Settings.ini file, to automatically switch ROM.")
-		Main.CloseROM()
+		print("ERROR: ROMS_FOLDER unspecified\n")
+		Main.DisplayError("ROMS_FOLDER unspecified.\n\nSet this in the Tracker's options menu, or the Settings.ini file.")
+		Main.LoadNextSeed = false
+		Main.Run()
 	end
 
 	local romname = gameinfo.getromname()
@@ -103,8 +119,10 @@ function Main.LoadNext()
 	if romprefix == nil then romprefix = "" end
 
 	if romnumber == nil then
-		print("Unable to load next ROM file: no numbers in current ROM name.\nClosing current ROM: " .. romname)
-		Main.CloseROM()
+		print("ERROR: No number in ROM name\n")
+		Main.DisplayError("Unable to load next ROM: no numbers in current ROM name.\n\nCurrent ROM: " .. romname .. ".gba")
+		Main.LoadNextSeed = false
+		Main.Run()
 	end
 
 	-- Increment to the next ROM and determine its full file path
@@ -122,8 +140,10 @@ function Main.LoadNext()
 		filecheck = io.open(nextrompath,"r")
 		if filecheck == nil then
 			-- This means there doesn't exist a ROM file with spaces or underscores
-			print("Unable to locate next ROM file to load.\nClosing current ROM: " .. romname)
-			Main.CloseROM()
+			print("ERROR: Next ROM not found\n")
+			Main.DisplayError("Unable to find next ROM: " .. nextromname .. ".gba\n\nMake sure your ROMs are numbered and the ROMs folder is correct.")
+			Main.LoadNextSeed = false
+			Main.Run()
 		else
 			io.close(filecheck)
 		end
@@ -138,14 +158,6 @@ function Main.LoadNext()
 	client.SetSoundOn(true)
 	Main.LoadNextSeed = false
 	Main.Run()
-end
-
-function Main.CloseROM()
-	if gameinfo.getromname() ~= "Null" then
-		client.closerom()
-		Main.LoadNextSeed = false
-		Main.Run()
-	end
 end
 
 Main.Run()

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -120,7 +120,8 @@ function GameSettings.setGameInfo(gamecode)
 		GameSettings.badgePrefix = games[gamecode].BADGE_PREFIX
 		GameSettings.badgeXOffsets = games[gamecode].BADGE_XOFFSETS
 	else
-		GameSettings.gamename = "Unsupported game, unable to load ROM."
+		GameSettings.gamename = "Unsupported game"
+		Main.DisplayError("This game is unsupported.\n\nOnly RSE/FRLG English versions are currently supported.")
 	end
 end
 

--- a/ironmon_tracker/Theme.lua
+++ b/ironmon_tracker/Theme.lua
@@ -227,6 +227,7 @@ function Theme.openImportWindow()
 			if not Theme.importThemeFromText(formInput) then
 				print("Error importing Theme Config string:")
 				print(">> " .. formInput)
+				Main.DisplayError("The config string you entered is invalid.\n\nPlease enter a valid config string.")
 			end
 		end
 		forms.destroy(form)

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -338,6 +338,7 @@ function Tracker.loadData(filepath)
 	local fileData = nil
 	if filepath:sub(-5):lower() ~= Constants.TRACKER_DATA_EXTENSION then
 		print("[ERROR] Unable to load Tracker data from selected file: " .. filepath)
+		Main.DisplayError("Invalid file selected.\n\nPlease select a TDAT file to load tracker data.")
 	else
 		fileData = Utils.readTableFromFile(filepath)
 	end


### PR DESCRIPTION
- Added a `Main.DisplayError` function
  - This takes in an error message string and creates a popup dialogue box with the error message for the user
  - This was made to be generic and applicable throughout the program wherever we want to display an error to the user
- Improved error handling in `Main.LoadNext`
  - Instead of closing current ROM on error and hoping they check the lua console dialogue, the current ROM stays open and instead an error dialogue pops up informing them of what went wrong
  - Less confusion on what went wrong, hopefully
  - Error messages still get printed to the console output for full logs, but can be removed if desired
- Implemented the `Main.DisplayError` function in a couple of other places to inform the user

Example screenshots of LoadNext error messages:
![Screenshot_9](https://user-images.githubusercontent.com/106463662/180432499-9a4bc8a4-cf22-48ad-a120-b97944b6dda2.png)
![Screenshot_10](https://user-images.githubusercontent.com/106463662/180432540-96329985-3086-4eae-a9c5-1dfcf1fe3984.png)
![Screenshot_11](https://user-images.githubusercontent.com/106463662/180432545-4e73360d-aa2c-45de-a3cb-a1633515b66a.png)

