### PR TITLE
Transform bug fix

### DIFF
--- a/ironmon_tracker/TrackerScreen.lua
+++ b/ironmon_tracker/TrackerScreen.lua
@@ -142,6 +142,7 @@ function TrackerScreen.updateButtonStates()
 
 		for _, statKey in ipairs(Constants.ORDERED_LISTS.STATSTAGES) do
 			local statValue = statMarkings[statKey]
+			TrackerScreen.buttons[statKey].statState = statValue
 			TrackerScreen.buttons[statKey].text = Constants.STAT_STATES[statValue].text
 			TrackerScreen.buttons[statKey].textColor = Constants.STAT_STATES[statValue].textColor
 		end


### PR DESCRIPTION
In the current codebase the transform tracking disable wasn't being correctly reset, meaning moves weren't getting tracked when they should be.

This is because it was only reset when the enemy mon changed, so I've also added a re-set to occur at the end of battle

I also did some cleanup of the transform tracking disable. The second boolean for force-switch moves is no longer required so i removed it. This was initially used because the transform tracking reset used to occur in the "pokeball sent out" event handler which occurs whenever the player or the enemy sends out a pokemon (thus a force-switch would have incorrectly reset the transform tracking disable due to your swapped pokemon coming out)

Tested this out and with this fix it now correctly resets the isTransformed boolean when the enemy sends out another pokemon and at the end of a battle