### PR TITLE
Bugfixes and Friendship Evo update, preparing for 0.5.4 release

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -202,7 +202,7 @@ function Main.LoadSettings()
 		local enableMoveTypes = settings.theme.MOVE_TYPES_ENABLED
 		if enableMoveTypes ~= nil then
 			Theme.MOVE_TYPES_ENABLED = enableMoveTypes
-			Theme.buttons.moveTypeEnabled.toggleState = enableMoveTypes
+			Theme.buttons.moveTypeEnabled.toggleState = not enableMoveTypes -- Show the opposite of the Setting, can't change existing theme strings
 		end
 	end
 

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -2,7 +2,7 @@
 -- Created by besteon, based on the PokemonBizhawkLua project by MKDasher
 
 Main = {
-	TrackerVersion = "0.5.3", -- The latest version of the tracker. Should be updated with each PR.
+	TrackerVersion = "0.5.4", -- The latest version of the tracker. Should be updated with each PR.
 	DataFolder = "ironmon_tracker", -- Root folder for the project data and sub scripts
 	SettingsFile = "Settings.ini", -- Location of the Settings file (typically in the root folder)
 	MetaSettings = {},
@@ -71,6 +71,7 @@ function Main.Run()
 			emu.frameadvance()
 		end
 	else
+		Program.initialize()
 		Options.initialize()
 		Theme.initialize()
 		Tracker.initialize()

--- a/ironmon_tracker/ColorPicker.lua
+++ b/ironmon_tracker/ColorPicker.lua
@@ -81,7 +81,7 @@ function ColorPicker:updateCirclePreview()
 	local circleCenter = self.circleCenter
 	local clickPos = {forms.getMouseX(self.mainCanvas),forms.getMouseY(self.mainCanvas)}
 	local x,y = clickPos[1],clickPos[2]
-	local distanceToRadius = self:distance(clickPos,circleCenter)
+	local distanceToRadius = ColorPicker.distance(clickPos,circleCenter)
 	if distanceToRadius > self.circleRadius then
 		local ratio = distanceToRadius/self.circleRadius
 		x = (x-85)/ratio
@@ -201,7 +201,7 @@ function ColorPicker:handleInput()
 		else
 			local clickPos = {forms.getMouseX(self.mainCanvas),forms.getMouseY(self.mainCanvas)}
 			if not self.draggingColor then
-				local distanceToCenter = self:distance(clickPos,self.circleCenter)
+				local distanceToCenter = ColorPicker.distance(clickPos,self.circleCenter)
 				if distanceToCenter >= 0 and distanceToCenter <= self.circleRadius then
 					self.draggingColor = true
 					self:updateCirclePreview()
@@ -241,7 +241,7 @@ function ColorPicker.distance(point1, point2)
 end
 
 function ColorPicker:pointInRange(point)
-	local distanceToRadius = self:distance(point,self.circleRadiusPosition)
+	local distanceToRadius = ColorPicker.distance(point,self.circleRadiusPosition)
 	if distanceToRadius <= self.radius then
 		return true
 	else

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -777,7 +777,7 @@ function Drawing.drawMoveInfoScreen(moveId)
 	local offsetColumnX = offsetX + 45
 	local offsetY = 0 + Constants.SCREEN.MARGIN + 3
 	local linespacing = 10
-	local botOffsetY = offsetY + (linespacing * 7) - 2 + 9
+	local botOffsetY = offsetY + (linespacing * 7) + 7
 
 	local move = MoveData.Moves[moveId]
 	local moveType = move.type
@@ -821,10 +821,10 @@ function Drawing.drawMoveInfoScreen(moveId)
 	local categoryInfo = ""
 	if moveCat == MoveData.Categories.PHYSICAL then
 		categoryInfo = categoryInfo .. "Physical"
-		Drawing.drawImageAsPixels(Constants.PIXEL_IMAGES.PHYSICAL, offsetX + 130, botOffsetY - linespacing - 13, Theme.COLORS["Default text"], boxInfoTopShadow)
+		Drawing.drawImageAsPixels(Constants.PIXEL_IMAGES.PHYSICAL, offsetColumnX + 36, offsetY + 2, Theme.COLORS["Default text"], boxInfoTopShadow)
 	elseif moveCat == MoveData.Categories.SPECIAL then
 		categoryInfo = categoryInfo .. "Special"
-		Drawing.drawImageAsPixels(Constants.PIXEL_IMAGES.SPECIAL, offsetX + 130, botOffsetY - linespacing - 13, Theme.COLORS["Default text"], boxInfoTopShadow)
+		Drawing.drawImageAsPixels(Constants.PIXEL_IMAGES.SPECIAL, offsetColumnX + 33, offsetY + 2, Theme.COLORS["Default text"], boxInfoTopShadow)
 	elseif moveCat == MoveData.Categories.STATUS then
 		categoryInfo = categoryInfo .. "Status"
 	else categoryInfo = categoryInfo .. Constants.BLANKLINE end

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -254,7 +254,7 @@ function Drawing.drawPokemonInfoArea(pokemon)
 	local levelEvoTextColor = Theme.COLORS["Default text"]
 	if Tracker.Data.isViewingOwn and Utils.isReadyToEvolveByLevel(pokemon.evolution, pokemon.level) then
 		levelEvoTextColor = Theme.COLORS["Positive text"]
-	elseif pokemon.friendship >= 220 and pokemon.evolution == PokemonData.Evolutions.FRIEND then
+	elseif pokemon.friendship >= Program.friendshipRequired and pokemon.evolution == PokemonData.Evolutions.FRIEND then
 		evoDetails = "(SOON)"
 		levelEvoTextColor = Theme.COLORS["Positive text"]
 	end
@@ -693,7 +693,7 @@ function Drawing.drawPokemonInfoScreen(pokemonID)
 	botOffsetY = botOffsetY + 1
 
 	-- MOVES LEVEL BOXES
-	Drawing.drawText(offsetX, botOffsetY, "New Move Levels:", Theme.COLORS["Default text"], boxInfoBotShadow)
+	Drawing.drawText(offsetX, botOffsetY, "New move levels:", Theme.COLORS["Default text"], boxInfoBotShadow)
 	botOffsetY = botOffsetY + linespacing + 1
 	local boxWidth = 16
 	local boxHeight = 13

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -552,40 +552,26 @@ function GameSettings.setGameAsFireRedSpanish(gameversion)
 			[0x081D8ED3] = 5, -- BattleScript_SturdyPreventsOHKO + 0x0 Sturdy
 			[0x081D8EE1] = 6, -- BattleScript_DampStopsExplosion + 0x0 Damp
 			[0x081D6D77] = 7, -- BattleScript_LimberProtected + 0x0 Limber (untested)
-			-- [0x00000000] = 9, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Static -- Likely: BattleScript_ApplySecondaryEffect
-			-- [0x081d9442] = 10, -- BattleScript_MonMadeMoveUseless - 0xE Volt Absorb 081D9442 and/or 081D942F TODO: these dont work
-			-- [0x081d9452] = 11, -- BattleScript_MonMadeMoveUseless + 0x1 Water Absorb 081D9452 and/or 081D9458 TODO: these dont work
 			[0x081D8F76] = 12, -- BattleScript_ObliviousPreventsAttraction + 0x0 Oblivious (untested)
-			-- [0x00000000] = 13, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Cloud Nine
-			-- [0x00000000] = 15, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Insomnia
 			[0x081D8FD1] = 16, -- BattleScript_ColorChangeActivates + 0x3 Color Change
 			[0x081D6981] = 17, -- BattleScript_ImmunityProtected + 0x0 Immunity (untested)
 			[0x081D8F32] = 18, -- BattleScript_FlashFireBoost + 0x3 Flash Fire
-			-- [0x00000000] = 19, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Shield Dust
 			[0x081D8F92] = 20, -- BattleScript_OwnTempoPrevents + 0x0 Own Tempo
-			-- [0x00000000] = 21, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Suction Cups (untested)
 			[0x081D8E3F] = 22, -- BattleScript_DoIntimidateActivationAnim + 0x0 Intimidate
 			[0x081D8FE5] = 24, -- BattleScript_RoughSkinActivates + 0x10 Rough Skin
-			-- [0x00000000] = 26, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Levitate -- No clean trigger to use
-			-- [0x00000000] = 27, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Effect Spore -- Likely: BattleScript_ApplySecondaryEffect
 			[0x081D9000] = 28, -- BattleScript_SynchronizeActivates + 0x0 Synchronize (untested)
 			[0x081D8F48] = 29, -- BattleScript_AbilityNoStatLoss + 0x0 Clear Body & White Smoke
 			[0x081D8DD3] = 36, -- BattleScript_TraceActivates + 0x0 Trace
-			-- [0x081d924c] = 38, -- BattleScript_MoveEffectPoison + 0x7 Poison Point 081D9247 and/or 081D924C-- BattleScript_ApplySecondaryEffect
 			[0x081D8FA8] = 43, -- BattleScript_SoundproofProtected + 0x8 Soundproof
 			[0x081D8DE0] = 44, -- BattleScript_RainDishActivates + 0x3 Rain Dish
 			[0x081D8DF1] = 45, -- BattleScript_SandstreamActivates + 0x0 Sand Stream
-			-- [0x00000000] = 49, -- BattleScript_MoveEffectBurn + 0x0 Flame Body 081D9256 and/or 081D925B -- Likely: BattleScript_ApplySecondaryEffect
-			-- [0x00000000] = 51, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Keen Eye (untested)
 			[0x081D8FB6] = 52, -- BattleScript_AbilityNoSpecificStatLoss + 0x6 Hyper Cutter
 			[0x081D9029] = 54, -- BattleScript_MoveUsedLoafingAround + 0x5 Truant
 			[0x081D8FF9] = 56, -- BattleScript_CuteCharmActivates + 0x9 Cute Charm
 			[0x081D8FC0] = 60, -- BattleScript_StickyHoldActivates + 0x0 Sticky Hold
 			[0x081D8E08] = 61, -- BattleScript_ShedSkinActivates + 0x3 Shed Skin
-			-- [0x00000000] = 64, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Liquid Ooze (Difficult: multiple addresses)
 			[0x081D8EAB] = 70, -- BattleScript_DroughtActivates + 0x0 Drought
 			[0x081D6506] = 72, -- BattleScript_CantMakeAsleep + 0x8 Vital Spirit
-			-- [0x00000000] = 73, -- BattleScript_AbilityNoStatLoss + 0x0 White Smoke (Same address as Clear Body)
 		}
 	end
 end
@@ -631,40 +617,26 @@ function GameSettings.setGameAsFireRedFrench(gameversion)
 			[0x081D7B73] = 5, -- BattleScript_SturdyPreventsOHKO + 0x0 Sturdy
 			[0x081D7B81] = 6, -- BattleScript_DampStopsExplosion + 0x0 Damp
 			[0x081D5A17] = 7, -- BattleScript_LimberProtected + 0x0 Limber (untested)
-			-- [0x00000000] = 9, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Static -- Likely: BattleScript_ApplySecondaryEffect
-			-- [0x081d9442] = 10, -- BattleScript_MonMadeMoveUseless - 0xE Volt Absorb 081D9442 and/or 081D942F TODO: these dont work
-			-- [0x081d9452] = 11, -- BattleScript_MonMadeMoveUseless + 0x1 Water Absorb 081D9452 and/or 081D9458 TODO: these dont work
 			[0x081D7C16] = 12, -- BattleScript_ObliviousPreventsAttraction + 0x0 Oblivious (untested)
-			-- [0x00000000] = 13, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Cloud Nine
-			-- [0x00000000] = 15, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Insomnia
 			[0x081D7C71] = 16, -- BattleScript_ColorChangeActivates + 0x3 Color Change
 			[0x081D5621] = 17, -- BattleScript_ImmunityProtected + 0x0 Immunity (untested)
 			[0x081D7BD2] = 18, -- BattleScript_FlashFireBoost + 0x3 Flash Fire
-			-- [0x00000000] = 19, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Shield Dust
 			[0x081D7C32] = 20, -- BattleScript_OwnTempoPrevents + 0x0 Own Tempo
-			-- [0x00000000] = 21, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Suction Cups (untested)
 			[0x081D7ADF] = 22, -- BattleScript_DoIntimidateActivationAnim + 0x0 Intimidate
 			[0x081D7C85] = 24, -- BattleScript_RoughSkinActivates + 0x10 Rough Skin
-			-- [0x00000000] = 26, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Levitate -- No clean trigger to use
-			-- [0x00000000] = 27, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Effect Spore -- Likely: BattleScript_ApplySecondaryEffect
 			[0x081D7CA0] = 28, -- BattleScript_SynchronizeActivates + 0x0 Synchronize (untested)
 			[0x081D7BE8] = 29, -- BattleScript_AbilityNoStatLoss + 0x0 Clear Body & White Smoke
 			[0x081D7A73] = 36, -- BattleScript_TraceActivates + 0x0 Trace
-			-- [0x081d924c] = 38, -- BattleScript_MoveEffectPoison + 0x7 Poison Point 081D9247 and/or 081D924C-- BattleScript_ApplySecondaryEffect
 			[0x081D7C48] = 43, -- BattleScript_SoundproofProtected + 0x8 Soundproof
 			[0x081D7A80] = 44, -- BattleScript_RainDishActivates + 0x3 Rain Dish
 			[0x081D7A91] = 45, -- BattleScript_SandstreamActivates + 0x0 Sand Stream
-			-- [0x00000000] = 49, -- BattleScript_MoveEffectBurn + 0x0 Flame Body 081D9256 and/or 081D925B -- Likely: BattleScript_ApplySecondaryEffect
-			-- [0x00000000] = 51, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Keen Eye (untested)
 			[0x081D7C56] = 52, -- BattleScript_AbilityNoSpecificStatLoss + 0x6 Hyper Cutter
 			[0x081D7CC9] = 54, -- BattleScript_MoveUsedLoafingAround + 0x5 Truant
 			[0x081D7C99] = 56, -- BattleScript_CuteCharmActivates + 0x9 Cute Charm
 			[0x081D7C60] = 60, -- BattleScript_StickyHoldActivates + 0x0 Sticky Hold
 			[0x081D7AA8] = 61, -- BattleScript_ShedSkinActivates + 0x3 Shed Skin
-			-- [0x00000000] = 64, -- BattleScript_xxxxxxxxxxxxxxxxxxx + 0x0 Liquid Ooze (Difficult: multiple addresses)
 			[0x081D7B4B] = 70, -- BattleScript_DroughtActivates + 0x0 Drought
 			[0x081D51A6] = 72, -- BattleScript_CantMakeAsleep + 0x8 Vital Spirit
-			-- [0x00000000] = 73, -- BattleScript_AbilityNoStatLoss + 0x0 White Smoke (Same address as Clear Body)
 		}
 	end
 end
@@ -792,16 +764,8 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 end
 
 function GameSettings.getTrackerAutoSaveName()
-	if GameSettings.gamename == "" then
-		return "AutoSave" .. Constants.TRACKER_DATA_EXTENSION
-	elseif GameSettings.gamename:sub(-8) == " (Spain)" then -- spain
-		-- Remove trailing " (spain)" from game name
-		return GameSettings.gamename:sub(1, -9) .. " AutoSave" .. Constants.TRACKER_DATA_EXTENSION
-	elseif GameSettings.gamename:sub(-9) == " (France)" then
-		-- Remove trailing " (france)" from game name
-		return GameSettings.gamename:sub(1, -10) .. " AutoSave" .. Constants.TRACKER_DATA_EXTENSION
-	else
-		-- Remove trailing " (U)" from game name
-		return GameSettings.gamename:sub(1, -5) .. " AutoSave" .. Constants.TRACKER_DATA_EXTENSION
-	end
+	local filenameEnding = "AutoSave" .. Constants.TRACKER_DATA_EXTENSION
+
+	-- Remove trailing " (___)" from game name
+	return GameSettings.gamename:gsub("%s%(.*%)", " ") .. filenameEnding
 end

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -24,6 +24,8 @@ GameSettings = {
 	gMoveToLearn = 0x00000000,
 	gBattleOutcome = 0x00000000, -- [0 = In battle, 1 = Won the match, 2 = Lost the match, 4 = Fled, 7 = Caught]
 
+	FriendshipRequiredToEvo = 0x00000000,
+
 	gSaveBlock1 = 0x00000000,
 	gSaveBlock1ptr = 0x00000000, -- Doesn't exist in Ruby/Sapphire
 	gSaveBlock2ptr = 0x00000000, -- Doesn't exist in Ruby/Sapphire
@@ -149,8 +151,8 @@ function GameSettings.setGameInfo(gamecode)
 end
 
 function GameSettings.setGameAsRuby(gameversion)
-	-- TODO: Add in ability auto-tracking: https://github.com/pret/pokeruby/tree/symbols
 	if gameversion == 0x00410000 then
+		-- https://raw.githubusercontent.com/pret/pokeruby/symbols/pokeruby.sym
 		print("ROM Detected: Pokemon Ruby v1.0")
 
 		GameSettings.gBaseStats = 0x081fec18
@@ -169,6 +171,8 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 
+		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
+
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
 		GameSettings.badgeOffset = 0x1220 + 0x100 -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
@@ -177,6 +181,7 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.bagPocket_Items_Size = 20
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x01400000 then
+		-- https://raw.githubusercontent.com/pret/pokeruby/symbols/pokeruby_rev1.sym
 		print("ROM Detected: Pokemon Ruby v1.1")
 
 		GameSettings.gBaseStats = 0x081fec30
@@ -195,6 +200,8 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 
+		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
+
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
 		GameSettings.badgeOffset = 0x1220 + 0x100 -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
@@ -203,6 +210,7 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.bagPocket_Items_Size = 20
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x023F0000 then
+		-- https://raw.githubusercontent.com/pret/pokeruby/symbols/pokeruby_rev2.sym
 		print("ROM Detected: Pokemon Ruby v1.2")
 
 		GameSettings.gBaseStats = 0x081fec30
@@ -221,6 +229,8 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 
+		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
+
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
 		GameSettings.badgeOffset = 0x1220 + 0x100 -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
@@ -232,8 +242,8 @@ function GameSettings.setGameAsRuby(gameversion)
 end
 
 function GameSettings.setGameAsSapphire(gameversion)
-	-- TODO: Add in ability auto-tracking: https://github.com/pret/pokeruby/tree/symbols
 	if gameversion == 0x00550000 then
+		-- https://raw.githubusercontent.com/pret/pokeruby/symbols/pokesapphire.sym
 		print("ROM Detected: Pokemon Sapphire v1.0")
 
 		GameSettings.gBaseStats = 0x081feba8
@@ -252,6 +262,8 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 
+		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
+
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
 		GameSettings.badgeOffset = 0x1220 + 0x100 -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
@@ -260,6 +272,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.bagPocket_Items_Size = 20
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x1540000 then
+		-- https://raw.githubusercontent.com/pret/pokeruby/symbols/pokesapphire_rev1.sym
 		print("ROM Detected: Pokemon Sapphire v1.1")
 
 		GameSettings.gBaseStats = 0x081febc0
@@ -278,6 +291,8 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 
+		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
+
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
 		GameSettings.badgeOffset = 0x1220 + 0x100 -- [SaveBlock1's flags offset] + [Badge flag offset: SYSTEM_FLAGS / 8]
@@ -286,6 +301,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.bagPocket_Items_Size = 20
 		GameSettings.bagPocket_Berries_Size = 46
 	elseif gameversion == 0x02530000 then
+		-- https://raw.githubusercontent.com/pret/pokeruby/symbols/pokesapphire_rev2.sym
 		print("ROM Detected: Pokemon Sapphire v1.2")
 
 		GameSettings.gBaseStats = 0x081febc0
@@ -303,6 +319,8 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.BattleScript_LearnMoveReturn = 0x081d8f09
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
+
+		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x02025734
 		GameSettings.gameStatsOffset = 0x1540
@@ -333,6 +351,8 @@ function GameSettings.setGameAsEmerald()
 	GameSettings.BattleScript_LearnMoveReturn = 0x082dac2b
 	GameSettings.gMoveToLearn = 0x020244e2
 	GameSettings.gBattleOutcome = 0x0202433a
+	
+	GameSettings.FriendshipRequiredToEvo = 0x0806d098 + 0x13E -- GetEvolutionTargetSpecies
 
 	GameSettings.gSaveBlock1 = 0x02025a00
 	GameSettings.gSaveBlock1ptr = 0x03005d8c
@@ -395,6 +415,8 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.BattleScript_LearnMoveReturn = 0x081d8ad3
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
+
+		GameSettings.FriendshipRequiredToEvo = 0x08042ED8 + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x0202552c
 		GameSettings.gSaveBlock1ptr = 0x03005008
@@ -469,6 +491,8 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 
+		GameSettings.FriendshipRequiredToEvo = 0x08042ec4 + 0x13E -- GetEvolutionTargetSpecies
+
 		GameSettings.gSaveBlock1 = 0x0202552c
 		GameSettings.gSaveBlock1ptr = 0x03005008
 		GameSettings.gSaveBlock2ptr = 0x0300500c
@@ -531,6 +555,8 @@ function GameSettings.setGameAsFireRedSpanish(gameversion)
 		GameSettings.BattleScript_LearnMoveReturn = 0x081d8ad3
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
+
+		GameSettings.FriendshipRequiredToEvo = 0x08042ED8 + 0x13E -- GetEvolutionTargetSpecies (untested)
 
 		--the only diffrance looks like in here gSaveBlock1ptr and gSaveBlock2ptr
 		GameSettings.gSaveBlock1ptr = 0x03004F58
@@ -597,6 +623,8 @@ function GameSettings.setGameAsFireRedFrench(gameversion)
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 
+		GameSettings.FriendshipRequiredToEvo = 0x08042ED8 + 0x13E -- GetEvolutionTargetSpecies (untested)
+
 		--the only diffrance looks like in here gSaveBlock1ptr and gSaveBlock2ptr
 		GameSettings.gSaveBlock1ptr = 0x03004F58
 		GameSettings.gSaveBlock2ptr = 0x03004F5C
@@ -662,6 +690,8 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 
+		GameSettings.FriendshipRequiredToEvo = 0x08042ed8 + 0x13E -- GetEvolutionTargetSpecies
+
 		GameSettings.gSaveBlock1 = 0x0202552c
 		GameSettings.gSaveBlock1ptr = 0x03005008
 		GameSettings.gSaveBlock2ptr = 0x0300500c
@@ -720,6 +750,8 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.BattleScript_LearnMoveReturn = 0x081d8a3f
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
+
+		GameSettings.FriendshipRequiredToEvo = 0x08042ec4 + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x0202552c
 		GameSettings.gSaveBlock1ptr = 0x03005008

--- a/ironmon_tracker/InfoScreen.lua
+++ b/ironmon_tracker/InfoScreen.lua
@@ -13,7 +13,7 @@ InfoScreen.buttons = {
 		type = Constants.BUTTON_TYPES.PIXELIMAGE,
 		image = Constants.PIXEL_IMAGES.MAGNIFYING_GLASS,
 		textColor = "Default text",
-		box = { Constants.SCREEN.WIDTH + 90, 20, 10, 10, },
+		box = { Constants.SCREEN.WIDTH + 133, 60, 10, 10, },
 		boxColors = { "Upper box border", "Upper box background" },
 		isVisible = function() return InfoScreen.viewScreen == InfoScreen.SCREENS.MOVE_INFO end,
 		onClick = function(self)
@@ -37,7 +37,7 @@ InfoScreen.buttons = {
 		type = Constants.BUTTON_TYPES.PIXELIMAGE,
 		image = Constants.PIXEL_IMAGES.NEXT_BUTTON,
 		textColor = "Default text",
-		box = { Constants.SCREEN.WIDTH + 98, 20, 10, 10, },
+		box = { Constants.SCREEN.WIDTH + 99, 23, 10, 10, },
 		boxColors = { "Upper box border", "Upper box background" },
 		isVisible = function() return InfoScreen.viewScreen == InfoScreen.SCREENS.POKEMON_INFO end,
 		onClick = function(self)
@@ -49,7 +49,7 @@ InfoScreen.buttons = {
 		type = Constants.BUTTON_TYPES.PIXELIMAGE,
 		image = Constants.PIXEL_IMAGES.PREVIOUS_BUTTON,
 		textColor = "Default text",
-		box = { Constants.SCREEN.WIDTH + 86, 20, 10, 10, },
+		box = { Constants.SCREEN.WIDTH + 85, 23, 10, 10, },
 		boxColors = { "Upper box border", "Upper box background" },
 		isVisible = function() return InfoScreen.viewScreen == InfoScreen.SCREENS.POKEMON_INFO end,
 		onClick = function(self)

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -3,6 +3,7 @@ Program = {
 	inCatchingTutorial = false,
 	hasCompletedTutorial = false,
 	isTransformed = false,
+	friendshipRequired = 220,
 	frames = {
 		waitToDraw = 0,
 		battleDataDelay = 0,
@@ -19,7 +20,15 @@ Program.SCREENS = {
 	THEME = 4,
 }
 
-Program.currentScreen = Program.SCREENS.TRACKER
+function Program.initialize()
+	Program.currentScreen = Program.SCREENS.TRACKER
+
+	-- Check if requirement for Friendship evos has changed (Default:219, MakeEvolutionsFaster:159)
+	local friendshipRequired = Memory.readbyte(GameSettings.FriendshipRequiredToEvo) + 1
+	if friendshipRequired > 1 and friendshipRequired <= 220 then
+		Program.friendshipRequired = friendshipRequired
+	end
+end
 
 function Program.main()
 	Input.checkForInput()

--- a/ironmon_tracker/Theme.lua
+++ b/ironmon_tracker/Theme.lua
@@ -60,16 +60,16 @@ Theme.buttons = {
 	},
 	moveTypeEnabled = {
 		type = Constants.BUTTON_TYPES.CHECKBOX,
-		text = "Color move names by type",
+		text = "Show color bar for move types",
 		textColor = "Default text",
-		clickableArea = { Constants.SCREEN.WIDTH + 10, 125, Constants.SCREEN.RIGHT_GAP - 12, 11 },
-		box = { Constants.SCREEN.WIDTH + 9, 125, 8, 8 },
+		clickableArea = { Constants.SCREEN.WIDTH + 9, 125, Constants.SCREEN.RIGHT_GAP - 12, 10 },
+		box = { Constants.SCREEN.WIDTH + 8, 125, 8, 8 },
 		boxColors = { "Lower box border", "Lower box background" },
-		toggleState = Theme.MOVE_TYPES_ENABLED,
+		toggleState = not Theme.MOVE_TYPES_ENABLED, -- Show the opposite of the Setting, can't change existing theme strings
 		toggleColor = "Positive text",
 		onClick = function(self)
 			self.toggleState = not self.toggleState -- toggle the setting
-			Theme.MOVE_TYPES_ENABLED = self.toggleState
+			Theme.MOVE_TYPES_ENABLED = not Theme.MOVE_TYPES_ENABLED
 			Theme.settingsUpdated = true
 			Program.redraw(true)
 		end
@@ -101,8 +101,8 @@ function Theme.initialize()
 		Theme.buttons[colorkey] = {
 			type = Constants.BUTTON_TYPES.COLORPICKER,
 			text = colorkey,
-			clickableArea = { Constants.SCREEN.WIDTH + 10, heightOffset, Constants.SCREEN.RIGHT_GAP - 12, 11 },
-			box = { Constants.SCREEN.WIDTH + 10, heightOffset, 8, 8 },
+			clickableArea = { Constants.SCREEN.WIDTH + 9, heightOffset, Constants.SCREEN.RIGHT_GAP - 12, 10 },
+			box = { Constants.SCREEN.WIDTH + 9, heightOffset, 8, 8 },
 			textColor = "Default text",
 			themeColor = colorkey,
 			onClick = function() Theme.openColorPickerWindow(colorkey) end
@@ -113,8 +113,8 @@ function Theme.initialize()
 	end
 
 	-- Adjust the extra options positions based on the verical space left
-	Theme.buttons.moveTypeEnabled.clickableArea[2] = heightOffset
-	Theme.buttons.moveTypeEnabled.box[2] = heightOffset
+	Theme.buttons.moveTypeEnabled.clickableArea[2] = heightOffset + 1
+	Theme.buttons.moveTypeEnabled.box[2] = heightOffset + 1
 end
 
 
@@ -152,7 +152,7 @@ function Theme.importThemeFromText(theme_config)
 
 	local enableMoveTypes = not (string.sub(theme_config, numHexCodes * 7 + 1, numHexCodes * 7 + 1) == "0")
 	Theme.MOVE_TYPES_ENABLED = enableMoveTypes
-	Theme.buttons.moveTypeEnabled.toggleState = enableMoveTypes
+	Theme.buttons.moveTypeEnabled.toggleState = not enableMoveTypes -- Show the opposite of the Setting, can't change existing theme strings
 
 	Theme.settingsUpdated = true
 	Program.redraw(true)

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -184,7 +184,11 @@ function Utils.getDetailedEvolutionsInfo(evoMethod)
 	end
 
 	if evoMethod == PokemonData.Evolutions.FRIEND then
-		return { "220 Friendship" }
+		if Program.friendshipRequired ~= nil and Program.friendshipRequired > 1 then
+			return { Program.friendshipRequired .. " Friendship" }
+		else
+			return { "220 Friendship" }
+		end
 	elseif evoMethod == PokemonData.Evolutions.STONES then
 		return { "5 Diff. Stones" }
 	elseif evoMethod == PokemonData.Evolutions.THUNDER then

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -407,9 +407,11 @@ function Utils.writeTableToFile(table, filename)
 	if file ~= nil then
 		local dataString = Pickle.pickle(table)
 
-		if dataString:sub(-1) ~= "\n" then dataString = dataString .. "\n" end --append a trailing \n if one is absent
+		--append a trailing \n if one is absent
+		if dataString:sub(-1) ~= "\n" then dataString = dataString .. "\n" end
 		for dataLine in dataString:gmatch("(.-)\n") do
 			file:write(dataLine)
+			file:write("\n")
 		end
 		file:close()
 	else


### PR DESCRIPTION
Resolves #128 

This PR covers a variety of minor bug fixes and a small update to the friendship evolution check to accommodate a randomizer setting.

- ColorPicker distance function bug caused by previous cleanup
- Visual updates to Move Info screen
- Renaming a theme option to be easier to understand (requires awkward workaround)
- Cleaning out some comments
- TDAT files now share data on multiple lines (vs single line)
