### PR TITLE
fix ability blanking out on evolution

### DIFF
--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -26,12 +26,6 @@ function Tracker.addUpdatePokemon(pokemonData, personality, isOwn)
 
 	-- If the Pokemon already exists, update the parts of it that you can; otherwise add it.
 	if pokemon ~= nil then
-		-- If the Pokemon evolved (or otherwise changed), clear it's ability; to be updated later in battle
-		if pokemonData.pokemonID ~= pokemon.pokemonID then
-			pokemonData.abilityId = nil
-			pokemon.abilityId = nil
-		end
-
 		-- Update each pokemon key if it exists between both Pokemon
 		for key, _ in pairs(pokemonData) do
 			if pokemonData[key] ~= nil and pokemon[key] ~= nil then


### PR DESCRIPTION
Leftover code from the old battle-reliant ability reads was what caused the abilities to blank out and break in the new ability-reading system.

It'd set the abilityId to nil on evolution, meaning the later part updating the pokemon data with the data from the memory read doesn't update abilityId because pokemon[abilityId] == nil. 

This was fine when abilities were read separately in battle as it ran a nil check but now abilities are read along with the pokemonData from `Program.readNewPokemonFromMemory` so it getting set to nil when the pokemonId changes caused abilities to be skipped over when updating data from the newly read pokemonData

(note: I've already slid this into the current v0.5.4 release)