### PR TITLE
fix egg spoilers

### DIFF
--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -287,6 +287,7 @@ function Program.readNewPokemonFromMemory(startAddress, personality)
 		friendship = Utils.getbits(growth3, 72, 8),
 		level = Utils.getbits(level_and_currenthp, 0, 8),
 		nature = personality % 25,
+		isEgg = Utils.getbits(misc2, 30, 1), -- [0 or 1] to determine if mon is still an egg
 		abilityId = abilityId,
 		status = status_result,
 		sleep_turns = sleep_turns_result,

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -49,6 +49,15 @@ function Tracker.getPokemon(slotNumber, isOwn)
 	if personality == nil or personality == 0 then return nil end
 
 	if isOwn then
+		if Tracker.Data.ownPokemon[personality].isEgg == 1 then
+			-- Currently viewed pokemon is still an egg
+			local nextSlot = slotNumber
+			repeat
+				-- Cycle to the next non-egg party member (you're required at least one non-egg in the party)
+				nextSlot = nextSlot + 1
+				personality = Tracker.Data.ownTeam[nextSlot]
+			until personality ~= nil and personality ~= 0 and Tracker.Data.ownPokemon[personality].isEgg == 0
+		end
 		return Tracker.Data.ownPokemon[personality]
 	else
 		return Tracker.Data.otherPokemon[personality]


### PR DESCRIPTION
Currently there's an issue where if you put an egg in the lead spot of the party the tracker reveals exactly what mon it is, as though it wasn't an egg
![Screenshot_13](https://user-images.githubusercontent.com/106463662/182902984-97ea6960-1541-4b03-b88a-a1cd3e7115d3.png)
Luckily the pokemon data we read also includes a bit for if they are an egg or not, so this issue is fixed by simply cycling to the next non-egg party member if the one that's currently selected is an egg (i.e. the tracker will show the pokemon that the game would send into battle if you entered one). You are always required to have one non-egg pokemon in the party.
![Screenshot_14](https://user-images.githubusercontent.com/106463662/182903240-7d3f2bc0-4530-4979-b666-161738481b9b.png)
![Screenshot_15](https://user-images.githubusercontent.com/106463662/182903244-99fa4d78-783c-4dd4-90a1-ff024538e677.png)

