### PR TITLE
Automatic Weather Ball Updates

### DIFF
--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -29,6 +29,7 @@ GameSettings = {
 	gMoveToLearn = 0x00000000,
 	gBattleOutcome = 0x00000000, -- [0 = In battle, 1 = Won the match, 2 = Lost the match, 4 = Fled, 7 = Caught]
 	gMoveResultFlags = 0x00000000,
+	gBattleWeather = 0x00000000,
 
 	gMapHeader = 0x00000000,
 	gBattleTerrain = 0x00000000,
@@ -206,6 +207,7 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 		GameSettings.gMoveResultFlags = 0x02024c68
+		GameSettings.gBattleWeather = 0x02024db8
 
 		GameSettings.gMapHeader = 0x0202e828
 		GameSettings.gBattleTerrain = 0x0300428c
@@ -352,6 +354,7 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 		GameSettings.gMoveResultFlags = 0x02023dcc
+		GameSettings.gBattleWeather = 0x02024db8
 
 		GameSettings.gMapHeader = 0x0202e828
 		GameSettings.gBattleTerrain = 0x0300428c
@@ -498,6 +501,7 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 		GameSettings.gMoveResultFlags = 0x02023dcc
+		GameSettings.gBattleWeather = 0x02024db8
 
 		GameSettings.gMapHeader = 0x0202e828
 		GameSettings.gBattleTerrain = 0x0300428c
@@ -648,6 +652,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 		GameSettings.gMoveResultFlags = 0x02023dcc
+		GameSettings.gBattleWeather = 0x02024db8
 
 		GameSettings.gMapHeader = 0x0202e828
 		GameSettings.gBattleTerrain = 0x0300428c
@@ -794,6 +799,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 		GameSettings.gMoveResultFlags = 0x02023dcc
+		GameSettings.gBattleWeather = 0x02024db8
 
 		GameSettings.gMapHeader = 0x0202e828
 		GameSettings.gBattleTerrain = 0x0300428c
@@ -940,6 +946,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gMoveToLearn = 0x02024e82
 		GameSettings.gBattleOutcome = 0x02024d26
 		GameSettings.gMoveResultFlags = 0x02023dcc
+		GameSettings.gBattleWeather = 0x02024db8
 
 		GameSettings.gMapHeader = 0x0202e828
 		GameSettings.gBattleTerrain = 0x0300428c
@@ -1090,6 +1097,7 @@ function GameSettings.setGameAsEmerald()
 	GameSettings.gMoveToLearn = 0x020244e2
 	GameSettings.gBattleOutcome = 0x0202433a
 	GameSettings.gMoveResultFlags = 0x0202427c
+	GameSettings.gBattleWeather = 0x020243cc
 	
 	GameSettings.gMapHeader = 0x02037318
 	GameSettings.gBattleTerrain = 0x02022ff0
@@ -1243,6 +1251,7 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 		GameSettings.gMoveResultFlags = 0x02023dcc
+		GameSettings.gBattleWeather = 0x02023f1c
 
 		GameSettings.gMapHeader = 0x02036dfc
 		GameSettings.gBattleTerrain = 0x02022b50
@@ -1393,6 +1402,7 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 		GameSettings.gMoveResultFlags = 0x02023dcc
+		GameSettings.gBattleWeather = 0x02023f1c
 
 		GameSettings.gMapHeader = 0x02036dfc
 		GameSettings.gBattleTerrain = 0x02022b50
@@ -1546,6 +1556,7 @@ function GameSettings.setGameAsFireRedItaly(gameversion)
 		GameSettings.BattleScript_LearnMoveReturn = 0x081D5ECD -- expect them to not always be right
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
+		GameSettings.gBattleWeather = 0x02023f1c
 
 		GameSettings.gMapHeader = 0x02036dfc
 		GameSettings.gBattleTerrain = 0x02022b50
@@ -1705,6 +1716,7 @@ function GameSettings.setGameAsFireRedSpanish(gameversion)
 		GameSettings.BattleScript_LearnMoveReturn = 0x081D8595
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
+		GameSettings.gBattleWeather = 0x02023f1c
 
 		GameSettings.gMapHeader = 0x02036dfc
 		GameSettings.gBattleTerrain = 0x02022b50
@@ -1865,6 +1877,7 @@ function GameSettings.setGameAsFireRedFrench(gameversion)
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 		GameSettings.gMoveResultFlags = 0x02023dcc
+		GameSettings.gBattleWeather = 0x02023f1c
 
 		GameSettings.gMapHeader = 0x02036dfc
 		GameSettings.gBattleTerrain = 0x02022b50
@@ -2024,6 +2037,7 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 		GameSettings.gMoveResultFlags = 0x02023dcc
+		GameSettings.gBattleWeather = 0x02023f1c
 
 		GameSettings.gMapHeader = 0x02036dfc
 		GameSettings.gBattleTerrain = 0x02022b50
@@ -2174,6 +2188,7 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.gMoveToLearn = 0x02024022
 		GameSettings.gBattleOutcome = 0x02023e8a
 		GameSettings.gMoveResultFlags = 0x02023dcc
+		GameSettings.gBattleWeather = 0x02023f1c
 
 		GameSettings.gMapHeader = 0x02036dfc
 		GameSettings.gBattleTerrain = 0x02022b50

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -329,6 +329,36 @@ function Utils.calculateHighHPBasedDamage(currentHP, maxHP)
 	return tostring(roundedPower)
 end
 
+function Utils.calculateWeatherBall(moveType, movePower)
+	if not Tracker.Data.inBattle then
+		return moveType, movePower
+	end
+
+	local weatherIds = {
+		[1] = "Rain", [5] = "Rain",
+		[8] = "Sandstorm", [24] = "Sandstorm",
+		[32] = "Harsh sunlight", [96] = "Harsh sunlight",
+		[128] = "Hail"
+	}
+	local battleWeather = Memory.readword(GameSettings.gBattleWeather)
+	local currentWeather = weatherIds[battleWeather]
+	
+	if currentWeather ~= nil then
+		if currentWeather == "Rain" then
+			moveType = PokemonData.Types.WATER
+		elseif currentWeather == "Sandstorm" then
+			moveType = PokemonData.Types.ROCK
+		elseif currentWeather == "Harsh sunlight" then
+			moveType = PokemonData.Types.FIRE
+		elseif currentWeather == "Hail" then
+			moveType = PokemonData.Types.ICE
+		end
+		movePower = 100
+	end
+
+	return moveType, movePower
+end
+
 -- Returns a number between 0 and 1, where 1 is best possible IVs and 0 is no IVs
 function Utils.estimateIVs(pokemon)
 	if pokemon == nil or pokemon.pokemonID == 0 then

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -602,6 +602,7 @@ function InfoScreen.drawMoveInfoScreen(moveId)
 	local move = MoveData.Moves[moveId]
 	local moveType = move.type
 	local moveCat = move.category
+	local movePower = move.power
 
 	-- Before drawing view boxes, check if extra space is needed for 'Priority' information
 	if move.priority ~= nil and move.priority ~= "0" then
@@ -627,6 +628,10 @@ function InfoScreen.drawMoveInfoScreen(moveId)
 			moveCat = MoveData.TypeToCategory[moveType]
 			Drawing.drawText(offsetX + 96, offsetY + linespacing * 2 - 4, "Set type ^", Theme.COLORS["Positive text"], boxInfoTopShadow)
 		end
+	-- If the move is Weather Ball then update based on current weather
+	elseif Options["Calculate variable damage"] and moveId == 311 then -- 311 = Weather Ball
+		moveType, movePower = Utils.calculateWeatherBall(moveType, movePower)
+		moveCat = MoveData.TypeToCategory[moveType]
 	end
 
 	-- TYPE ICON
@@ -664,12 +669,11 @@ function InfoScreen.drawMoveInfoScreen(moveId)
 	offsetY = offsetY + linespacing
 
 	-- POWER
-	local powerInfo = move.power
-	if move.power == Constants.NO_POWER then
-		powerInfo = Constants.BLANKLINE
+	if movePower == Constants.NO_POWER then
+		movePower = Constants.BLANKLINE
 	end
 	Drawing.drawText(offsetX, offsetY, "Power:", Theme.COLORS["Default text"], boxInfoTopShadow)
-	Drawing.drawText(offsetColumnX, offsetY, powerInfo, Theme.COLORS["Default text"], boxInfoTopShadow)
+	Drawing.drawText(offsetColumnX, offsetY, movePower, Theme.COLORS["Default text"], boxInfoTopShadow)
 	offsetY = offsetY + linespacing
 
 	-- ACCURACY

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -748,6 +748,13 @@ function TrackerScreen.drawMovesArea(pokemon, opposingPokemon)
 			moveCategory = MoveData.TypeToCategory[moveType]
 		end
 
+		-- WEATHER BALL MOVE UPDATE
+		if Options["Calculate variable damage"] and moveData.name == "Weather Ball" then
+			moveType, movePower = Utils.calculateWeatherBall(moveType, movePower)
+			moveCategory = MoveData.TypeToCategory[moveType]
+			moveTypeColor = Constants.MoveTypeColors[moveType]
+		end
+
 		-- MOVE CATEGORY
 		if Options["Show physical special icons"] then
 			if moveCategory == MoveData.Categories.PHYSICAL then


### PR DESCRIPTION
Resolves #113 
- Adds function that automatically adjusts weather ball's type and power for the current weather in-battle.
- Also updates it in the move info page.
- Weather ball stays at vanilla type/power if not in battle or if the "Calculate variable damage" option is disabled

![Screenshot_17](https://user-images.githubusercontent.com/106463662/183098539-bb0bf331-b299-4c47-af92-e195b9cb7452.png)
![image](https://user-images.githubusercontent.com/106463662/183101455-4454611e-82a5-4757-b395-db240ca62451.png)


Only current issue relating to this is that if Castform has its vanilla ability Forecast then STAB still gets calculated based off of castform's normal form:
![Screenshot_16](https://user-images.githubusercontent.com/106463662/183099823-a8b0dfeb-0dee-44c4-9ffa-1ae692f16f11.png)

Given that forecast *only* works on Castform and I believe it's removed from the randomisation pool for this reason, this specifically is a lower-priority issue though would be nice to fix for casual playthroughs.

This is an overall Pokémon type-tracking issue though since the same would happen in the case of Color Change or moves like Conversion.