### PR TITLE
Last damage warning

### DIFF
--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -279,7 +279,7 @@ function TrackerScreen.buildCarousel()
 				if Program.BattleTurn.damageReceived > 0 then
 					lastAttackMsg = moveInfo.name .. ": " .. Program.BattleTurn.damageReceived .. " damage"
 					if Program.BattleTurn.damageReceived > pokemon.curHP then
-						-- Warn user that the damage dealt could kill if used again
+						-- Warn user that the damage taken is potentially lethal
 						TrackerScreen.Buttons.LastAttackSummary.textColor = "Negative text"
 					else
 						TrackerScreen.Buttons.LastAttackSummary.textColor = "Default text"

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -271,13 +271,19 @@ function TrackerScreen.buildCarousel()
 		-- Don't show the last attack information while the enemy is attacking, or it spoils the move & damage
 		isVisible = function() return Tracker.Data.inBattle and not Program.BattleTurn.enemyIsAttacking and Program.BattleTurn.lastMoveId ~= 0 end,
 		framesToShow = 180,
-		getContentList = function()
+		getContentList = function(pokemon)
 			local lastAttackMsg
 			-- Currently this only records last move used for damaging moves
 			if Program.BattleTurn.lastMoveId > 0 and Program.BattleTurn.lastMoveId <= #MoveData.Moves then
 				local moveInfo = MoveData.Moves[Program.BattleTurn.lastMoveId]
 				if Program.BattleTurn.damageReceived > 0 then
 					lastAttackMsg = moveInfo.name .. ": " .. Program.BattleTurn.damageReceived .. " damage"
+					if Program.BattleTurn.damageReceived > pokemon.curHP then
+						-- Warn user that the damage dealt could kill if used again
+						TrackerScreen.Buttons.LastAttackSummary.textColor = "Negative text"
+					else
+						TrackerScreen.Buttons.LastAttackSummary.textColor = "Default text"
+					end
 				else
 					lastAttackMsg = "Last move: " .. moveInfo.name
 				end


### PR DESCRIPTION
This was a suggestion given in the discord, to change the text colour of the last damage taken carousel text to warn the player that the last damage taken is potentially lethal
Went with negative text colour for this, but if another colour is preferred then lemme know
![image](https://user-images.githubusercontent.com/106463662/183123139-b94e3570-8b3e-4375-a1f1-4123b0cf2bd0.png)
