### PR TITLE
Quick fix for Route Info clarifcation and two minor bugs

### DIFF
--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -369,8 +369,15 @@ function Utils.estimateIVs(pokemon)
 
 	-- Result is between 0 and 96, with 48 being average (effectively identical to its BST), and 96 being best possible result
 	local ivGuess = (sumStats * 50 / pokemon.level) - PokemonData.Pokemon[pokemon.pokemonID].bst
-	
-	return ivGuess / 96
+	local percentageResult = ivGuess / 96
+
+	if percentageResult < 0 then
+		return 0
+	elseif percentageResult > 1 then
+		return 1
+	else
+		return percentageResult
+	end
 end
 
 function Utils.pokemonHasMove(pokemon, moveName)

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -335,7 +335,7 @@ function InfoScreen.getPokemonButtonsForEncounterArea(mapId, encounterArea)
 	end
 
 	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 3
-	local startY = Constants.SCREEN.MARGIN + 48
+	local startY = Constants.SCREEN.MARGIN + 50
 	local offsetX = 0
 	local offsetY = 0
 	local iconWidth = 32
@@ -752,6 +752,10 @@ function InfoScreen.drawRouteInfoScreen(mapId, encounterArea)
 	end
 	Drawing.drawText(boxX - 1, botBoxY - 11, encounterHeaderText, Theme.COLORS["Header text"], bgHeaderShadow)
 	gui.drawRectangle(boxX, botBoxY, boxWidth, botBoxHeight, Theme.COLORS["Lower box border"], Theme.COLORS["Lower box background"])
+
+	if not InfoScreen.Buttons.showOriginalRoute.toggleState then
+		Drawing.drawText(boxX + 2, botBoxY, "In order of appearance:", Theme.COLORS["Default text"], boxTopShadow)
+	end
 
 	-- POKEMON SEEN
 	local opposingPokemon = Tracker.getPokemon(Tracker.Data.otherViewSlot, false)

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -115,6 +115,7 @@ function SetupScreen.initialize()
 		button.boxColors = { SetupScreen.borderColor, SetupScreen.boxFillColor }
 	end
 
+	SetupScreen.Buttons.ChoosePortrait.text = Constants.Words.POKEMON .. " icon set:  " .. Options.IconSetMap[Options["Pokemon icon set"]].name
 	SetupScreen.Buttons.PokemonIcon:onClick() -- Randomize what Pokemon icon is shown
 
 	if Options.ROMS_FOLDER ~= nil and Options.ROMS_FOLDER ~= "" then


### PR DESCRIPTION
When viewing route encounters, it's unclear what the order of the Pokemon shown stands for. There is some confusion that it relates to the same order when looking at encounter percentages. This should help clear that up

Also fixes:
- The name of the Pokemon Icon Set wasn't if loaded from Settings.ini
- The EstimateIVs function would sometimes return a value that wasn't between 0 and 1.