### PR TITLE
Fixing infinite loop crash and blinking carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This project is based on [MKDasher's PokemonBizhawkLua project](https://github.c
 
 ## Supported Games
 
+For NDS (gen 4/5) games, please use the [NDS Ironmon Tracker](https://github.com/Brian0255/NDS-Ironmon-Tracker) by OnlySpaghettiCode
+
 The following games are currently supported:
 
 - Pokémon Ruby (U)
@@ -30,56 +32,23 @@ The following games are currently supported:
 
 With more non-english version support potentially coming in the future!
 
-For NDS (gen 4/5) games, please use the [NDS Ironmon Tracker](https://github.com/Brian0255/NDS-Ironmon-Tracker) by OnlySpaghettiCode
-
 ## Installation
 
-0. If you haven't used BizHawk before, [download the emulator](https://tasvideos.org/BizHawk/ReleaseHistory) (v2.8 or higher).
-   - **IMPORTANT**: _Run BizHawk once and **close** it_, then start it again before continuing! This ensures that BizHawk sets itself up properly on your system. Otherwise, the tracker may get some odd errors when trying to start it during your first use of BizHawk.
-1. **Download** the project from the [releases](https://github.com/besteon/Ironmon-Tracker/releases/latest) section. The main branch has additional changes and may not be stable.
-   - If you are feeling adventurous and wish to help us in finding bugs, you are more than welcome to clone the main branch. If the tracker crashes, please provide the log dump from the Lua Console to us via Discord or the [Issues](https://github.com/besteon/Ironmon-Tracker/issues) tab.
-2. Unzip the project anywhere you like. We recommend extracting the full folder and all of its contents directly into the `Lua` folder where you installed BizHawk. Note: The `ironmon_tracker` folder must be in the same directory as `Ironmon-Tracker.lua`.
-3. Load your ROM in [Bizhawk](https://tasvideos.org/BizHawk/ReleaseHistory) (use **version v2.8** or later for maximum compatibility)
-4. Open the Lua Console in the Bizhawk program: `Tools -> Lua Console`). Then click the little folder icon to "Open a file" (or use `Script -> Open Script`) and select the `Ironmon-Tracker.lua` file in the location you extracted it to.
-   - Be careful not to click the New file icon, Bizhawk does not warn you about overwriting scripts so it's easy to do so by mistake.
-   - If you installed the tracker in Bizhawk's `Lua` folder, this location is shown by default and you should see the `Ironmon-Tracker.lua` file right away.
-5. Configure the settings for the Tracker by clicking the gear/cog icon near the top of the tracker window. From here, provide a location where you keep your ROMs by clicking on the note icon next to where it says `Roms folder`. Additionally, you can customize the tracker's look-and-feel through the `Customize Theme` button.
-
-If you want to use your controller to toggle stat prediction markers on opponent Pokémon, set Button Mode in the in-game options to LR to prevent the help menu from displaying.
+1. **Get Bizhawk**: If you haven't used BizHawk before, [download the emulator](https://tasvideos.org/BizHawk/ReleaseHistory) (v2.8 or higher)
+2. **Download the Tracker**: You can get the latest project release from the [releases](https://github.com/besteon/Ironmon-Tracker/releases/latest) section.
+   - The main branch has additional changes and may not be stable. If you are feeling adventurous and wish to help us in finding bugs, you are more than welcome to clone the main branch. If the tracker crashes, please provide the log dump from the Lua Console to us via Discord or the [Issues](https://github.com/besteon/Ironmon-Tracker/issues) tab.
+3. **Install and Setup**: See the full [Installation Guide](https://github.com/besteon/Ironmon-Tracker/wiki/Installation-Guide) for more detailed instructions for installing or upgrading.
+4. **Quickstart Guide**: After getting it all setup, check out the [Quickstart Guide](https://github.com/besteon/Ironmon-Tracker/wiki/Quickstart-Guide) for an overview on how to use the Tracker and learn about all of the information that it displays.
 
 ## Latest Changes
 
 - **_NEW!!_ Route tracking and info, Full ability tracking, Notes on last damage taken, and more!**
 
-![image](https://user-images.githubusercontent.com/4258818/181117644-8e37257e-6645-4bdb-97bb-9f4359097095.png)
+![image](https://user-images.githubusercontent.com/4258818/183269070-4ab20627-1364-47c1-ba99-b20115cc5609.png)
 
-## Features
+## Full Feature List
 
-- **Your Pokémon**: Your Pokémon's stats, moves, ability, and more are tracked in real-time as you play! As you learn new moves and use them, level up, and use items, the tracker updates the appropriate information. It will also tell you the level or condition it needs to evolve, the number of moves it will learn, and the next level a move will be learned. All data is sourced from [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Main_Page) except some evolution requirements based on the use of the randomizer.
-- **Pokémon Info Look-up**: Click on the icon of your Pokémon or an enemy Pokémon to learn more details about them. This provides easy access to handy info like BST, Evolution(s), Weaknesses, and when the Pokémon learns each new move as it levels up.
-- **Stat modifying moves**: If your opponent or you use a stat modifying move, like `Growl`, up and down chevrons are displayed next to the affected stat on the target. Up to three chevrons are displayed, and change color when the fourth, fifth, and sixth stack are applied.
-- **Enemy abilities**: Click on the area where the enemy abilties are shown to change them, allowing you to take notes on which one or two abilities the Pokémon has. In most cases, the abilities that activate on screen are automatically tracked for you.
-- **Enemy moveset**: Enemy Pokémon moves are unknown AND they change as the various Pokémon level up throughout the game! The tracker will display moves a Pokémon has as they use them, along with the basic PP, power, and accuracy information. When you encounter the same Pokémon type later in the game, old moves are marked with a `*` at the end of the name. This allows you to know that the move may still be known or may be replaced by a new move.
-- **Move Info Look-up**: Click on any move to learn more details about that move. This will often provide useful and cool details about the move you might not otherwise have known existed.
-- **Route Info Look-up**: While fighting a wild Pokémon, you can click on the route icon on the tracker to see more information about that particular route. It will show you each unique Pokémon species you've encountered thus far, as well as the original encounter rates you'd find in the base game (like in a walkthrough).
-- **Stat Prediction**: Enemy Pokémon stats are unknown, but you can mark a prediction on which stats may be high or low by adding a + or - icon to the appropriate stat. This is accomplished on the enemy Pokémon by cycling through the stats with the L button and toggling the prediction with the R button.
-- **Notes**: Click on the bottom bar to leave a note about the Pokémon you are facing!
-- **Move effectiveness**: Moves that are super effective or not very effective against the opposing Pokémon will display one or two chevrons next to the move's power stat. Moves that are completely ineffective will display a red `X`.
-- **Attack type icons**: Icons for moves that are physical or special attack types can be displayed next to the move name.
-- **Healing items**: The tracker displays the number of healing items on hand in the bag and what percentage of max HP of the currently displayed Pokémon those items will heal by.
-  - This feature only works in Emerald, Fire Red, and Leaf Green.
-- **Quick loading seeds**: You can create a bunch of seeds (ROMs) ahead of time, and then use a button combination to load the next seed. Seeds must be in a numerical order.
-  - _For example:_ you can start at 13 with a file name like `kaizo13.gba`. Pressing the button combination would then load `kaizo14.gba`. Press it again and `kaizo15.gba` is loaded.
-- **Settings**: You can now modify **nearly all** settings for the tracker within the tracker itself! Click on the gear icon near the Pokémon name to open the new Settings menu.
-  - Click on a setting to turn it on or off!
-  - Click on the Roms Folder setting to open a dialog that allows you to pick the folder where your files are stored.
-    - Note: Pick any file in the desired folder. The folder itself will be saved as the setting.
-  - Edit Controller configuration to change up what buttons are used to toggle the view, or load the next seed.
-  - The Settings.ini file will update with your changes when you close the settings menu. You can still modify this file if you really need to..
-- **Themes**: Customize the way your tracker looks by editing the theme colors for any of it's element.
-  - Choose from a handful of preloaded themes.
-  - Want to make a small change, or change everything? Go for it! Changes will save in your Settings.ini file so they persist between play sessions.
-  - Got a cool theme you want to share, or want to try using a theme someone else has created? You can use Export and Import to do just that.
+A full feature list is available on the [project's Wiki](https://github.com/besteon/Ironmon-Tracker/wiki/Feature-List).
 
 ## FAQ
 

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -69,6 +69,10 @@ function Input.checkJoypadInput(joypadButtons)
 		if Input.controller.framesSinceInput < Input.controller.boxVisibleFrames then
 			Input.controller.framesSinceInput = 0
 
+			-- This might be redundant, but adding in the extra safety check
+			if Input.controller.statIndex < 1 then Input.controller.statIndex = 1 end
+			if Input.controller.statIndex > 6 then Input.controller.statIndex = 6 end
+
 			local statKey = Constants.OrderedLists.STATSTAGES[Input.controller.statIndex]
 			local statButton = TrackerScreen.Buttons[statKey]
 			statButton:onClick()
@@ -106,6 +110,10 @@ function Input.checkMouseInput(xmouse, ymouse)
 			end
 		end
 	end
+end
+
+function Input.resetControllerIndex()
+	Input.controller.statIndex = 0
 end
 
 --[[

--- a/ironmon_tracker/Memory.lua
+++ b/ironmon_tracker/Memory.lua
@@ -1,6 +1,7 @@
 Memory = {}
 
 function Memory.read(addr, size)
+	if addr == nil or addr <= 0x0 then return 0 end
 	local mem = ""
 	local memdomain = bit.rshift(addr, 24)
 	if memdomain == 0 then
@@ -38,6 +39,7 @@ end
 
 -- Unless absolutely necessary (looking at you fishing rods), do NOT write to memory
 function Memory.write(addr, value, size)
+	if addr == nil or addr <= 0x0 then return false end
 	local mem = ""
 	local memdomain = bit.rshift(addr, 24)
 	if memdomain == 0 then

--- a/ironmon_tracker/Memory.lua
+++ b/ironmon_tracker/Memory.lua
@@ -1,7 +1,12 @@
 Memory = {}
 
 function Memory.read(addr, size)
-	if addr == nil or addr <= 0x0 then return 0 end
+	if addr == nil or addr <= 0x0 then
+		print(debug.traceback())
+		print("[ERROR] Unable to read game memory from unknown address.")
+		return 0
+	end
+
 	local mem = ""
 	local memdomain = bit.rshift(addr, 24)
 	if memdomain == 0 then
@@ -39,7 +44,12 @@ end
 
 -- Unless absolutely necessary (looking at you fishing rods), do NOT write to memory
 function Memory.write(addr, value, size)
-	if addr == nil or addr <= 0x0 then return false end
+	if addr == nil or addr <= 0x0 then
+		print(debug.traceback())
+		print("[ERROR] Unable to write to game memory using an unknown address.")
+		return false
+	end
+
 	local mem = ""
 	local memdomain = bit.rshift(addr, 24)
 	if memdomain == 0 then

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -126,8 +126,7 @@ function Program.updateTrackedAndCurrentData()
 				Tracker.Data.isViewingOwn = false
 			end
 
-			-- Reset the controller's position when a new pokemon is sent out
-			Input.controller.statIndex = 6
+			Input.resetControllerIndex()
 
 			-- Delay drawing the new pokemon, because of send out animation
 			Program.Frames.waitToDraw = 0
@@ -599,7 +598,7 @@ function Program.beginNewBattle(isWild)
 	Tracker.Data.isViewingOwn = not Options["Auto swap to enemy"]
 	Tracker.Data.ownViewSlot = 1
 	Tracker.Data.otherViewSlot = 1
-	Input.controller.statIndex = 6 -- Reset the controller's position when a new pokemon is sent out
+	Input.resetControllerIndex()
 
 	-- Handles a common case of looking up a move, then entering combat. As a battle begins, the move info screen should go away.
 	if Program.currentScreen == Program.Screens.INFO then

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -54,14 +54,19 @@ function Tracker.getPokemon(slotNumber, isOwn)
 	if personality == nil or personality == 0 then return nil end
 
 	if isOwn then
-		if Tracker.Data.ownPokemon[personality].isEgg == 1 then
+		local isEggPokemon = Tracker.Data.ownPokemon[personality].isEgg == 1
+		if isEggPokemon then
 			-- Currently viewed pokemon is still an egg
 			local nextSlot = slotNumber
+			local numPokemon = #Tracker.Data.ownTeam
 			repeat
 				-- Cycle to the next non-egg party member (you're required at least one non-egg in the party)
-				nextSlot = nextSlot + 1
+				nextSlot = (nextSlot % numPokemon) + 1
 				personality = Tracker.Data.ownTeam[nextSlot]
-			until personality ~= nil and personality ~= 0 and Tracker.Data.ownPokemon[personality].isEgg == 0
+				if personality ~= nil and personality ~= 0 then
+					isEggPokemon = Tracker.Data.ownPokemon[personality].isEgg == 1
+				end
+			until not isEggPokemon or nextSlot == slotNumber
 		end
 		return Tracker.Data.ownPokemon[personality]
 	else

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -2,8 +2,13 @@ Tracker = {}
 Tracker.Data = {}
 
 function Tracker.initialize()
-	local filepath = GameSettings.getTrackerAutoSaveName()
-	Tracker.loadData(filepath)
+	if Options["Auto save tracked game data"] then
+		local filepath = GameSettings.getTrackerAutoSaveName()
+		Tracker.loadData(filepath)
+	else
+		Tracker.resetData()
+		print("Initializing new Tracker data for this game (auto-save option is disabled).")
+	end
 end
 
 -- Either adds this pokemon to storage if it doesn't exist, or updates it if it's already there
@@ -369,7 +374,7 @@ function Tracker.resetData()
 	-- If adding new data fields to this object, always append to the end; allows TDAT files to be upgrade-safe
 	Tracker.Data = {
 		version = Main.TrackerVersion,
-		romHash = nil,
+		romHash = gameinfo.getromhash(),
 
 		trainerID = 0,
 		allPokemon = {}, -- Used to track information about all pokemon seen thus far
@@ -409,7 +414,6 @@ function Tracker.loadData(filepath)
 
 	-- Initialize empty Tracker data, to potentially populate with data from .TDAT save file
 	Tracker.resetData()
-	Tracker.Data.romHash = gameinfo.getromhash()
 
 	-- Loose safety check to ensure a valid data file is loaded
 	local fileData = nil

--- a/ironmon_tracker/data/MoveData.lua
+++ b/ironmon_tracker/data/MoveData.lua
@@ -1840,7 +1840,7 @@ MoveData.Moves = {
 		accuracy = "100",
 		category = MoveData.Categories.SPECIAL,
 		iscontact = true,
-		summary = "Steals the target's held item, if it has one. An item cannot be stolen if the target has Sticky Hold.",
+		summary = "Steals the target's held item, if it has one. An item cannot be stolen if the user already has an item, or the target has Sticky Hold.",
 	},
 	{
 		id = "169",

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -161,9 +161,9 @@ TrackerScreen.Buttons = {
 
 TrackerScreen.CarouselTypes = {
     BADGES = 1, -- Outside of battle
-	NOTES = 2, -- During new game intro or inside of battle
-	LAST_ATTACK = 3, -- During battle, only between turns
-	ROUTE_INFO = 4, -- During battle, only if encounter is a wild pokemon
+	LAST_ATTACK = 2, -- During battle, only between turns
+	ROUTE_INFO = 3, -- During battle, only if encounter is a wild pokemon
+	NOTES = 4, -- During new game intro or inside of battle
 }
 
 TrackerScreen.carouselIndex = 1
@@ -327,8 +327,12 @@ end
 function TrackerScreen.getCurrentCarouselItem()
 	local carousel = TrackerScreen.CarouselItems[TrackerScreen.carouselIndex]
 
+	-- Adjust rotation delay check for carousel based on the speed of emulation
+	local fpsMultiplier = math.max(client.get_approx_framerate() / 60, 1) -- minimum of 1
+	local adjustedVisibilityFrames = carousel.framesToShow * fpsMultiplier
+
 	-- Check if the current carousel's time has expired, or if it shouldn't be shown
-	if carousel == nil or not carousel.isVisible() or Program.Frames.carouselActive > carousel.framesToShow then
+	if carousel == nil or not carousel.isVisible() or Program.Frames.carouselActive > adjustedVisibilityFrames then
 		local nextCarousel = TrackerScreen.getNextVisibleCarouselItem(TrackerScreen.carouselIndex)
 		TrackerScreen.carouselIndex = nextCarousel.type
 		Program.Frames.carouselActive = 0
@@ -680,7 +684,7 @@ function TrackerScreen.drawStatsArea(pokemon)
 
 	-- Draw BST
 	Drawing.drawText(statOffsetX, statOffsetY, "BST", Theme.COLORS["Default text"], shadowcolor)
-	Drawing.drawText(statOffsetX + 25, statOffsetY, pokemon.bst, Theme.COLORS["Default text"], shadowcolor)
+	Drawing.drawNumber(statOffsetX + 25, statOffsetY, pokemon.bst, 3, Theme.COLORS["Default text"], shadowcolor)
 
 	-- If controller is in use and highlighting any stats, draw that
 	Drawing.drawInputOverlay()


### PR DESCRIPTION
There is an issue with the isEgg memory read where if the wrong value is read from memory (caused by game data hiccups), then it will cause the getPokemon to get stuck in an infinite loop and crash Bizhawk.

This fix ensures the loop eventually breaks by looping back around to the original viewslot.

I've also included a fix for users who regularly use speed-up and notice the carousel rotation speed causes it to blink.