### PR TITLE
Provide an option to enable/disable the Last Damage calculation information

### DIFF
--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -91,6 +91,7 @@ Constants.OrderedLists = {
 		"PC heals count downward",
 		"Auto save tracked game data",
 		"Pokemon icon set",
+		"Show last damage calcs",
 		"Reveal info if randomized",
 	},
 	CONTROLS = {

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -17,6 +17,7 @@ Options = {
 	["PC heals count downward"] = true,
 	["Auto save tracked game data"] = true,
 	["Pokemon icon set"] = "1", -- Original icon set
+	["Show last damage calcs"] = true,
 	["Reveal info if randomized"] = true,
 
 	CONTROLS = {

--- a/ironmon_tracker/screens/GameOptionsScreen.lua
+++ b/ironmon_tracker/screens/GameOptionsScreen.lua
@@ -12,6 +12,7 @@ GameOptionsScreen.OptionKeys = {
 	"Show move effectiveness",
 	"Calculate variable damage",
 	"Count enemy PP usage",
+	"Show last damage calcs",
 	"Reveal info if randomized",
 }
 

--- a/ironmon_tracker/screens/GameOptionsScreen.lua
+++ b/ironmon_tracker/screens/GameOptionsScreen.lua
@@ -21,7 +21,7 @@ GameOptionsScreen.Buttons = {
 		type = Constants.ButtonTypes.FULL_BORDER,
 		text = "Estimate " .. Constants.Words.POKEMON .. "'s Potential",
 		ivText = "",
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 5, Constants.SCREEN.MARGIN + 105, 123, 11 },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 5, Constants.SCREEN.MARGIN + 110, 123, 11 },
 		onClick = function(self)
 			local leadPokemon = Tracker.getPokemon(Tracker.Data.ownViewSlot, true)
 			if leadPokemon ~= nil then
@@ -47,7 +47,7 @@ GameOptionsScreen.Buttons = {
 
 function GameOptionsScreen.initialize()
 	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 3
-	local startY = Constants.SCREEN.MARGIN + 18
+	local startY = Constants.SCREEN.MARGIN + 14
 
 	for _, optionKey in ipairs(GameOptionsScreen.OptionKeys) do
 		GameOptionsScreen.Buttons[optionKey] = {

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -269,7 +269,7 @@ function TrackerScreen.buildCarousel()
 	TrackerScreen.CarouselItems[TrackerScreen.CarouselTypes.LAST_ATTACK] = {
 		type = TrackerScreen.CarouselTypes.LAST_ATTACK,
 		-- Don't show the last attack information while the enemy is attacking, or it spoils the move & damage
-		isVisible = function() return Tracker.Data.inBattle and not Program.BattleTurn.enemyIsAttacking and Program.BattleTurn.lastMoveId ~= 0 end,
+		isVisible = function() return Options["Show last damage calcs"] and Tracker.Data.inBattle and not Program.BattleTurn.enemyIsAttacking and Program.BattleTurn.lastMoveId ~= 0 end,
 		framesToShow = 180,
 		getContentList = function()
 			local lastAttackMsg


### PR DESCRIPTION
There's been a bit of conversation about whether the Last Damage information is "too much" for the tracker to be doing. While most voices have said it's probably fine given you can just calc it yourself, I'd still like to include this option for those that don't want so much hand-holding.

This PR exposes an option to the user to turn the Last Damage calculation information on or off. When turned off, the damage carousel will simply be skipped (not visible).