### PR TITLE
Improved version/file checks

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -40,7 +40,7 @@ function Main.Initialize()
 	print("\nIronmon-Tracker (Gen 3): v" .. Main.TrackerVersion)
 
 	-- Check the version of BizHawk that is running
-	if Main.UnsupportedBizhawkVersion() then
+	if not Main.SupportedBizhawkVersion() then
 		print("This version of BizHawk is not supported for use with the Tracker.\nPlease update to version 2.8 or higher.")
 		Main.DisplayError("This version of BizHawk is not supported for use with the Tracker.\n\nPlease update to version 2.8 or higher.")
 		return false
@@ -62,16 +62,27 @@ function Main.Initialize()
 	return true
 end
 
--- Returns true if Bizhawk version is older than 2.8
-function Main.UnsupportedBizhawkVersion()
+-- Checks if Bizhawk version is 2.8 or later
+function Main.SupportedBizhawkVersion()
 	-- Significantly older Bizhawk versions don't have a client.getversion function
-	if client.getversion == nil then return true end
+	if client.getversion == nil then return false end
 
 	-- Check the major and minor version numbers separately, to account for versions such as "2.10"
 	local major, minor = string.match(client.getversion(), "(%d+)%.(%d+)")
-	if major == nil or minor == nil then return true end
-
-	return (tonumber(major) < 2 or tonumber(minor) < 8)
+	if major ~= nil then
+		local majorNumber = tonumber(major)
+		if majorNumber > 2 then
+			-- Will allow anything v3.0 and upwards
+			return true
+		elseif majorNumber == 2 then
+			-- Is v2.x, check minor version number
+			if minor ~= nil then
+				return tonumber(minor) >= 8
+			end
+		end
+	end
+	
+	return false
 end
 
 -- Checks if a file exists

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -64,7 +64,7 @@ end
 
 -- Checks if the current Bizhawk version is 2.8 or later
 function Main.CheckBizhawkVersion()
-	-- Older Bizhawk versions don't have a client.getversion function
+	-- Significantly older Bizhawk versions don't have a client.getversion function
 	if client.getversion == nil then return true end
 
 	-- Check the major and minor version numbers separately, to account for versions such as "2.10"

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -62,7 +62,7 @@ function Main.Initialize()
 	return true
 end
 
--- Checks if the current Bizhawk version is 2.8 or later
+-- Returns true if Bizhawk version is older than 2.8
 function Main.UnsupportedBizhawkVersion()
 	-- Significantly older Bizhawk versions don't have a client.getversion function
 	if client.getversion == nil then return true end

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -40,7 +40,7 @@ function Main.Initialize()
 	print("\nIronmon-Tracker (Gen 3): v" .. Main.TrackerVersion)
 
 	-- Check the version of BizHawk that is running
-	if Main.CheckBizhawkVersion() then
+	if Main.UnsupportedBizhawkVersion() then
 		print("This version of BizHawk is not supported for use with the Tracker.\nPlease update to version 2.8 or higher.")
 		Main.DisplayError("This version of BizHawk is not supported for use with the Tracker.\n\nPlease update to version 2.8 or higher.")
 		return false
@@ -49,7 +49,7 @@ function Main.Initialize()
 	-- Attempt to load the required tracker files
 	for _, file in ipairs(Main.TrackerFiles) do
 		local path = Main.DataFolder .. file
-		if Main.fileExists(path) then
+		if Main.FileExists(path) then
 			dofile(path)
 		else
 			print("Unable to load " .. path .. "\nMake sure all of the downloaded Tracker's files are still together.")
@@ -63,7 +63,7 @@ function Main.Initialize()
 end
 
 -- Checks if the current Bizhawk version is 2.8 or later
-function Main.CheckBizhawkVersion()
+function Main.UnsupportedBizhawkVersion()
 	-- Significantly older Bizhawk versions don't have a client.getversion function
 	if client.getversion == nil then return true end
 
@@ -75,7 +75,7 @@ function Main.CheckBizhawkVersion()
 end
 
 -- Checks if a file exists
-function Main.fileExists(path)
+function Main.FileExists(path)
 	local file = io.open(path,"r")
 	if file ~= nil then
 		io.close(file)
@@ -173,11 +173,11 @@ function Main.LoadNext()
 	local nextrompath = Options.ROMS_FOLDER .. "/" .. nextromname .. ".gba"
 
 	-- First try loading the next rom as-is with spaces, otherwise replace spaces with underscores and try again
-	if not Main.fileExists(nextrompath) then
+	if not Main.FileExists(nextrompath) then
 		-- File doesn't exist, try again with underscores instead of spaces
 		nextromname = nextromname:gsub(" ", "_")
 		nextrompath = Options.ROMS_FOLDER .. "/" .. nextromname .. ".gba"
-		if not Main.fileExists(nextrompath) then
+		if not Main.FileExists(nextrompath) then
 			-- This means there doesn't exist a ROM file with spaces or underscores
 			print("ERROR: Next ROM not found\n")
 			Main.DisplayError("Unable to find next ROM: " .. nextromname .. ".gba\n\nMake sure your ROMs are numbered and the ROMs folder is correct.")

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -528,8 +528,3 @@ function Utils.getEncryptionKey(size)
 	local saveBlock2addr = Memory.readdword(GameSettings.gSaveBlock2ptr)
 	return Memory.read(saveBlock2addr + GameSettings.EncryptionKeyOffset, size)
 end
-
-function Utils.fileExists(path)
-	local file = io.open(path,"r")
-	if file ~= nil then io.close(file) return true else return false end
-end


### PR DESCRIPTION
Finally got round to future-proofing the Bizhawk version check. The updated check uses regex to check the major and minor version numbers separately, rather than the hardcoded string checks done before. This would then allow a theoretical 2.10 release of Bizhawk to pass the check.

Also, improved the error handling and loading of required tracker files. It only checked the Inifile.lua so would technically pass the check if for whatever reason a user moved any of the other files out the folder except the Inifile.lua. I've defined the files to load in a table (which can be edited if we add to/change the files in the data folder) so that a check is ran for each file it attempts to load before loading it.