### PR TITLE
Restore fishing law

### DIFF
--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -69,6 +69,13 @@ Constants.MoveTypeColors = {
 	unknown = 0xFF68A090, -- For the "Curse" move in Gen 2 - 4
 }
 
+Constants.GAME_STATS = { -- Enums for in-game stats
+	-- https://github.com/pret/pokefirered/blob/master/include/constants/game_stat.h
+	FISHING_CAPTURES = 12, -- Deceptive name, gets incremented when fishing encounter happens
+	USED_POKECENTER = 15,
+	RESTED_AT_HOME = 16,
+}
+
 Constants.OrderedLists = {
 	STATSTAGES = {
 		"hp",

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -366,7 +366,7 @@ function Program.updateBattleDataFromMemory()
 			Program.CurrentRoute.encounterArea = RouteData.getEncounterAreaByTerrain(battleTerrain, battleFlags)
 
 			-- Check if fishing encounter, if so then get the rod that was used
-			local gameStat_FishingCaptures = Utils.getGameStat(12)
+			local gameStat_FishingCaptures = Utils.getGameStat(Constants.GAME_STATS.FISHING_CAPTURES)
 			if gameStat_FishingCaptures ~= Tracker.Data.gameStatsFishing then
 				Tracker.Data.gameStatsFishing = gameStat_FishingCaptures
 
@@ -665,9 +665,9 @@ function Program.updatePCHealsFromMemory()
 	-- Updates PC Heal tallies and handles auto-tracking PC Heal counts when the option is on
 	-- Currently checks the total number of heals from pokecenters and from mom
 	-- Does not include whiteouts, as those don't increment either of these gamestats
-	local gameStat_UsedPokecenter = Utils.getGameStat(15)
+	local gameStat_UsedPokecenter = Utils.getGameStat(Constants.GAME_STATS.USED_POKECENTER)
 	-- Turns out Game Freak are weird and only increment mom heals in RSE, not FRLG
-	local gameStat_RestedAtHome = Utils.getGameStat(16)
+	local gameStat_RestedAtHome = Utils.getGameStat(Constants.GAME_STATS.RESTED_AT_HOME)
 
 	local combinedHeals = gameStat_UsedPokecenter + gameStat_RestedAtHome
 

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -365,9 +365,15 @@ function Program.updateBattleDataFromMemory()
 			Program.CurrentRoute.mapId = Memory.readword(GameSettings.gMapHeader + 0x12) -- 0x12: mapLayoutId
 			Program.CurrentRoute.encounterArea = RouteData.getEncounterAreaByTerrain(battleTerrain, battleFlags)
 
-			local fishingRod = Memory.readword(GameSettings.gSpecialVar_ItemId)
-			if RouteData.Rods[fishingRod] ~= nil then
-				Program.CurrentRoute.encounterArea = RouteData.Rods[fishingRod]
+			-- Check if fishing encounter, if so then get the rod that was used
+			local gameStat_FishingCaptures = Utils.getGameStat(12)
+			if gameStat_FishingCaptures ~= Tracker.Data.gameStatsFishing then
+				Tracker.Data.gameStatsFishing = gameStat_FishingCaptures
+
+				local fishingRod = Memory.readword(GameSettings.gSpecialVar_ItemId)
+				if RouteData.Rods[fishingRod] ~= nil then
+					Program.CurrentRoute.encounterArea = RouteData.Rods[fishingRod]
+				end
 			end
 
 			Program.CurrentRoute.hasInfo = RouteData.hasRouteEncounterArea(Program.CurrentRoute.mapId, Program.CurrentRoute.encounterArea)
@@ -650,11 +656,6 @@ function Program.endBattle(isWild)
 		Program.currentScreen = Program.Screens.TRACKER
 	end
 
-	-- If the battle was a fishing encounter, clear out the rod used from memory (not pretty, but it works)
-	if RouteData.isFishingEncounter(Program.CurrentRoute.encounterArea) then
-		Memory.writeword(GameSettings.gSpecialVar_ItemId, 0)
-	end
-
 	-- Delay drawing the return to viewing your pokemon screen
 	Program.Frames.waitToDraw = Utils.inlineIf(isWild, 70, 150)
 	Program.Frames.saveData = Utils.inlineIf(isWild, 70, 150) -- Save data after every battle
@@ -662,20 +663,11 @@ end
 
 function Program.updatePCHealsFromMemory()
 	-- Updates PC Heal tallies and handles auto-tracking PC Heal counts when the option is on
-	local saveBlock1Addr = Utils.getSaveBlock1Addr()
-	local gameStatsAddr = saveBlock1Addr + GameSettings.gameStatsOffset
-
 	-- Currently checks the total number of heals from pokecenters and from mom
 	-- Does not include whiteouts, as those don't increment either of these gamestats
-	local gameStat_UsedPokecenter = Memory.readdword(gameStatsAddr + 15 * 0x4)
+	local gameStat_UsedPokecenter = Utils.getGameStat(15)
 	-- Turns out Game Freak are weird and only increment mom heals in RSE, not FRLG
-	local gameStat_RestedAtHome = Memory.readdword(gameStatsAddr + 16 * 0x4)
-
-	local key = Utils.getEncryptionKey(4) -- Want a 32-bit key
-	if key ~= nil then
-		gameStat_UsedPokecenter = bit.bxor(gameStat_UsedPokecenter, key)
-		gameStat_RestedAtHome = bit.bxor(gameStat_RestedAtHome, key)
-	end
+	local gameStat_RestedAtHome = Utils.getGameStat(16)
 
 	local combinedHeals = gameStat_UsedPokecenter + gameStat_RestedAtHome
 

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -414,7 +414,7 @@ function Tracker.resetData()
 		},
 		encounterTable = { -- key: mapId, value: lookup table with key for terrain type and value of unique pokemonIDs
 		},
-		gameStatsFishing = Utils.getGameStat(12), -- Tally of fishing encounters, to track when one occurs
+		gameStatsFishing = Utils.getGameStat(Constants.GAME_STATS.FISHING_CAPTURES), -- Tally of fishing encounters, to track when one occurs
 	}
 end
 

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -414,6 +414,7 @@ function Tracker.resetData()
 		},
 		encounterTable = { -- key: mapId, value: lookup table with key for terrain type and value of unique pokemonIDs
 		},
+		gameStatsFishing = Utils.getGameStat(12), -- Tally of fishing encounters, to track when one occurs
 	}
 end
 

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -529,6 +529,22 @@ function Utils.getEncryptionKey(size)
 	return Memory.read(saveBlock2addr + GameSettings.EncryptionKeyOffset, size)
 end
 
+function Utils.getGameStat(statIndex)
+	-- Reads the game stat stored at statIndex in memory
+	-- https://github.com/pret/pokefirered/blob/master/include/constants/game_stat.h
+	local saveBlock1Addr = Utils.getSaveBlock1Addr()
+	local gameStatsAddr = saveBlock1Addr + GameSettings.gameStatsOffset
+
+	local gameStatValue = Memory.readdword(gameStatsAddr + statIndex * 0x4)
+
+	local key = Utils.getEncryptionKey(4) -- Want a 32-bit key
+	if key ~= nil then
+		gameStatValue = bit.bxor(gameStatValue, key)
+	end
+
+	return gameStatValue
+end
+
 function Utils.fileExists(path)
 	local file = io.open(path,"r")
 	if file ~= nil then io.close(file) return true else return false end


### PR DESCRIPTION
Instead of writing to memory to reset the item stored in `gSpecialVar_ItemId` to prevent a non-fishing encounter from being counted as a fishing encounter, can read the in-game tally of fishing encounters stored in the [game stats](https://github.com/pret/pokefirered/blob/master/include/constants/game_stat.h) to check if one occurred.

Also cleaned up the other game stats reads as part of this, moving the actual read to a Utils function and defining enums for the game stats currently being used in Constants.

To note, I set the fishing encounters tally in Tracker.Data to initialise to whatever the memory read of the in-game fishing encounters stat is at time of tracker data reset. This is to prevent a wild encounter being incorrectly tracked as a fishing encounter if someone were to clear their tracker data mid-run while the fishing rod is still set in `gSpecialVar_ItemId` in game memory.

Law and order has been restored ⚖️ 