### PR TITLE
The Hide Summary Stats option doesn't work for the current game

### DIFF
--- a/ironmon_tracker/screens/GameOptionsScreen.lua
+++ b/ironmon_tracker/screens/GameOptionsScreen.lua
@@ -55,7 +55,7 @@ function GameOptionsScreen.initialize()
 
 				-- If check summary gets toggled, force update on tracker data (case for just starting the game and turning option on)
 				if self.text == GameOptionsScreen.OptionKeys[2] then
-					Tracker.Data.hasCheckedSummary = not Options[self.text]
+					Tracker.Data.hasCheckedSummary = Options[self.text]
 				end
 
 				Options.updateSetting(self.text, self.toggleState)

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -792,7 +792,7 @@ function InfoScreen.drawRouteInfoScreen(mapId, encounterArea)
 	gui.drawRectangle(boxX, botBoxY, boxWidth, botBoxHeight, Theme.COLORS["Lower box border"], Theme.COLORS["Lower box background"])
 
 	if not InfoScreen.Buttons.showOriginalRoute.toggleState then
-		Drawing.drawText(boxX + 2, botBoxY, "In order of appearance:", Theme.COLORS["Default text"], boxTopShadow)
+		Drawing.drawText(boxX + 2, botBoxY, "In order of appearance:", Theme.COLORS["Default text"], boxBotShadow)
 	end
 
 	-- POKEMON SEEN

--- a/ironmon_tracker/screens/TrackedDataScreen.lua
+++ b/ironmon_tracker/screens/TrackedDataScreen.lua
@@ -40,12 +40,9 @@ TrackedDataScreen.Buttons = {
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 112, Constants.SCREEN.MARGIN + 135, 24, 11 },
 		onClick = function(self)
 			-- Revert the Clear Data button
-			local clearBtn = TrackedDataScreen.Buttons.ClearData
-			if clearBtn.confirmReset then
-				clearBtn.text = " * Clear Data *"
-				clearBtn.textColor = "Default text"
-				clearBtn.confirmReset = false
-			end
+			TrackedDataScreen.Buttons.ClearData.text = " * Clear Data *"
+			TrackedDataScreen.Buttons.ClearData.textColor = "Default text"
+			TrackedDataScreen.Buttons.ClearData.confirmReset = false
 
 			-- Save all of the Options to the Settings.ini file, and navigate back to the main Tracker screen
 			Main.SaveSettings()


### PR DESCRIPTION
Currently if this option is toggled in the middle of a playthrough, it won't work properly. It has inverted logic.

Also fixing a visual bug with some text on the Route display page.