### PR TITLE
Replace route info MORE button with back/forward cycle buttons

### DIFF
--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -215,6 +215,31 @@ function RouteData.getNextAvailableEncounterArea(mapId, encounterArea)
 	return encounterArea
 end
 
+function RouteData.getPreviousAvailableEncounterArea(mapId, encounterArea)
+	if not RouteData.hasRoute(mapId) then return nil end
+
+	local startingIndex = 0
+	for index, area in ipairs(RouteData.OrderedEncounters) do
+		if encounterArea == area then
+			startingIndex = index
+			break
+		end
+	end
+
+	local numEncounters = #RouteData.OrderedEncounters
+	-- This fancy formula is due to indices starting at 1, thanks lua
+	local previousIndex = ((startingIndex - 2 + numEncounters) % numEncounters) + 1
+	while startingIndex ~= previousIndex do
+		encounterArea = RouteData.OrderedEncounters[previousIndex]
+		if RouteData.hasRouteEncounterArea(mapId, encounterArea) then
+			break
+		end
+		previousIndex = ((previousIndex - 2 + numEncounters) % numEncounters) + 1
+	end
+
+	return encounterArea
+end
+
 -- Returns a table of all pokemon info in an area, where pokemonID is the key, and encounter rate/levels are the values
 function RouteData.getEncounterAreaPokemon(mapId, encounterArea)
 	if not RouteData.hasRouteEncounterArea(mapId, encounterArea) then return {} end

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -89,12 +89,25 @@ InfoScreen.Buttons = {
 			Program.redraw(true)
 		end
 	},
-	showMoreRouteEncounters = {
-		type = Constants.ButtonTypes.FULL_BORDER,
-		text = "More...",
+	previousRoute = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = Constants.PixelImages.PREVIOUS_BUTTON,
 		textColor = "Default text",
-		box = { Constants.SCREEN.WIDTH + 83, 141, 30, 11 },
-		boxColors = { "Lower box border", "Lower box background" },
+		box = { Constants.SCREEN.WIDTH + 6, 37, 10, 10, },
+		isVisible = function() return InfoScreen.viewScreen == InfoScreen.Screens.ROUTE_INFO end,
+		onClick = function(self)
+			if not self:isVisible() then return end
+			local mapId = InfoScreen.infoLookup.mapId
+			local encounterArea = InfoScreen.infoLookup.encounterArea
+			InfoScreen.infoLookup.encounterArea = RouteData.getPreviousAvailableEncounterArea(mapId, encounterArea)
+			Program.redraw(true)
+		end
+	},
+	nextRoute = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = Constants.PixelImages.NEXT_BUTTON,
+		textColor = "Default text",
+		box = { Constants.SCREEN.WIDTH + 136, 37, 10, 10, },
 		isVisible = function() return InfoScreen.viewScreen == InfoScreen.Screens.ROUTE_INFO end,
 		onClick = function(self)
 			if not self:isVisible() then return end
@@ -786,9 +799,9 @@ function InfoScreen.drawRouteInfoScreen(mapId, encounterArea)
 	gui.defaultTextBackground(Theme.COLORS["Lower box background"])
 	local encounterHeaderText = Constants.Words.POKEMON .. " seen by " .. encounterArea
 	if encounterArea == RouteData.EncounterArea.STATIC then
-		encounterHeaderText = encounterHeaderText .. " encounters"
+		encounterHeaderText = encounterArea .. " " .. Constants.Words.POKEMON .. " encounters"
 	end
-	Drawing.drawText(boxX - 1, botBoxY - 11, encounterHeaderText, Theme.COLORS["Header text"], bgHeaderShadow)
+	Drawing.drawText(boxX + 10, botBoxY - 11, encounterHeaderText, Theme.COLORS["Header text"], bgHeaderShadow)
 	gui.drawRectangle(boxX, botBoxY, boxWidth, botBoxHeight, Theme.COLORS["Lower box border"], Theme.COLORS["Lower box background"])
 
 	if not InfoScreen.Buttons.showOriginalRoute.toggleState then
@@ -816,6 +829,7 @@ function InfoScreen.drawRouteInfoScreen(mapId, encounterArea)
 
 	-- Draw all buttons
 	Drawing.drawButton(InfoScreen.Buttons.lookupRoute, boxTopShadow)
-	Drawing.drawButton(InfoScreen.Buttons.showMoreRouteEncounters, boxBotShadow)
+	Drawing.drawButton(InfoScreen.Buttons.nextRoute, bgHeaderShadow)
+	Drawing.drawButton(InfoScreen.Buttons.previousRoute, bgHeaderShadow)
 	Drawing.drawButton(InfoScreen.Buttons.close, boxBotShadow)
 end


### PR DESCRIPTION
Alternative solution for #182, replaces the MORE button with a back and forward button to cycle through encounter tables.

The original issue was to hide the MORE button when there are no other encounter tables, due to it being potentially confusing. I feel like back/forward buttons are clear enough to not have to hide them for no other encounter tables / the header text would look out of place on its own without them but I'd be happy to go back and rework this a little to also hide them when no other encounter tables are there if that is desired

I had to change the header text for static encounters to "Static Pokémon encounters" to make it fit.

Demo:
![RouteInfoButtons](https://user-images.githubusercontent.com/106463662/184645734-76b021a4-3b88-4fd4-b7fd-2b6897733203.gif)

