### PR TITLE
Separating Battle logic from Program.lua

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -33,6 +33,7 @@ function Main.Initialize()
 		"/Input.lua",
 		"/Drawing.lua",
 		"/Program.lua",
+		"/Battle.lua",
 		"/Pickle.lua",
 		"/Tracker.lua",
 	}
@@ -165,7 +166,7 @@ function Main.Run()
 		event.onexit(Program.HandleExit, "HandleExit")
 
 		while Main.loadNextSeed == false do
-			Program.main()
+			Program.mainLoop()
 			emu.frameadvance()
 		end
 

--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -1,0 +1,409 @@
+Battle = {
+	inBattle = false,
+	isWildEncounter = false,
+	enemyTransformed = false, -- TODO: Handle both enemy battlers
+
+	-- "Low accuracy" values
+	battleMsg = 0,
+	battler = 0, -- 0 or 2 if player, 1 or 3 if enemy
+	battlerTarget = 0,
+
+	-- "High accuracy" values
+	attacker = 0, -- 0 or 2 if player, 1 or 3 if enemy
+	turnCount = -1,
+	prevDamageTotal = 0,
+	damageReceived = 0,
+	lastEnemyMoveId = 0,
+	enemyHasAttacked = false,
+	
+	-- "Low accuracy" values
+	Synchronize = {
+		turnCount = 0,
+		battler = -1,
+		attacker = -1,
+		battlerTarget = -1,
+	},
+	-- "Low accuracy" values
+	CurrentRoute = {
+		mapId = 0,
+		encounterArea = RouteData.EncounterArea.LAND,
+		hasInfo = false,
+	},
+}
+
+function Battle.update()
+	if Program.Frames.lowAccuracyUpdate == 0 and not Program.inCatchingTutorial then
+		Battle.updateBattleStatus()
+	end
+
+	if not Battle.inBattle then return end
+
+	if Program.Frames.highAccuracyUpdate == 0 then
+		Battle.updateHighAccuracy()
+	end
+	if Program.Frames.lowAccuracyUpdate == 0 then
+		Battle.updateLowAccuracy()
+	end
+end
+
+-- Check if we can enter battle (opposingPokemon check required for lab fight), or if a battle has just finished
+function Battle.updateBattleStatus()
+	-- BattleStatus [0 = In battle, 1 = Won the match, 2 = Lost the match, 4 = Fled, 7 = Caught]
+	local lastBattleStatus = Memory.readbyte(GameSettings.gBattleOutcome)
+	local opposingPokemon = Tracker.getPokemon(1, false) -- get the lead pokemon on the enemy team
+
+	if not Battle.inBattle and lastBattleStatus == 0 and opposingPokemon ~= nil then
+		Battle.isWildEncounter = Tracker.Data.trainerID == opposingPokemon.trainerID -- testing this shorter version
+		-- Battle.isWildEncounter = Tracker.Data.trainerID ~= nil and Tracker.Data.trainerID ~= 0 and Tracker.Data.trainerID == opposingPokemon.trainerID
+		Battle.beginNewBattle()
+	elseif Battle.inBattle and lastBattleStatus ~= 0 then
+		Battle.endCurrentBattle()
+	end
+end
+
+-- Updates once every [10] frames. Be careful adding too many things to this 10 frame update
+function Battle.updateHighAccuracy()
+	Battle.processBattleTurn()
+end
+
+-- Updates once every [30] frames.
+function Battle.updateLowAccuracy()
+	local viewingWhichPokemon = Tracker.Data.otherViewSlot
+
+	Program.updateViewSlots()
+	Battle.updateTrackedInfo()
+
+	if viewingWhichPokemon ~= Tracker.Data.otherViewSlot then
+		Battle.changeOpposingPokemonView()
+	end
+end
+
+function Battle.processBattleTurn()
+	-- attackerValue = 0 or 2 for player mons and 1 or 3 for enemy mons (2,3 are doubles partners)
+	Battle.attacker = Memory.readbyte(GameSettings.gBattlerAttacker)
+
+	local currentTurn = Memory.readbyte(GameSettings.gBattleResults + 0x13)
+	local currDamageTotal = Memory.readword(GameSettings.gTakenDmg)
+
+	-- As a new turn starts, note the previous amount of total damage
+	if currentTurn ~= Battle.turnCount then
+		Battle.turnCount = currentTurn
+		Battle.prevDamageTotal = currDamageTotal
+		Battle.enemyHasAttacked = false
+	end
+
+	local damageDelta = currDamageTotal - Battle.prevDamageTotal
+	if damageDelta ~= 0 then
+		-- Check current and previous attackers to see if enemy attacked within the last 30 frames
+		if Battle.attacker % 2 ~= 0 then
+			local enemyMoveId = Memory.readword(GameSettings.gBattleResults + 0x24)
+			if enemyMoveId ~= 0 then
+				-- If a new move is being used, reset the damage from the last move
+				if not Battle.enemyHasAttacked then
+					Battle.damageReceived = 0
+					Battle.enemyHasAttacked = true
+				end
+
+				Battle.lastEnemyMoveId = enemyMoveId
+				Battle.damageReceived = Battle.damageReceived + damageDelta
+				Battle.prevDamageTotal = currDamageTotal
+			end
+		else
+			Battle.prevDamageTotal = currDamageTotal
+		end
+	end
+end
+
+function Battle.updateTrackedInfo()
+	-- Required delay between reading Pokemon data from battle, as it takes ~N frames for old battle values to be cleared out
+	if Program.Frames.battleDataDelay > 0 then
+		Program.Frames.battleDataDelay = Program.Frames.battleDataDelay - 30 -- 30 for low accuracy updates
+		return
+	end
+
+	local ownersPokemon = Tracker.getPokemon(Tracker.Data.ownViewSlot, true)
+	local opposingPokemon = Tracker.getPokemon(Tracker.Data.otherViewSlot, false)
+
+	if ownersPokemon == nil or opposingPokemon == nil then -- unsure if this is ever true at this point
+		return
+	end
+
+	-- Update useful battle values, will expand/rework this later
+	Program.readBattleValues()
+
+	local ownersAbilityId = PokemonData.getAbilityId(ownersPokemon.pokemonID, ownersPokemon.abilityNum)
+	local opposingAbilityId = PokemonData.getAbilityId(opposingPokemon.pokemonID, opposingPokemon.abilityNum)
+
+	-- Always track your own Pokemon's ability once you decide to use it
+	Tracker.TrackAbility(ownersPokemon.pokemonID, ownersAbilityId)
+
+	Battle.updateStatStages(ownersPokemon, true)
+	Battle.updateStatStages(opposingPokemon, false)
+	Battle.checkEnemyEncounter(opposingPokemon)
+	Battle.checkEnemyMovesUsed(opposingPokemon)
+
+	-- Auto-track opponent abilities if they go off
+	if Battle.checkEnemyAbilityUsed(opposingAbilityId, ownersAbilityId) then
+		Tracker.TrackAbility(opposingPokemon.pokemonID, opposingAbilityId)
+	end
+end
+
+function Battle.updateStatStages(pokemon, isOwn)
+	local startAddress = GameSettings.gBattleMons + Utils.inlineIf(isOwn, 0x0, 0x58)
+	local hp_atk_def_speed = Memory.readdword(startAddress + 0x18)
+	local spatk_spdef_acc_evasion = Memory.readdword(startAddress + 0x1C)
+
+	pokemon.statStages.hp = Utils.getbits(hp_atk_def_speed, 0, 8)
+	if pokemon.statStages.hp ~= 0 then
+		pokemon.statStages = {
+			hp = pokemon.statStages.hp,
+			atk = Utils.getbits(hp_atk_def_speed, 8, 8),
+			def = Utils.getbits(hp_atk_def_speed, 16, 8),
+			spa = Utils.getbits(spatk_spdef_acc_evasion, 0, 8),
+			spd = Utils.getbits(spatk_spdef_acc_evasion, 8, 8),
+			spe = Utils.getbits(hp_atk_def_speed, 24, 8),
+			acc = Utils.getbits(spatk_spdef_acc_evasion, 16, 8),
+			eva = Utils.getbits(spatk_spdef_acc_evasion, 24, 8),
+		}
+	else
+		-- Unsure if this reset is necessary, or what the if condition is checking for
+		pokemon.statStages = { hp = 6, atk = 6, def = 6, spa = 6, spd = 6, spe = 6, acc = 6, eva = 6 }
+	end
+end
+
+-- If the pokemon doesn't belong to the player, and hasn't been encountered yet, increment
+function Battle.checkEnemyEncounter(opposingPokemon)
+	if opposingPokemon.hasBeenEncountered then return end
+
+	opposingPokemon.hasBeenEncountered = true
+	Tracker.TrackEncounter(opposingPokemon.pokemonID, Battle.isWildEncounter)
+
+	local battleTerrain = Memory.readword(GameSettings.gBattleTerrain)
+	local battleFlags = Memory.readdword(GameSettings.gBattleTypeFlags)
+
+	Battle.CurrentRoute.mapId = Memory.readword(GameSettings.gMapHeader + 0x12) -- 0x12: mapLayoutId
+	Battle.CurrentRoute.encounterArea = RouteData.getEncounterAreaByTerrain(battleTerrain, battleFlags)
+
+	-- Check if fishing encounter, if so then get the rod that was used
+	local gameStat_FishingCaptures = Utils.getGameStat(Constants.GAME_STATS.FISHING_CAPTURES)
+	if gameStat_FishingCaptures ~= Tracker.Data.gameStatsFishing then
+		Tracker.Data.gameStatsFishing = gameStat_FishingCaptures
+
+		local fishingRod = Memory.readword(GameSettings.gSpecialVar_ItemId)
+		if RouteData.Rods[fishingRod] ~= nil then
+			Battle.CurrentRoute.encounterArea = RouteData.Rods[fishingRod]
+		end
+	end
+
+	Battle.CurrentRoute.hasInfo = RouteData.hasRouteEncounterArea(Battle.CurrentRoute.mapId, Battle.CurrentRoute.encounterArea)
+
+	if Battle.isWildEncounter and Battle.CurrentRoute.hasInfo then
+		Tracker.TrackRouteEncounter(Battle.CurrentRoute.mapId, Battle.CurrentRoute.encounterArea, opposingPokemon.pokemonID)
+	end
+end
+
+-- Check if the opposing Pokemon used a move (it's missing pp from max), and if so track it
+function Battle.checkEnemyMovesUsed(opposingPokemon)
+	if Battle.enemyTransformed then return end
+
+	for _, move in pairs(opposingPokemon.moves) do
+		if MoveData.isValidMove(move.id) then
+			local moveUsed = false
+
+			-- Manually track Focus Punch, since PP isn't deducted if the mon charges the move but then dies
+			if move.id == 264 and Battle.enemyHasAttacked and Battle.battleMsg ~= 0 and Battle.battleMsg == GameSettings.BattleScript_FocusPunchSetUp then
+				moveUsed = true
+			elseif move.pp < tonumber(MoveData.Moves[move.id].pp) then
+				moveUsed = true
+			end
+
+			if moveUsed then
+				Tracker.TrackMove(opposingPokemon.pokemonID, move.id, opposingPokemon.level)
+
+				if move.id == 144 then -- 144 = Transform
+					Battle.enemyTransformed = true
+				end
+			end
+		end
+	end
+end
+
+-- Checks if ability should be auto-tracked. Returns true if so; false otherwise
+function Battle.checkEnemyAbilityUsed(enemyAbility, playerAbility)
+	if Battle.Synchronize.turnCount < Battle.turnCount then
+		Battle.Synchronize.turnCount = Battle.turnCount
+		Battle.Synchronize.battler = -1
+		Battle.Synchronize.attacker = -1
+		Battle.Synchronize.battlerTarget = -1
+	end
+
+	--Levitate doesn't get a message, so it gets checked independently
+	if enemyAbility == 26 and Battle.attacker % 2 == 0 then
+		local levitateCheck = Memory.readbyte(GameSettings.gBattleCommunication + 0x6)
+		if levitateCheck == 4 then
+		-- Requires checking gBattleCommunication for the B_MSG_GROUND_MISS flag (4)
+			return true
+		end
+	end
+	
+	-- Abilities to check via battler read
+	local battlerMsg = GameSettings.ABILITIES.BATTLER[Battle.battleMsg]
+
+	if battlerMsg ~= nil then
+		if battlerMsg[playerAbility] and playerAbility == 36 and Battle.battler % 2 == 0 then -- 36 = Trace
+			-- Track the enemy's ability if the player's Pokemon uses its Trace ability
+			return true
+		elseif battlerMsg[enemyAbility] then
+			if enemyAbility == 28 then -- 28 = Synchronize
+				-- Enemy is using Synchronize on the player, battler is set to status target instead
+				if Battle.battler % 2 == 0 then return true end
+			elseif Battle.battler % 2 == 1 then
+				-- Enemy is the one that used the ability
+				return true
+			end
+		end
+	end
+
+	-- Abilities to check for when ally is the battler
+	local reverseBattlerMsg = GameSettings.ABILITIES.REVERSE_BATTLER[Battle.battleMsg]
+
+	if reverseBattlerMsg ~= nil then
+		if reverseBattlerMsg[enemyAbility] and Battle.battler % 2 == 0 then
+			return true
+		end
+	end
+
+	-- Abilities to check via attacker read
+	local attackerMsg = GameSettings.ABILITIES.ATTACKER[Battle.battleMsg]
+	local reverseAttackerMsg = GameSettings.ABILITIES.REVERSE_ATTACKER[Battle.battleMsg]
+
+	if attackerMsg ~= nil and attackerMsg[enemyAbility] and Battle.attacker % 2 == 0 then
+		if Battle.battlerTarget % 2 == 1 then
+			-- Otherwise, player activated enemy's ability
+			return true
+		end
+	end
+	if reverseAttackerMsg ~= nil and reverseAttackerMsg[enemyAbility] and Battle.attacker % 2 == 1 then
+		--Owner of the ability is logged as the attacker
+		return true
+	end
+
+	-- Contact-based status-inflicting abilities
+	local statusInflictMsg = GameSettings.ABILITIES.STATUS_INFLICT[Battle.battleMsg]
+
+	if statusInflictMsg ~= nil then
+		-- Log allied pokemon contact status ability trigger for Synchronize
+		if statusInflictMsg[enemyAbility] then
+			if Battle.battler % 2 == 1 then
+				if (Battle.battlerTarget % 2 == 1 and Battle.attacker % 2 == 0) or (Battle.Synchronize.attacker == Battle.attacker and Battle.Synchronize.battlerTarget == Battle.battlerTarget and Battle.Synchronize.battler ~= Battle.battler) then
+					-- Player activated enemy's contact-based status ability
+					return true
+				end
+			end
+		end
+		if statusInflictMsg[playerAbility] and Battle.attacker % 2 == 1 then
+			Battle.Synchronize.turnCount = Battle.turnCount
+			Battle.Synchronize.battler = Battle.battler
+			Battle.Synchronize.attacker = Battle.attacker
+			Battle.Synchronize.battlerTarget = Battle.battlerTarget
+		end
+	end
+
+	-- Abilities not covered by the above checks
+	local battleTargetMsg = GameSettings.ABILITIES.BATTLE_TARGET[Battle.battleMsg]
+
+	if battleTargetMsg ~= nil and battleTargetMsg[enemyAbility] then
+		if Battle.battlerTarget % 2 == 1 then
+			if battleTargetMsg.scope == "both" and enemyAbility ~= playerAbility then
+				-- Allied prevention ability takes priority over enemy, so if we both have it, ignore theirs
+				return true
+			elseif battleTargetMsg.scope == "self" then
+				return true
+			end
+		elseif Battle.battlerTarget % 2 == 0 and battleTargetMsg.scope == "other" then
+			-- Leech seed sets gBattlerTarget to mon receiving hp, so this is where we see liquid ooze
+			return true
+		end
+	end
+
+	return false
+end
+
+function Battle.beginNewBattle()
+	if Battle.inBattle then return end
+
+	Program.Frames.battleDataDelay = 60
+
+	-- If this is a new battle, reset views and other pokemon tracker info
+	Battle.inBattle = true
+	Battle.turnCount = 0
+	Battle.Synchronize.turnCount = 0
+	Battle.Synchronize.attacker = -1
+	Battle.Synchronize.battlerTarget = -1	
+
+	Tracker.Data.isViewingOwn = not Options["Auto swap to enemy"]
+	Tracker.Data.ownViewSlot = 1
+	Tracker.Data.otherViewSlot = 1
+	Input.resetControllerIndex()
+
+	-- Handles a common case of looking up a move, then entering combat. As a battle begins, the move info screen should go away.
+	if Program.currentScreen == Program.Screens.INFO then
+		InfoScreen.clearScreenData()
+		Program.currentScreen = Program.Screens.TRACKER
+	end
+
+	 -- Delay drawing the new pokemon (or effectiveness of your own), because of send out animation
+	Program.Frames.waitToDraw = Utils.inlineIf(Battle.isWildEncounter, 150, 250)
+end
+
+function Battle.endCurrentBattle()
+	if not Battle.inBattle then return end
+
+	Battle.inBattle = false
+	Battle.turnCount = -1
+	Battle.lastEnemyMoveId = 0
+	Battle.Synchronize.turnCount = 0
+	Battle.Synchronize.attacker = -1
+	Battle.Synchronize.battlerTarget = -1
+
+	Battle.CurrentRoute.hasInfo = false
+	Battle.enemyTransformed = false
+
+	Tracker.Data.isViewingOwn = true
+	Tracker.Data.ownViewSlot = 1
+	Tracker.Data.otherViewSlot = 1
+	-- While the below clears our currently stored enemy pokemon data, most gets read back in from memory anyway
+	Tracker.Data.otherPokemon = {}
+	Tracker.Data.otherTeam = { 0, 0, 0, 0, 0, 0 }
+
+	-- Reset stat stage changes for the owner's pokemon team
+	for i=1, 6, 1 do
+		local pokemon = Tracker.getPokemon(i, true)
+		if pokemon ~= nil then
+			pokemon.statStages = { hp = 6, atk = 6, def = 6, spa = 6, spd = 6, spe = 6, acc = 6, eva = 6 }
+		end
+	end
+
+	-- Handles a common case of looking up a move, then moving on with the current battle. As the battle ends, the move info screen should go away.
+	if Program.currentScreen == Program.Screens.INFO then
+		InfoScreen.clearScreenData()
+		Program.currentScreen = Program.Screens.TRACKER
+	end
+
+	-- Delay drawing the return to viewing your pokemon screen
+	Program.Frames.waitToDraw = Utils.inlineIf(Battle.isWildEncounter, 70, 150)
+	Program.Frames.saveData = Utils.inlineIf(Battle.isWildEncounter, 70, 150) -- Save data after every battle
+end
+
+function Battle.changeOpposingPokemonView()
+	Battle.enemyTransformed = false
+
+	if Options["Auto swap to enemy"] then
+		Tracker.Data.isViewingOwn = false
+	end
+
+	Input.resetControllerIndex()
+
+	-- Delay drawing the new pokemon, because of send out animation
+	Program.Frames.waitToDraw = 0
+end

--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -207,7 +207,7 @@ function Battle.checkEnemyMovesUsed(opposingPokemon)
 	if Battle.enemyTransformed then return end
 
 	for _, move in pairs(opposingPokemon.moves) do
-		if MoveData.isValidMove(move.id) then
+		if MoveData.isValid(move.id) then
 			local moveUsed = false
 
 			-- Manually track Focus Punch, since PP isn't deducted if the mon charges the move but then dies

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -31,7 +31,7 @@ end
 
 function Drawing.drawPokemonIcon(id, x, y)
 	id = id or 0
-	if id < 0 or id > #PokemonData.Pokemon then
+	if id < 0 or id > PokemonData.totalPokemon then
 		id = 0 -- Blank Pokemon data/icon
 	end
 

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -29,14 +29,13 @@ function Drawing.drawBackgroundAndMargins(x, y, width, height)
 	gui.drawRectangle(x, y, width, height, Theme.COLORS["Main background"], Theme.COLORS["Main background"])
 end
 
-function Drawing.drawPokemonIcon(id, x, y)
-	id = id or 0
-	if id < 0 or id > PokemonData.totalPokemon then
-		id = 0 -- Blank Pokemon data/icon
+function Drawing.drawPokemonIcon(pokemonID, x, y)
+	if not PokemonData.isValid(pokemonID) then
+		pokemonID = 0 -- Blank Pokemon data/icon
 	end
 
 	local iconset = Options.IconSetMap[Options["Pokemon icon set"]]
-	local imagepath = Main.DataFolder .. "/images/" .. iconset.folder .. "/" .. id .. iconset.extension
+	local imagepath = Main.DataFolder .. "/images/" .. iconset.folder .. "/" .. pokemonID .. iconset.extension
 
 	if iconset.name == "Stadium" then
 		y = y + 4

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -33,7 +33,7 @@ end
 function Input.checkJoypadInput(joypadButtons)
 	-- "Options.CONTROLS["Toggle view"]" pressed
 	if joypadButtons[Options.CONTROLS["Toggle view"]] and Input.prevJoypadInput[Options.CONTROLS["Toggle view"]] ~= joypadButtons[Options.CONTROLS["Toggle view"]] then
-		if Tracker.Data.inBattle then
+		if Battle.inBattle then
 			Tracker.Data.isViewingOwn = not Tracker.Data.isViewingOwn
 		end
 		Program.redraw(true)

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -414,7 +414,7 @@ function Program.validPokemonData(pokemonData)
 	if pokemonData == nil then return false end
 
 	-- If the Pokemon exists, but it's ID is invalid
-	if pokemonData.pokemonID ~= nil and (pokemonData.pokemonID < 0 or pokemonData.pokemonID > PokemonData.totalPokemon) then
+	if not PokemonData.isValid(pokemonData.pokemonID) and pokemonData.pokemonID ~= 0 then -- 0 = blank pokemon id
 		return false
 	end
 
@@ -425,7 +425,7 @@ function Program.validPokemonData(pokemonData)
 
 	-- For each of the Pokemon's moves that isn't blank, is that move real
 	for _, move in pairs(pokemonData.moves) do
-		if move.id < 0 or move.id > MoveData.totalMoves then -- 0 = blank move id
+		if not MoveData.isValid(move.id) and move.id ~= 0 then -- 0 = blank move id
 			return false
 		end
 	end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -2,36 +2,17 @@ Program = {
 	currentScreen = 1,
 	inCatchingTutorial = false,
 	hasCompletedTutorial = false,
-	isTransformed = false,
 	friendshipRequired = 220,
 	activeFormId = 0,
 	Frames = {
-		waitToDraw = 0,
-		battleDataDelay = 0,
-		half_sec_update = 30,
-		three_sec_update = 180,
-		saveData = 3600,
-		carouselActive = 0,
+		waitToDraw = 30, -- counts down
+		highAccuracyUpdate = 10, -- counts down
+		lowAccuracyUpdate = 30, -- counts down
+		three_sec_update = 180, -- counts down
+		saveData = 3600, -- counts down
+		carouselActive = 0, -- counts up
+		battleDataDelay = 60, -- counts down
 	},
-	BattleTurn = {
-		turnCount = -1,
-		prevDamageTotal = 0,
-		damageReceived = 0,
-		lastMoveId = 0,
-		attackerValue = 0, -- used to more accurately tracker the current attack (check every 10 frames)
-		enemyIsAttacking = false,
-	},
-	CurrentRoute = {
-		mapId = 0,
-		encounterArea = RouteData.EncounterArea.LAND,
-		hasInfo = false,
-	},
-	SyncData = {
-		turnCount = 0,
-		battler = -1,
-		attacker = -1,
-		battlerTarget = -1,
-	}
 }
 
 Program.Screens = {
@@ -53,6 +34,12 @@ function Program.initialize()
 		Program.friendshipRequired = friendshipRequired
 	end
 
+	-- Update data asap
+	Program.Frames.highAccuracyUpdate = 1
+	Program.Frames.lowAccuracyUpdate = 1
+	Program.Frames.three_sec_update = 1
+	Program.Frames.waitToDraw = 1
+
 	PokemonData.readDataFromMemory()
 	MoveData.readDataFromMemory()
 
@@ -63,22 +50,18 @@ function Program.initialize()
 	-- RouteData.readWildPokemonInfoFromMemory()
 end
 
-function Program.main()
+function Program.mainLoop()
 	Input.checkForInput()
-
-	Program.updateTrackedAndCurrentData()
-
-	Program.redraw()
+	Program.update()
+	Battle.update()
+	Program.redraw(false)
+	Program.stepFrames() -- TODO: Really want a better way to handle this
 end
 
 -- 'forced' = true will force a draw, skipping the normal frame wait time
 function Program.redraw(forced)
-	if forced then
-		Program.Frames.waitToDraw = 0
-	end
-
 	-- Only redraw the screen every half second (60 frames/sec)
-	if Program.Frames.waitToDraw > 0 then
+	if not forced and Program.Frames.waitToDraw > 0 then
 		Program.Frames.waitToDraw = Program.Frames.waitToDraw - 1
 		return
 	end
@@ -100,11 +83,9 @@ function Program.destroyActiveForm()
 	end
 end
 
-function Program.updateTrackedAndCurrentData()
+function Program.update()
 	-- Be careful adding too many things to this 10 frame update
-	if Program.Frames.half_sec_update % 10 == 0 then
-		Program.processBattleTurnFromMemory()
-
+	if Program.Frames.highAccuracyUpdate == 0 then
 		-- If the lead Pokemon changes, then update the animated Pokemon picture box
 		if Options["Animated Pokemon popout"] then
 			local leadPokemon = Tracker.getPokemon(Tracker.Data.ownViewSlot, true)
@@ -119,72 +100,46 @@ function Program.updateTrackedAndCurrentData()
 	end
 
 	-- Get any "new" information from game memory for player's pokemon team every half second (60 frames/sec)
-	if Program.Frames.half_sec_update == 0 then
-		Program.Frames.half_sec_update = 30
-
+	if Program.Frames.lowAccuracyUpdate == 0 then
 		local viewingWhichPokemon = Tracker.Data.otherViewSlot
 
 		Program.inCatchingTutorial = Program.isInCatchingTutorial()
+		if not Program.inCatchingTutorial then
+			Program.updatePokemonTeams()
 
-		if not Program.inCatchingTutorial then -- Don't update/track data while in the catching tutorial
-			Program.updatePokemonTeamsFromMemory()
-			Program.updateBattleDataFromMemory() -- This will only read memory data if in battle.
-
-			-- Check for if summary screen is being shown
+			-- Check if summary screen has being shown
 			if not Tracker.Data.hasCheckedSummary then
-				local summaryCheck = Memory.readbyte(GameSettings.sMonSummaryScreen)
-				if summaryCheck ~= 0 then
+				if Memory.readbyte(GameSettings.sMonSummaryScreen) ~= 0 then
 					Tracker.Data.hasCheckedSummary = true
 				end
 			end
-		end
-
-		-- Use this to check if the opposing Pokemon changes
-		if Tracker.Data.inBattle and viewingWhichPokemon ~= Tracker.Data.otherViewSlot then
-			-- Reset the transform tracking disable
-			if Program.isTransformed then
-				Program.isTransformed = false
-			end
-
-			if Options["Auto swap to enemy"] then
-				Tracker.Data.isViewingOwn = false
-			end
-
-			Input.resetControllerIndex()
-
-			-- Delay drawing the new pokemon, because of send out animation
-			Program.Frames.waitToDraw = 0
 		end
 	end
 
 	-- Only update "Heals in Bag", "PC Heals", and "Badge Data" info every 3 seconds (3 seconds * 60 frames/sec)
 	if Program.Frames.three_sec_update == 0 then
-		Program.Frames.three_sec_update = 180
-
-		Program.updateBagHealingItemsFromMemory()
-		Program.updatePCHealsFromMemory()
-		Program.updateBadgesObtainedFromMemory()
+		Program.updateBagHealingItems()
+		Program.updatePCHeals()
+		Program.updateBadgesObtained()
 	end
 
 	-- Only save tracker data every 1 minute (60 seconds * 60 frames/sec) and after every battle (set elsewhere)
 	if Program.Frames.saveData == 0 then
-		Program.Frames.saveData = 3600
 		if Options["Auto save tracked game data"] then
 			Tracker.saveData()
 		end
 	end
+end
 
-	Program.Frames.half_sec_update = Program.Frames.half_sec_update - 1
-	Program.Frames.three_sec_update = Program.Frames.three_sec_update - 1
-	Program.Frames.saveData = Program.Frames.saveData - 1
+function Program.stepFrames()
+	Program.Frames.highAccuracyUpdate = (Program.Frames.highAccuracyUpdate - 1) % 10
+	Program.Frames.lowAccuracyUpdate = (Program.Frames.lowAccuracyUpdate - 1) % 30
+	Program.Frames.three_sec_update = (Program.Frames.three_sec_update - 1) % 180
+	Program.Frames.saveData = (Program.Frames.saveData - 1) % 3600
 	Program.Frames.carouselActive = Program.Frames.carouselActive + 1
 end
 
-function Program.updatePokemonTeamsFromMemory()
-	-- [0 = In battle, 1 = Won the match, 2 = Lost the match, 4 = Fled, 7 = Caught]
-	local lastBattleStatus = Memory.readbyte(GameSettings.gBattleOutcome)
-	local isOpposingPokemonWild = false
-
+function Program.updatePokemonTeams()
 	-- Check for updates to each pokemon team
 	local addressOffset = 0
 	for i = 1, 6, 1 do
@@ -193,7 +148,7 @@ function Program.updatePokemonTeamsFromMemory()
 		Tracker.Data.ownTeam[i] = personality
 
 		if personality ~= 0 then
-			local newPokemonData = Program.readNewPokemonFromMemory(GameSettings.pstats + addressOffset, personality)
+			local newPokemonData = Program.readNewPokemon(GameSettings.pstats + addressOffset, personality)
 
 			if Program.validPokemonData(newPokemonData) then
 				-- Sets the player's trainerID as soon as they get their first Pokemon
@@ -212,15 +167,11 @@ function Program.updatePokemonTeamsFromMemory()
 		Tracker.Data.otherTeam[i] = personality
 
 		if personality ~= 0 then
-			local newPokemonData = Program.readNewPokemonFromMemory(GameSettings.estats + addressOffset, personality)
+			local newPokemonData = Program.readNewPokemon(GameSettings.estats + addressOffset, personality)
 
 			if Program.validPokemonData(newPokemonData) then
-				if Tracker.Data.trainerID ~= nil and Tracker.Data.trainerID ~= 0 then
-					isOpposingPokemonWild = Tracker.Data.trainerID == newPokemonData.trainerID
-				end
-
 				-- Double-check a race condition where current PP values are wildly out of range if retrieved right before a battle begins
-				if not Tracker.Data.inBattle then
+				if not Battle.inBattle then
 					for _, move in pairs(newPokemonData.moves) do
 						if move.id ~= 0 then
 							move.pp = tonumber(MoveData.Moves[move.id].pp) -- set value to max PP
@@ -232,19 +183,12 @@ function Program.updatePokemonTeamsFromMemory()
 			end
 		end
 
+		-- Next Pokemon - Each is offset by 100 bytes
 		addressOffset = addressOffset + 100
-	end
-
-	-- Check if we can enter battle (opposingPokemon check required for lab fight), or if a battle has just finished
-	local opposingPokemon = Tracker.getPokemon(1, false)
-	if not Tracker.Data.inBattle and lastBattleStatus == 0 and opposingPokemon ~= nil then
-		Program.beginNewBattle(isOpposingPokemonWild)
-	elseif Tracker.Data.inBattle and lastBattleStatus ~= 0 then
-		Program.endBattle(isOpposingPokemonWild)
 	end
 end
 
-function Program.readNewPokemonFromMemory(startAddress, personality)
+function Program.readNewPokemon(startAddress, personality)
 	local otid = Memory.readdword(startAddress + 4)
 	local magicword = bit.bxor(personality, otid) -- The XOR encryption key for viewing the Pokemon data
 
@@ -348,235 +292,21 @@ function Program.readNewPokemonFromMemory(startAddress, personality)
 	return pokemonData
 end
 
--- Updates viewslots for display, increment encounter count, update abilities if they don't exist already, as well as any stat stage changes
-function Program.updateBattleDataFromMemory()
-	if not Tracker.Data.inBattle then return end
-
-	Program.updateViewSlotsFromMemory()
-
-	-- Required delay between reading Pokemon data from battle, as it takes ~N frames for old battle values to be cleared out
-	if Program.Frames.battleDataDelay > 0 then
-		Program.Frames.battleDataDelay = Program.Frames.battleDataDelay - 30
-		return
-	end
-
-	local ownersPokemon = Tracker.getPokemon(Tracker.Data.ownViewSlot, true)
-	local opposingPokemon = Tracker.getPokemon(Tracker.Data.otherViewSlot, false)
-
-	if ownersPokemon ~= nil and opposingPokemon ~= nil then
-		Program.updateStatStagesDataFromMemory(ownersPokemon, true)
-		Program.updateStatStagesDataFromMemory(opposingPokemon, false)
-
-		local ownersAbilityId = PokemonData.getAbilityId(ownersPokemon.pokemonID, ownersPokemon.abilityNum)
-		local opposingAbilityId = PokemonData.getAbilityId(opposingPokemon.pokemonID, opposingPokemon.abilityNum)
-
-		-- Always track your own Pokemon's ability once you decide to use it
-		Tracker.TrackAbility(ownersPokemon.pokemonID, ownersAbilityId)
-
-		-- ENCOUNTERS: If the pokemon doesn't belong to the player, and hasn't been encountered yet, increment
-		if opposingPokemon.hasBeenEncountered == nil or not opposingPokemon.hasBeenEncountered then
-			opposingPokemon.hasBeenEncountered = true
-
-			local isWild = Tracker.Data.trainerID == opposingPokemon.trainerID -- equal IDs = wild pokemon, nonequal = trainer
-			Tracker.TrackEncounter(opposingPokemon.pokemonID, isWild)
-
-			local battleTerrain = Memory.readword(GameSettings.gBattleTerrain)
-			local battleFlags = Memory.readdword(GameSettings.gBattleTypeFlags)
-
-			Program.CurrentRoute.mapId = Memory.readword(GameSettings.gMapHeader + 0x12) -- 0x12: mapLayoutId
-			Program.CurrentRoute.encounterArea = RouteData.getEncounterAreaByTerrain(battleTerrain, battleFlags)
-
-			-- Check if fishing encounter, if so then get the rod that was used
-			local gameStat_FishingCaptures = Utils.getGameStat(Constants.GAME_STATS.FISHING_CAPTURES)
-			if gameStat_FishingCaptures ~= Tracker.Data.gameStatsFishing then
-				Tracker.Data.gameStatsFishing = gameStat_FishingCaptures
-
-				local fishingRod = Memory.readword(GameSettings.gSpecialVar_ItemId)
-				if RouteData.Rods[fishingRod] ~= nil then
-					Program.CurrentRoute.encounterArea = RouteData.Rods[fishingRod]
-				end
-			end
-
-			Program.CurrentRoute.hasInfo = RouteData.hasRouteEncounterArea(Program.CurrentRoute.mapId, Program.CurrentRoute.encounterArea)
-
-			if isWild and Program.CurrentRoute.hasInfo then
-				Tracker.TrackRouteEncounter(Program.CurrentRoute.mapId, Program.CurrentRoute.encounterArea, opposingPokemon.pokemonID)
-			end
-		end
-
-		local battleMsg = Memory.readdword(GameSettings.gBattlescriptCurrInstr)
-		-- Auto-track opponent abilities if they go off
-		if Program.autoTrackAbilitiesCheck(battleMsg, opposingAbilityId, ownersAbilityId) then
-			Tracker.TrackAbility(opposingPokemon.pokemonID, opposingAbilityId)
-		end
-
-		-- MOVES: Check if the opposing Pokemon used a move (it's missing pp from max), and if so track it
-		for _, move in pairs(opposingPokemon.moves) do
-			if move.id ~= 0 and move.pp < tonumber(MoveData.Moves[move.id].pp) then
-				Program.handleAttackMove(move.id, false)
-			end
-		end
-
-		if GameSettings.BattleScript_FocusPunchSetUp ~= 0x00000000 then
-			-- Manually track Focus Punch, since PP isn't deducted if the mon charges the move but then dies
-			if battleMsg == GameSettings.BattleScript_FocusPunchSetUp and Program.BattleTurn.attackerValue % 2 ~= 0 then
-				Program.handleAttackMove(264, false)
-			end
-		end
-	end
+function Program.readBattleValues()
+	Battle.battleMsg = Memory.readdword(GameSettings.gBattlescriptCurrInstr)
+	Battle.battler = Memory.readbyte(GameSettings.gBattleScriptingBattler)
+	Battle.battlerTarget = Memory.readbyte(GameSettings.gBattlerTarget)
 end
 
-function Program.processBattleTurnFromMemory()
-	if not Tracker.Data.inBattle then return end
-
-	-- attackerValue = 0 or 2 for player mons and 1 or 3 for enemy mons (2,3 are doubles partners)
-	Program.BattleTurn.attackerValue = Memory.readbyte(GameSettings.gBattlerAttacker)
-
-	local currentTurn = Memory.readbyte(GameSettings.gBattleResults + 0x13)
-	local currDamageTotal = Memory.readword(GameSettings.gTakenDmg)
-
-	-- As a new turn starts, note the previous amount of total damage
-	if currentTurn ~= Program.BattleTurn.turnCount then
-		Program.BattleTurn.turnCount = currentTurn
-		Program.BattleTurn.prevDamageTotal = currDamageTotal
-		Program.BattleTurn.enemyIsAttacking = false
-	end
-
-	local damageDelta = currDamageTotal - Program.BattleTurn.prevDamageTotal
-	if damageDelta ~= 0 then
-		-- Check current and previous attackers to see if enemy attacked within the last 30 frames
-		if Program.BattleTurn.attackerValue % 2 ~= 0 then
-			local enemyMoveId = Memory.readword(GameSettings.gBattleResults + 0x24)
-			if enemyMoveId ~= 0 then
-				-- If a new move is being used, reset the damage from the last move
-				if not Program.BattleTurn.enemyIsAttacking then
-					Program.BattleTurn.damageReceived = 0
-					Program.BattleTurn.enemyIsAttacking = true
-				end
-
-				Program.BattleTurn.lastMoveId = enemyMoveId
-				Program.BattleTurn.damageReceived = Program.BattleTurn.damageReceived + damageDelta
-				Program.BattleTurn.prevDamageTotal = currDamageTotal
-			end
-		else
-			Program.BattleTurn.prevDamageTotal = currDamageTotal
-		end
-	end
-end
-
--- Checks if ability should be auto-tracked. Returns true if so; false otherwise
-function Program.autoTrackAbilitiesCheck(battleMsg, enemyAbility, playerAbility)
-	local battler = Memory.readbyte(GameSettings.gBattleScriptingBattler) -- 0 or 2 if player, 1 or 3 if enemy
-	local attacker = Memory.readbyte(GameSettings.gBattlerAttacker) -- 0 or 2 if player, 1 or 3 if enemy
-	local battlerTarget = Memory.readbyte(GameSettings.gBattlerTarget)
-	local currentTurn = Memory.readbyte(GameSettings.gBattleResults + 0x13)
-
-	if Program.SyncData.turnCount < currentTurn then
-		Program.SyncData.turnCount = currentTurn
-		Program.SyncData.battler = -1
-		Program.SyncData.attacker = -1
-		Program.SyncData.battlerTarget = -1
-	end
-
-	--Levitate doesn't get a message, so it gets checked independently
-	if enemyAbility == 26 and attacker % 2 == 0 then
-		local levitateCheck = Memory.readbyte(GameSettings.gBattleCommunication + 0x6)
-		if levitateCheck == 4 then
-		-- Requires checking gBattleCommunication for the B_MSG_GROUND_MISS flag (4)
-			return true
-		end
-	end
-	
-	-- Abilities to check via battler read
-	local battlerMsg = GameSettings.ABILITIES.BATTLER[battleMsg]
-
-	if battlerMsg ~= nil then
-		if battlerMsg[playerAbility] and playerAbility == 36 and battler % 2 == 0 then -- 36 = Trace
-			-- Track the enemy's ability if the player's Pokemon uses its Trace ability
-			return true
-		elseif battlerMsg[enemyAbility] then
-			if enemyAbility == 28 then -- 28 = Synchronize
-				-- Enemy is using Synchronize on the player, battler is set to status target instead
-				if battler % 2 == 0 then return true end
-			elseif battler % 2 == 1 then
-				-- Enemy is the one that used the ability
-				return true
-			end
-		end
-	end
-
-	-- Abilities to check for when ally is the battler
-	local reverseBattlerMsg = GameSettings.ABILITIES.REVERSE_BATTLER[battleMsg]
-
-	if reverseBattlerMsg ~= nil then
-		if reverseBattlerMsg[enemyAbility] and battler % 2 == 0 then
-			return true
-		end
-	end
-
-	-- Abilities to check via attacker read
-	local attackerMsg = GameSettings.ABILITIES.ATTACKER[battleMsg]
-	local reverseAttackerMsg = GameSettings.ABILITIES.REVERSE_ATTACKER[battleMsg]
-
-	if attackerMsg ~= nil and attackerMsg[enemyAbility] and attacker % 2 == 0 then
-		if battlerTarget % 2 == 1 then
-			-- Otherwise, player activated enemy's ability
-			return true
-		end
-	end
-	if reverseAttackerMsg ~= nil and reverseAttackerMsg[enemyAbility] and attacker % 2 == 1 then
-		--Owner of the ability is logged as the attacker
-		return true
-	end
-
-	-- Contact-based status-inflicting abilities
-	local statusInflictMsg = GameSettings.ABILITIES.STATUS_INFLICT[battleMsg]
-
-	if statusInflictMsg ~= nil then
-		-- Log allied pokemon contact status ability trigger for Synchronize
-		if statusInflictMsg[enemyAbility] then
-			if battler % 2 == 1 then
-				if (battlerTarget % 2 == 1 and attacker % 2 == 0) or (Program.SyncData.attacker == attacker and Program.SyncData.battlerTarget == battlerTarget and Program.SyncData.battler ~= battler) then
-					-- Player activated enemy's contact-based status ability
-					return true
-				end
-			end
-		end
-		if statusInflictMsg[playerAbility] and attacker % 2 == 1 then
-			Program.SyncData.turnCount = currentTurn
-			Program.SyncData.battler = battler
-			Program.SyncData.attacker = attacker
-			Program.SyncData.battlerTarget = battlerTarget
-		end
-	end
-
-	-- Abilities not covered by the above checks
-	local battleTargetMsg = GameSettings.ABILITIES.BATTLE_TARGET[battleMsg]
-
-	if battleTargetMsg ~= nil and battleTargetMsg[enemyAbility] then
-		if battlerTarget % 2 == 1 then
-			if battleTargetMsg.scope == "both" and enemyAbility ~= playerAbility then
-				-- Allied prevention ability takes priority over enemy, so if we both have it, ignore theirs
-				return true
-			elseif battleTargetMsg.scope == "self" then
-				return true
-			end
-		elseif battlerTarget % 2 == 0 and battleTargetMsg.scope == "other" then
-			-- Leech seed sets gBattlerTarget to mon receiving hp, so this is where we see liquid ooze
-			return true
-		end
-	end
-
-	return false
-end
-
-function Program.updateViewSlotsFromMemory()
+function Program.updateViewSlots()
 	-- First update which own/other slots are being viewed
 	Tracker.Data.ownViewSlot = Memory.readbyte(GameSettings.gBattlerPartyIndexesSelfSlotOne) + 1
 	Tracker.Data.otherViewSlot = Memory.readbyte(GameSettings.gBattlerPartyIndexesEnemySlotOne) + 1
 
-	-- Secondary enemy pokemon (likely the doubles battle partner)
-	if Program.BattleTurn.attackerValue == 3 then
+	-- Secondary pokemon (likely the doubles battle partner)
+	if Battle.attacker == 2 then -- untested
+		Tracker.Data.otherViewSlot = Memory.readbyte(GameSettings.gBattlerPartyIndexesSelfSlotTwo) + 1
+	elseif Battle.attacker == 3 then
 		Tracker.Data.otherViewSlot = Memory.readbyte(GameSettings.gBattlerPartyIndexesEnemySlotTwo) + 1
 	end
 
@@ -589,105 +319,7 @@ function Program.updateViewSlotsFromMemory()
 	end
 end
 
-function Program.updateStatStagesDataFromMemory(pokemon, isOwn)
-	local startAddress = GameSettings.gBattleMons + Utils.inlineIf(isOwn, 0x0, 0x58)
-	local hp_atk_def_speed = Memory.readdword(startAddress + 0x18)
-	local spatk_spdef_acc_evasion = Memory.readdword(startAddress + 0x1C)
-
-	pokemon.statStages.hp = Utils.getbits(hp_atk_def_speed, 0, 8)
-	if pokemon.statStages.hp ~= 0 then
-		pokemon.statStages = {
-			hp = pokemon.statStages.hp,
-			atk = Utils.getbits(hp_atk_def_speed, 8, 8),
-			def = Utils.getbits(hp_atk_def_speed, 16, 8),
-			spa = Utils.getbits(spatk_spdef_acc_evasion, 0, 8),
-			spd = Utils.getbits(spatk_spdef_acc_evasion, 8, 8),
-			spe = Utils.getbits(hp_atk_def_speed, 24, 8),
-			acc = Utils.getbits(spatk_spdef_acc_evasion, 16, 8),
-			eva = Utils.getbits(spatk_spdef_acc_evasion, 24, 8),
-		}
-	else
-		-- Unsure if this reset is necessary, or what the if condition is checking for
-		pokemon.statStages = { hp = 6, atk = 6, def = 6, spa = 6, spd = 6, spe = 6, acc = 6, eva = 6 }
-	end
-end
-
--- This should be called every time the player gets into a battle (wild pokemon or trainer battle)
-function Program.beginNewBattle(isWild)
-	if Tracker.Data.inBattle then return end
-	if isWild == nil then isWild = false end
-
-	Program.Frames.battleDataDelay = 60
-
-	-- If this is a new battle, reset views and other pokemon tracker info
-	Tracker.Data.inBattle = true
-	Tracker.Data.isViewingOwn = not Options["Auto swap to enemy"]
-	Tracker.Data.ownViewSlot = 1
-	Tracker.Data.otherViewSlot = 1
-	Input.resetControllerIndex()
-
-	-- Handles a common case of looking up a move, then entering combat. As a battle begins, the move info screen should go away.
-	if Program.currentScreen == Program.Screens.INFO then
-		InfoScreen.clearScreenData()
-		Program.currentScreen = Program.Screens.TRACKER
-	end
-
-	--Reset Synchronize tracker
-	Program.SyncData.turnCount = 0
-	Program.SyncData.attacker = -1
-	Program.SyncData.battlerTarget = -1
-
-	 -- Delay drawing the new pokemon (or effectiveness of your own), because of send out animation
-	Program.Frames.waitToDraw = Utils.inlineIf(isWild, 150, 250)
-end
-
--- This should be called every time the player finishes a battle (wild pokemon or trainer battle)
-function Program.endBattle(isWild)
-	if not Tracker.Data.inBattle then return end
-	if isWild == nil then isWild = false end
-
-	Tracker.Data.inBattle = false
-	Tracker.Data.isViewingOwn = true
-	Tracker.Data.ownViewSlot = 1
-	Tracker.Data.otherViewSlot = 1
-	-- While the below clears our currently stored enemy pokemon data, most gets read back in from memory anyway
-	Tracker.Data.otherPokemon = {}
-	Tracker.Data.otherTeam = { 0, 0, 0, 0, 0, 0 }
-
-	-- Reset the transform tracking disable
-	if Program.isTransformed then
-		Program.isTransformed = false
-	end
-
-	-- Reset last attack information
-	Program.BattleTurn.turnCount = -1
-	Program.BattleTurn.lastMoveId = 0
-	Program.CurrentRoute.hasInfo = false
-	--Reset Synchronize tracker
-	Program.SyncData.turnCount = 0
-	Program.SyncData.attacker = -1
-	Program.SyncData.battlerTarget = -1
-
-	-- Reset stat stage changes for the pokemon team
-	for i=1, 6, 1 do
-		local pokemon = Tracker.getPokemon(i, true)
-		if pokemon ~= nil then
-			pokemon.statStages = { hp = 6, atk = 6, def = 6, spa = 6, spd = 6, spe = 6, acc = 6, eva = 6 }
-		end
-	end
-
-	-- Handles a common case of looking up a move, then moving on with the current battle. As the battle ends, the move info screen should go away.
-	if Program.currentScreen == Program.Screens.INFO then
-		InfoScreen.clearScreenData()
-		Program.currentScreen = Program.Screens.TRACKER
-	end
-
-	-- Delay drawing the return to viewing your pokemon screen
-	Program.Frames.waitToDraw = Utils.inlineIf(isWild, 70, 150)
-	Program.Frames.saveData = Utils.inlineIf(isWild, 70, 150) -- Save data after every battle
-end
-
-function Program.updatePCHealsFromMemory()
+function Program.updatePCHeals()
 	-- Updates PC Heal tallies and handles auto-tracking PC Heal counts when the option is on
 	-- Currently checks the total number of heals from pokecenters and from mom
 	-- Does not include whiteouts, as those don't increment either of these gamestats
@@ -715,7 +347,7 @@ function Program.updatePCHealsFromMemory()
 	end
 end
 
-function Program.updateBadgesObtainedFromMemory()
+function Program.updateBadgesObtained()
 	local badgeBits = nil
 	local saveblock1Addr = Utils.getSaveBlock1Addr()
 	if GameSettings.game == 1 then -- Ruby/Sapphire
@@ -732,26 +364,6 @@ function Program.updateBadgesObtainedFromMemory()
 			local badgeButton = TrackerScreen.Buttons[badgeName]
 			local badgeState = Utils.getbits(badgeBits, index - 1, 1)
 			badgeButton:updateState(badgeState)
-		end
-	end
-end
-
-function Program.handleAttackMove(moveId, isOwn)
-	if moveId == nil then return end
-	if isOwn == nil then isOwn = true end
-
-	-- For now, only handle moves from opposing Pokemon
-	-- Don't track moves if opponent is transformed
-	if not isOwn and not Program.isTransformed then
-		local pokemon = Tracker.getPokemon(Tracker.Data.otherViewSlot, false)
-		if pokemon ~= nil then
-			if not Tracker.isTrackingMove(pokemon.pokemonID, moveId, pokemon.level) then
-				Tracker.TrackMove(pokemon.pokemonID, moveId, pokemon.level)
-			end
-		end
-		-- This comes after the move tracking so transform itself gets tracked
-		if moveId == 144 then -- 144 = Transform
-			Program.isTransformed = true
 		end
 	end
 end
@@ -774,7 +386,7 @@ function Program.getLearnedMoveId()
 end
 
 -- Useful for dynamically getting the Pokemon's types if they have changed somehow (Color change, Transform, etc)
-function Program.getPokemonTypesFromMemory(isOwn)
+function Program.getPokemonTypes(isOwn)
 	local typesData = Memory.readword(GameSettings.gBattleMons + 0x21 + Utils.inlineIf(isOwn, 0x0, 0x58))
 	return {
 		PokemonData.TypeIndexMap[Utils.getbits(typesData, 0, 8)],
@@ -802,7 +414,7 @@ function Program.validPokemonData(pokemonData)
 	if pokemonData == nil then return false end
 
 	-- If the Pokemon exists, but it's ID is invalid
-	if pokemonData.pokemonID ~= nil and (pokemonData.pokemonID < 0 or pokemonData.pokemonID > #PokemonData.Pokemon) then
+	if pokemonData.pokemonID ~= nil and (pokemonData.pokemonID < 0 or pokemonData.pokemonID > PokemonData.totalPokemon) then
 		return false
 	end
 
@@ -813,7 +425,7 @@ function Program.validPokemonData(pokemonData)
 
 	-- For each of the Pokemon's moves that isn't blank, is that move real
 	for _, move in pairs(pokemonData.moves) do
-		if move.id < 0 or move.id > #MoveData.Moves then -- 0 = blank move id
+		if move.id < 0 or move.id > MoveData.totalMoves then -- 0 = blank move id
 			return false
 		end
 	end
@@ -821,19 +433,19 @@ function Program.validPokemonData(pokemonData)
 	return true
 end
 
-function Program.updateBagHealingItemsFromMemory()
+function Program.updateBagHealingItems()
 	if not Tracker.Data.isViewingOwn then return end
 
 	local leadPokemon = Tracker.getPokemon(Tracker.Data.ownViewSlot, true)
 	if leadPokemon ~= nil then
-		local healingItems = Program.calcBagHealingItemsFromMemory(leadPokemon.stats.hp)
+		local healingItems = Program.calcBagHealingItems(leadPokemon.stats.hp)
 		if healingItems ~= nil then
 			Tracker.Data.healingItems = healingItems
 		end
 	end
 end
 
-function Program.calcBagHealingItemsFromMemory(pokemonMaxHP)
+function Program.calcBagHealingItems(pokemonMaxHP)
 	local totals = {
 		healing = 0,
 		numHeals = 0,
@@ -845,7 +457,7 @@ function Program.calcBagHealingItemsFromMemory(pokemonMaxHP)
 	end
 
 	-- Formatted as: healingItemsInBag[itemID] = quantity
-	local healingItemsInBag = Program.getHealingItemsFromMemory()
+	local healingItemsInBag = Program.getHealingItems()
 	if healingItemsInBag == nil then
 		return totals
 	end
@@ -873,7 +485,7 @@ function Program.calcBagHealingItemsFromMemory(pokemonMaxHP)
 	return totals
 end
 
-function Program.getHealingItemsFromMemory()
+function Program.getHealingItems()
 	-- I believe this key has to be looked-up each time, as the ptr changes periodically
 	local key = Utils.getEncryptionKey(2) -- Want a 16-bit key
 

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -138,6 +138,8 @@ end
 
 -- Adds the Pokemon's move to the tracked data if it doesn't exist, otherwise updates it.
 function Tracker.TrackMove(pokemonID, moveId, level)
+	if Tracker.isTrackingMove(pokemonID, moveId, level) then return end -- rework later for better accuracy below
+
 	-- If no move data exist, set this as the first move
 	local trackedPokemon = Tracker.getOrCreateTrackedPokemon(pokemonID)
 	if trackedPokemon.moves == nil then
@@ -399,7 +401,7 @@ function Tracker.resetData()
 		ownViewSlot = 1, -- During battle, this references which of your own six pokemon [1-6] are being used
 		otherViewSlot = 1, -- During battle, this references which of the other six pokemon [1-6] are being used
 		isViewingOwn = true,
-		inBattle = false,
+		inBattle = false, -- No longer used, doubt it's safe to remove, haven't tested
 
 		hasCheckedSummary = not Options["Hide stats until summary shown"],
 		gameStatsHeals = 0, -- Tally of auto-tracked heals, separate to allow manual adjusting of centerHeals

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -329,7 +329,7 @@ function Utils.calculateHighHPBasedDamage(movePower, currentHP, maxHP)
 end
 
 function Utils.calculateWeatherBall(moveType, movePower)
-	if not Tracker.Data.inBattle then
+	if not Battle.inBattle then
 		return moveType, movePower
 	end
 

--- a/ironmon_tracker/data/MoveData.lua
+++ b/ironmon_tracker/data/MoveData.lua
@@ -204,7 +204,7 @@ function MoveData.moveHasUnusualPower(moveId)
 	return false
 end
 
-function MoveData.isValidMove(moveId)
+function MoveData.isValid(moveId)
 	return moveId ~= nil and moveId >= 1 and moveId <= MoveData.totalMoves
 end
 

--- a/ironmon_tracker/data/MoveData.lua
+++ b/ironmon_tracker/data/MoveData.lua
@@ -1,4 +1,6 @@
-MoveData = {}
+MoveData = {
+	totalMoves = 354,
+}
 
 -- Move categories identify the type of attack a move is: physical, special, or status
 MoveData.Categories = {
@@ -96,7 +98,7 @@ function MoveData.readDataFromMemory()
 	-- If any data at all was randomized, read in full move data from memory
 	if MoveData.checkIfDataIsRandomized() then
 		print("Randomized move data detected, reading from game memory...")
-		for moveId=1, #MoveData.Moves, 1 do
+		for moveId=1, MoveData.totalMoves, 1 do
 			local moveData = MoveData.Moves[moveId]
 
 			moveInfo = MoveData.readMoveInfoFromMemory(moveId)
@@ -200,6 +202,10 @@ function MoveData.moveHasUnusualPower(moveId)
 	if moveId == 222 then return true end -- Magnitude power = "RNG"
 
 	return false
+end
+
+function MoveData.isValidMove(moveId)
+	return moveId ~= nil and moveId >= 1 and moveId <= MoveData.totalMoves
 end
 
 --[[

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -160,6 +160,10 @@ function PokemonData.getAbilityId(pokemonID, abilityNum)
 	return abilityId
 end
 
+function PokemonData.isValid(pokemonID)
+	return pokemonID ~= nil and pokemonID >= 1 and pokemonID <= PokemonData.totalPokemon
+end
+
 PokemonData.TypeIndexMap = {
 	[0x00] = PokemonData.Types.NORMAL,
 	[0x01] = PokemonData.Types.FIGHTING,

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -1,4 +1,6 @@
-PokemonData = {}
+PokemonData = {
+	totalPokemon = 411,
+}
 
 -- Enumerated constants that defines the various types a Pokémon and its Moves are
 PokemonData.Types = {
@@ -60,7 +62,7 @@ function PokemonData.readDataFromMemory()
 	-- If any data at all was randomized, read in full Pokemon data from memory
 	if PokemonData.checkIfDataIsRandomized() then
 		print("Randomized " .. Constants.Words.POKEMON .. " data detected, reading from game memory...")
-		for pokemonID=1, #PokemonData.Pokemon, 1 do
+		for pokemonID=1, PokemonData.totalPokemon, 1 do
 			local pokemonData = PokemonData.Pokemon[pokemonID]
 
 			if PokemonData.IsRand.pokemonTypes then

--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -263,7 +263,7 @@ function RouteData.getEncounterAreaPokemon(mapId, encounterArea)
 		end
 
 		-- Some version have fewer Pokemon than others; if so, the ID will be -1
-		if pokemonID > 0 and pokemonID <= PokemonData.totalPokemon then
+		if PokemonData.isValid(pokemonID) then
 			table.insert(areaInfo, {
 				pokemonID = pokemonID,
 				rate = rate,

--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -263,7 +263,7 @@ function RouteData.getEncounterAreaPokemon(mapId, encounterArea)
 		end
 
 		-- Some version have fewer Pokemon than others; if so, the ID will be -1
-		if pokemonID > 0 and pokemonID <= #PokemonData.Pokemon then
+		if pokemonID > 0 and pokemonID <= PokemonData.totalPokemon then
 			table.insert(areaInfo, {
 				pokemonID = pokemonID,
 				rate = rate,

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -425,7 +425,7 @@ function InfoScreen.drawScreen()
 	if InfoScreen.viewScreen == InfoScreen.Screens.POKEMON_INFO then
 		local pokemonID = InfoScreen.infoLookup
 		-- Only draw valid pokemon data, pokemonID = 0 is blank move data
-		if pokemonID < 1 or pokemonID > PokemonData.totalPokemon then
+		if not PokemonData.isValid(pokemonID) then
 			Program.changeScreenView(Program.Screens.TRACKER)
 		else
 			InfoScreen.drawPokemonInfoScreen(pokemonID)
@@ -433,7 +433,7 @@ function InfoScreen.drawScreen()
 	elseif InfoScreen.viewScreen == InfoScreen.Screens.MOVE_INFO then
 		local moveId = InfoScreen.infoLookup
 		-- Only draw valid move data, moveId = 0 is blank move data
-		if moveId < 1 or moveId > MoveData.totalMoves then
+		if not MoveData.isValid(moveId) then
 			Program.changeScreenView(Program.Screens.TRACKER)
 		else
 			InfoScreen.drawMoveInfoScreen(moveId)

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -425,7 +425,7 @@ function InfoScreen.drawScreen()
 	if InfoScreen.viewScreen == InfoScreen.Screens.POKEMON_INFO then
 		local pokemonID = InfoScreen.infoLookup
 		-- Only draw valid pokemon data, pokemonID = 0 is blank move data
-		if pokemonID < 1 or pokemonID > #PokemonData.Pokemon then
+		if pokemonID < 1 or pokemonID > PokemonData.totalPokemon then
 			Program.changeScreenView(Program.Screens.TRACKER)
 		else
 			InfoScreen.drawPokemonInfoScreen(pokemonID)
@@ -433,7 +433,7 @@ function InfoScreen.drawScreen()
 	elseif InfoScreen.viewScreen == InfoScreen.Screens.MOVE_INFO then
 		local moveId = InfoScreen.infoLookup
 		-- Only draw valid move data, moveId = 0 is blank move data
-		if moveId < 1 or moveId > #MoveData.Moves then
+		if moveId < 1 or moveId > MoveData.totalMoves then
 			Program.changeScreenView(Program.Screens.TRACKER)
 		else
 			InfoScreen.drawMoveInfoScreen(moveId)

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -29,7 +29,7 @@ SetupScreen.Buttons = {
 			return imagepath
 		end,
 		onClick = function(self)
-			self.pokemonID = math.random(#PokemonData.Pokemon - 25)
+			self.pokemonID = math.random(PokemonData.totalPokemon - 25)
 			if self.pokemonID > 251 then
 				self.pokemonID = self.pokemonID + 25
 			end

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -6,7 +6,7 @@ TrackerScreen.Buttons = {
 		getIconPath = function(self)
 			local pokemonID = 0
 			local pokemon = Tracker.getViewedPokemon()
-			if pokemon ~= nil and pokemon.pokemonID > 0 and pokemon.pokemonID <= PokemonData.totalPokemon then
+			if pokemon ~= nil and PokemonData.isValid(pokemon.pokemonID) then
 				pokemonID = pokemon.pokemonID
 			end
 			local iconset = Options.IconSetMap[Options["Pokemon icon set"]]
@@ -277,12 +277,12 @@ function TrackerScreen.buildCarousel()
 		getContentList = function()
 			local lastAttackMsg
 			-- Currently this only records last move used for damaging moves
-			if Battle.lastEnemyMoveId > 0 and Battle.lastEnemyMoveId <= MoveData.totalMoves then
+			if MoveData.isValid(Battle.lastEnemyMoveId) then
 				local moveInfo = MoveData.Moves[Battle.lastEnemyMoveId]
 				if Battle.damageReceived > 0 then
 					lastAttackMsg = moveInfo.name .. ": " .. Battle.damageReceived .. " damage"
 					local ownPokemon = Tracker.getPokemon(Tracker.Data.ownViewSlot, true)
-					if Battle.damageReceived > ownPokemon.curHP then
+					if Battle.damageReceived >= ownPokemon.curHP then
 						-- Warn user that the damage taken is potentially lethal
 						TrackerScreen.Buttons.LastAttackSummary.textColor = "Negative text"
 					else
@@ -633,25 +633,23 @@ function TrackerScreen.drawPokemonInfoArea(pokemon)
 			-- Auto-tracking PC Heals button
 			Drawing.drawButton(TrackerScreen.Buttons.PCHealAutoTracking, shadowcolor)
 		end
-	else
-		-- Assumes we are in Battle, unsure if this check is neccessary
-		-- if Tracker.Data.trainerID ~= nil and pokemon.trainerID ~= nil then
-			local routeName = Constants.BLANKLINE
-			if RouteData.hasRoute(Battle.CurrentRoute.mapId) then
-				routeName = RouteData.Info[Battle.CurrentRoute.mapId].name or Constants.BLANKLINE
-			end
-			local encounterText = Tracker.getEncounters(pokemon.pokemonID, Battle.isWildEncounter)
-			if encounterText > 999 then encounterText = 999 end
-			if Battle.isWildEncounter then
-				encounterText = "Seen in the wild: " .. encounterText
-			else
-				encounterText = "Seen on trainers: " .. encounterText
-			end
+	elseif Battle.inBattle then 
+		-- For now, only show route info while in Battle; later find a way to alway show
+		local routeName = Constants.BLANKLINE
+		if RouteData.hasRoute(Battle.CurrentRoute.mapId) then
+			routeName = RouteData.Info[Battle.CurrentRoute.mapId].name or Constants.BLANKLINE
+		end
+		local encounterText = Tracker.getEncounters(pokemon.pokemonID, Battle.isWildEncounter)
+		if encounterText > 999 then encounterText = 999 end
+		if Battle.isWildEncounter then
+			encounterText = "Seen in the wild: " .. encounterText
+		else
+			encounterText = "Seen on trainers: " .. encounterText
+		end
 
-			Drawing.drawButton(TrackerScreen.Buttons.RouteDetails, shadowcolor)
-			Drawing.drawText(Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 11, Constants.SCREEN.MARGIN + 53, encounterText, Theme.COLORS["Default text"], shadowcolor)
-			Drawing.drawText(Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 11, Constants.SCREEN.MARGIN + 63, routeName, Theme.COLORS["Default text"], shadowcolor)
-		-- end
+		Drawing.drawButton(TrackerScreen.Buttons.RouteDetails, shadowcolor)
+		Drawing.drawText(Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 11, Constants.SCREEN.MARGIN + 53, encounterText, Theme.COLORS["Default text"], shadowcolor)
+		Drawing.drawText(Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 11, Constants.SCREEN.MARGIN + 63, routeName, Theme.COLORS["Default text"], shadowcolor)
 	end
 end
 


### PR DESCRIPTION
Initial effort of separating out a ton of battle logic from `Program.lua` into a new file, `Battle.lua`. Wanting to get this merged in sooner rather than later (and update `bugfixes` branch afterwards), so others can build off of it.

The main goal is separating Program/Battle based on the responsibilities of each: 
- **Program** likely handles anything related to the frame loops, the timings for handling input and drawing. It also does everything that involves reading data from memory (a few loose ends in Drawing/Utils). 
- **Battle** manages some of the Programs data at a more granular level, and tracks any entire fight. This allows better data management for when in a battle, more accurate data reads, and condensing some of the redundant code from a few of our recent features. (granted, not many improvements right now, but its a start)

Eventually we can have `Battle.lua` provide us with a simplified set of data to draw to the screen. Currently all of this logic is scattered throughout `TrackerScreen.drawMovesArea(...)` which has to perform all of the "calculations" inside a "drawing" function. These ideally would be separated.

Also worth noting, we should probably test this a good bit, especially with some of the ability triggers, and very especially synchronize.