### PR TITLE
Fix broken ability read

### DIFF
--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -69,12 +69,13 @@ function PokemonData.readDataFromMemory()
 					pokemonData.types = types
 				end
 			end
-			if PokemonData.IsRand.pokemonAbilities then
+			-- For now, read in all ability data since it's not stored in the PokemonData.Pokemon below 
+			-- if PokemonData.IsRand.pokemonAbilities then
 				abilities = PokemonData.readPokemonAbilitiesFromMemory(pokemonID)
 				if abilities ~= nil then
 					pokemonData.abilities = abilities
 				end
-			end
+			-- end
 		end
 		local datalog = Constants.BLANKLINE .. " New " .. Constants.Words.POKEMON .. " data loaded: "
 		if PokemonData.IsRand.pokemonTypes then
@@ -84,14 +85,6 @@ function PokemonData.readDataFromMemory()
 			datalog = datalog .. "Abilities, "
 		end
 		print(datalog:sub(1, -3)) -- Remove trailing ", "
-	end
-
-	-- For now, read in all ability data since it's not stored in the PokemonData.Pokemon below 
-	if not PokemonData.IsRand.pokemonAbilities then
-		abilities = PokemonData.readPokemonAbilitiesFromMemory(pokemonID)
-		if abilities ~= nil then
-			pokemonData.abilities = abilities
-		end
 	end
 end
 


### PR DESCRIPTION
commit 04add0f added a change to always read in ability data, as the vanilla data isn't currently stored in the tracker. However this read was put at the end of the function entirely and not in the for loop that iterates through pokemonIDs, so on initialisation of the tracker it would attempt to call the `readPokemonAbilitiesFromMemory` function with a nil pokemonID and crash.

Since the code block to read the abilities is the same, just instead opted to comment out the isRand check for abilities with the explanatory comment above. Then when we *do* put in the vanilla ability data can just uncomment this check to add the functionality