### PR TITLE
Bill's Island Adventure! (Sevii Isles Data)

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -202,7 +202,7 @@ function Battle.checkEnemyEncounter(opposingPokemon)
 
 		local rockSmashResult = Memory.readword(GameSettings.gSpecialVar_Result)
 		if rockSmashResult == 1 then
-			Program.CurrentRoute.encounterArea = RouteData.EncounterArea.ROCKSMASH
+			Battle.CurrentRoute.encounterArea = RouteData.EncounterArea.ROCKSMASH
 		end
 	end
 

--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -72,6 +72,7 @@ Constants.GAME_STATS = { -- Enums for in-game stats
 	FISHING_CAPTURES = 12, -- Deceptive name, gets incremented when fishing encounter happens
 	USED_POKECENTER = 15,
 	RESTED_AT_HOME = 16,
+	USED_ROCK_SMASH = 19,
 }
 
 Constants.OrderedLists = {

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -228,6 +228,7 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gBattleTerrain = 0x0300428c
 		GameSettings.gBattleTypeFlags = 0x020239f8
 		GameSettings.gSpecialVar_ItemId = 0x0203855e -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x0202e8dc -- For rock smash
 		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -377,6 +378,7 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gBattleTerrain = 0x0300428c
 		GameSettings.gBattleTypeFlags = 0x020239f8
 		GameSettings.gSpecialVar_ItemId = 0x0203855e -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x0202e8dc -- For rock smash
 		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -526,6 +528,7 @@ function GameSettings.setGameAsRuby(gameversion)
 		GameSettings.gBattleTerrain = 0x0300428c
 		GameSettings.gBattleTypeFlags = 0x020239f8
 		GameSettings.gSpecialVar_ItemId = 0x0203855e -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x0202e8dc -- For rock smash
 		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -679,6 +682,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gBattleTerrain = 0x0300428c
 		GameSettings.gBattleTypeFlags = 0x020239f8
 		GameSettings.gSpecialVar_ItemId = 0x0203855e -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x0202e8dc -- For rock smash
 		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -828,6 +832,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gBattleTerrain = 0x0300428c
 		GameSettings.gBattleTypeFlags = 0x020239f8
 		GameSettings.gSpecialVar_ItemId = 0x0203855e -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x0202e8dc -- For rock smash
 		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -977,6 +982,7 @@ function GameSettings.setGameAsSapphire(gameversion)
 		GameSettings.gBattleTerrain = 0x0300428c
 		GameSettings.gBattleTypeFlags = 0x020239f8
 		GameSettings.gSpecialVar_ItemId = 0x0203855e -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x0202e8dc -- For rock smash
 		GameSettings.FriendshipRequiredToEvo = 0x0803f48c + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x02025734
@@ -1130,6 +1136,7 @@ function GameSettings.setGameAsEmerald()
 	GameSettings.gBattleTerrain = 0x02022ff0
 	GameSettings.gBattleTypeFlags = 0x02022fec
 	GameSettings.gSpecialVar_ItemId = 0x0203ce7c -- For fishing rod
+	GameSettings.gSpecialVar_Result = 0x020375f0 -- For rock smash
 	GameSettings.FriendshipRequiredToEvo = 0x0806d098 + 0x13E -- GetEvolutionTargetSpecies
 
 	GameSettings.gSaveBlock1 = 0x02025a00
@@ -1286,6 +1293,7 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.gBattleTerrain = 0x02022b50
 		GameSettings.gBattleTypeFlags = 0x02022b4c
 		GameSettings.gSpecialVar_ItemId = 0x0203ad30 -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x020370d0 -- For rock smash
 		GameSettings.FriendshipRequiredToEvo = 0x08042ED8 + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x0202552c
@@ -1439,6 +1447,7 @@ function GameSettings.setGameAsFireRed(gameversion)
 		GameSettings.gBattleTerrain = 0x02022b50
 		GameSettings.gBattleTypeFlags = 0x02022b4c
 		GameSettings.gSpecialVar_ItemId = 0x0203ad30 -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x020370d0 -- For rock smash
 		GameSettings.FriendshipRequiredToEvo = 0x08042ec4 + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x0202552c
@@ -1595,6 +1604,7 @@ function GameSettings.setGameAsFireRedItaly(gameversion)
 		GameSettings.gBattleTerrain = 0x02022b50
 		GameSettings.gBattleTypeFlags = 0x02022b4c
 		GameSettings.gSpecialVar_ItemId = 0x0203ad30 -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x020370d0 -- For rock smash
 		GameSettings.gMoveResultFlags = 0x02023dcc
 		GameSettings.FriendshipRequiredToEvo = 0x08042db0 + 0x13E -- GetEvolutionTargetSpecies (untested)
 		
@@ -1757,6 +1767,7 @@ function GameSettings.setGameAsFireRedSpanish(gameversion)
 		GameSettings.gBattleTerrain = 0x02022b50
 		GameSettings.gBattleTypeFlags = 0x02022b4c
 		GameSettings.gSpecialVar_ItemId = 0x0203ad30 -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x020370d0 -- For rock smash
 		GameSettings.gMoveResultFlags = 0x02023dcc
 		GameSettings.FriendshipRequiredToEvo = 0x08042db0 + 0x13E -- GetEvolutionTargetSpecies (untested)
 		
@@ -1920,6 +1931,7 @@ function GameSettings.setGameAsFireRedFrench(gameversion)
 		GameSettings.gBattleTerrain = 0x02022b50
 		GameSettings.gBattleTypeFlags = 0x02022b4c
 		GameSettings.gSpecialVar_ItemId = 0x0203ad30 -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x020370d0 -- For rock smash
 		GameSettings.FriendshipRequiredToEvo = 0x08042d9c + 0x13E -- GetEvolutionTargetSpecies (untested)
 
 		--the only diffrance looks like in here gSaveBlock1ptr and gSaveBlock2ptr
@@ -2082,6 +2094,7 @@ function GameSettings.setGameAsFireRedGermany(gameversion)
 		GameSettings.gBattleTerrain = 0x02022b50
 		GameSettings.gBattleTypeFlags = 0x02022b4c
 		GameSettings.gSpecialVar_ItemId = 0x0203ad30 -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x020370d0 -- For rock smash
 		GameSettings.gMoveResultFlags = 0x02023dcc
 		GameSettings.FriendshipRequiredToEvo = 0x08042DC4 + 0x13E -- GetEvolutionTargetSpecies (untested)
 		
@@ -2245,6 +2258,7 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.gBattleTerrain = 0x02022b50
 		GameSettings.gBattleTypeFlags = 0x02022b4c
 		GameSettings.gSpecialVar_ItemId = 0x0203ad30 -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x020370d0 -- For rock smash
 		GameSettings.FriendshipRequiredToEvo = 0x08042ed8 + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x0202552c
@@ -2399,6 +2413,7 @@ function GameSettings.setGameAsLeafGreen(gameversion)
 		GameSettings.gBattleTerrain = 0x02022b50
 		GameSettings.gBattleTypeFlags = 0x02022b4c
 		GameSettings.gSpecialVar_ItemId = 0x0203ad30 -- For fishing rod
+		GameSettings.gSpecialVar_Result = 0x020370d0 -- For rock smash
 		GameSettings.FriendshipRequiredToEvo = 0x08042ec4 + 0x13E -- GetEvolutionTargetSpecies
 
 		GameSettings.gSaveBlock1 = 0x0202552c

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -160,7 +160,7 @@ function Program.updateTrackedAndCurrentData()
 	-- Only update "Heals in Bag", "PC Heals", and "Badge Data" info every 3 seconds (3 seconds * 60 frames/sec)
 	if Program.Frames.three_sec_update == 0 then
 		Program.Frames.three_sec_update = 180
-
+		
 		Program.updateBagHealingItemsFromMemory()
 		Program.updatePCHealsFromMemory()
 		Program.updateBadgesObtainedFromMemory()
@@ -388,12 +388,23 @@ function Program.updateBattleDataFromMemory()
 
 			-- Check if fishing encounter, if so then get the rod that was used
 			local gameStat_FishingCaptures = Utils.getGameStat(Constants.GAME_STATS.FISHING_CAPTURES)
-			if gameStat_FishingCaptures ~= Tracker.Data.gameStatsFishing then
+			if gameStat_FishingCaptures > Tracker.Data.gameStatsFishing then
 				Tracker.Data.gameStatsFishing = gameStat_FishingCaptures
 
 				local fishingRod = Memory.readword(GameSettings.gSpecialVar_ItemId)
 				if RouteData.Rods[fishingRod] ~= nil then
 					Program.CurrentRoute.encounterArea = RouteData.Rods[fishingRod]
+				end
+			end
+
+			-- Check if rock smash encounter, if so then check encounter happened
+			local gameStat_UsedRockSmash = Utils.getGameStat(Constants.GAME_STATS.USED_ROCK_SMASH)
+			if gameStat_UsedRockSmash > Tracker.Data.gameStatsRockSmash then
+				Tracker.Data.gameStatsRockSmash = gameStat_UsedRockSmash
+
+				local rockSmashResult = Memory.readword(GameSettings.gSpecialVar_Result)
+				if rockSmashResult == 1 then
+					Program.CurrentRoute.encounterArea = RouteData.EncounterArea.ROCKSMASH
 				end
 			end
 

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -415,6 +415,7 @@ function Tracker.resetData()
 		encounterTable = { -- key: mapId, value: lookup table with key for terrain type and value of unique pokemonIDs
 		},
 		gameStatsFishing = Utils.getGameStat(Constants.GAME_STATS.FISHING_CAPTURES), -- Tally of fishing encounters, to track when one occurs
+		gameStatsRockSmash = Utils.getGameStat(Constants.GAME_STATS.USED_ROCK_SMASH), -- Tally of rock smash uses, to track encounters
 	}
 end
 

--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -1439,10 +1439,616 @@ function RouteData.setupRouteInfoAsFRLG()
 		[216] = { name = "Lance's Room", },
 		[217] = { name = "Champion's Room", },
 		[228] = { name = "Saffron City Dojo", },
+
+		-- [[Sevii Isles]]
+		[230] = { name = "One Island",
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.95, minLv = 5, maxLv = 40, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {90,120}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[232] = { name = "Three Island", }, -- Only trainers here
+		[233] = { name = "Four Island",
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = {194,183}, rate = 0.70, minLv = 5, maxLv = 25, },
+				{ pokemonID = {54,79}, rate = 0.30, minLv = 5, maxLv = 35, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = 60, rate = 0.60, minLv = 5, maxLv = 15, },
+				{ pokemonID = 118, rate = 0.20, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = 60, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 61, rate = 0.40, minLv = 20, maxLv = 30, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 15, maxLv = 35, },
+			},
+		},
+		[234] = { name = "Five Island",
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.65, minLv = 5, maxLv = 40, },
+				{ pokemonID = 187, rate = 0.30, minLv = 5, maxLv = 15, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {90,120}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[237] = { name = "Kindle Road",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 77, rate = 0.30, minLv = 31, maxLv = 34, },
+				{ pokemonID = 21, rate = 0.25, minLv = 30, maxLv = 32, },
+				{ pokemonID = 22, rate = 0.10, minLv = 36, maxLv = 36, },
+				{ pokemonID = 52, rate = 0.10, minLv = 31, maxLv = 31, },
+				{ pokemonID = 74, rate = 0.10, minLv = 31, maxLv = 31, },
+				{ pokemonID = 53, rate = 0.05, minLv = 37, maxLv = 40, },
+				{ pokemonID = 78, rate = 0.05, minLv = 37, maxLv = 40, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 34, maxLv = 34, },
+			},
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.95, minLv = 5, maxLv = 40, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+			[RouteData.EncounterArea.ROCKSMASH] = {
+				{ pokemonID = 74, rate = 0.95, minLv = 5, maxLv = 30, },
+				{ pokemonID = 75, rate = 0.05, minLv = 25, maxLv = 40, },
+			},
+		},
+		[238] = { name = "Treasure Beach",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 21, rate = 0.30, minLv = 31, maxLv = 31, },
+				{ pokemonID = 114, rate = 0.30, minLv = 33, maxLv = 35, },
+				{ pokemonID = 22, rate = 0.20, minLv = 36, maxLv = 40, },
+				{ pokemonID = 52, rate = 0.10, minLv = 31, maxLv = 31, },
+				{ pokemonID = 53, rate = 0.05, minLv = 37, maxLv = 40, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 31, maxLv = 31, },
+			},
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.95, minLv = 5, maxLv = 40, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[239] = { name = "Cape Brink",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = {43,69}, rate = 0.30, minLv = 30, maxLv = 32, },
+				{ pokemonID = 21, rate = 0.20, minLv = 31, maxLv = 31, },
+				{ pokemonID = {44,70}, rate = 0.15, minLv = 36, maxLv = 38, },
+				{ pokemonID = 22, rate = 0.10, minLv = 36, maxLv = 36, },
+				{ pokemonID = 52, rate = 0.10, minLv = 31, maxLv = 31, },
+				{ pokemonID = 53, rate = 0.05, minLv = 37, maxLv = 40, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 31, maxLv = 31, },
+				{ pokemonID = {55,80}, rate = 0.05, minLv = 37, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = {54,79}, rate = 0.95, minLv = 5, maxLv = 40, },
+				{ pokemonID = {55,80}, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = 60, rate = 0.60, minLv = 5, maxLv = 15, },
+				{ pokemonID = 118, rate = 0.20, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = 60, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 61, rate = 0.40, minLv = 20, maxLv = 30, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 15, maxLv = 35, },
+			},
+		},
+		[240] = { name = "Bond Bridge", -- 007, license to kill your sub-500BST survival run
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 16, rate = 0.30, minLv = 29, maxLv = 32, },
+				{ pokemonID = {43,69}, rate = 0.20, minLv = 31, maxLv = 31, },
+				{ pokemonID = 17, rate = 0.15, minLv = 34, maxLv = 40, },
+				{ pokemonID = {44,70}, rate = 0.10, minLv = 36, maxLv = 36, },
+				{ pokemonID = 52, rate = 0.10, minLv = 31, maxLv = 31, },
+				{ pokemonID = 48, rate = 0.05, minLv = 34, maxLv = 34, },
+				{ pokemonID = 53, rate = 0.05, minLv = 37, maxLv = 40, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 31, maxLv = 31, },
+			},
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.95, minLv = 5, maxLv = 40, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = nil, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[241] = { name = "Three Island Port",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 206, rate = 1.00, minLv = 5, maxLv = 35, },
+			},
+		},
+		[246] = { name = "Resort Gorgeous",
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.65, minLv = 5, maxLv = 40, },
+				{ pokemonID = 187, rate = 0.30, minLv = 5, maxLv = 15, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {211,223}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[247] = { name = "Water Labyrinth",
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.65, minLv = 5, maxLv = 40, },
+				{ pokemonID = 187, rate = 0.30, minLv = 5, maxLv = 15, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {211,223}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[248] = { name = "Five Isle Meadow",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 161, rate = 0.30, minLv = 10, maxLv = 15, },
+				{ pokemonID = 16, rate = 0.20, minLv = 44, maxLv = 44, },
+				{ pokemonID = 17, rate = 0.15, minLv = 48, maxLv = 50, },
+				{ pokemonID = 187, rate = 0.15, minLv = 10, maxLv = 15, },
+				{ pokemonID = 52, rate = 0.10, minLv = 41, maxLv = 41, },
+				{ pokemonID = 53, rate = 0.05, minLv = 47, maxLv = 50, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 41, maxLv = 41, },
+			},
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.65, minLv = 5, maxLv = 40, },
+				{ pokemonID = 187, rate = 0.30, minLv = 5, maxLv = 15, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {211,223}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[249] = { name = "Memorial Pillar",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 187, rate = 1.00, minLv = 6, maxLv = 16, },
+			},
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.65, minLv = 5, maxLv = 40, },
+				{ pokemonID = 187, rate = 0.30, minLv = 5, maxLv = 15, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {211,223}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[250] = { name = "Outcast Island",
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.95, minLv = 5, maxLv = 40, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {211,223}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[251] = { name = "Green Path",
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.95, minLv = 5, maxLv = 40, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {211,223}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[252] = { name = "Water Path",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 161, rate = 0.30, minLv = 10, maxLv = 15, },
+				{ pokemonID = 21, rate = 0.20, minLv = 44, maxLv = 44, },
+				{ pokemonID = 22, rate = 0.15, minLv = 48, maxLv = 50, },
+				{ pokemonID = {43,69}, rate = 0.10, minLv = 44, maxLv = 44, },
+				{ pokemonID = 52, rate = 0.10, minLv = 41, maxLv = 41, },
+				{ pokemonID = {44,70}, rate = 0.05, minLv = 48, maxLv = 48, },
+				{ pokemonID = 53, rate = 0.05, minLv = 47, maxLv = 50, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 41, maxLv = 41, },
+			},
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.95, minLv = 5, maxLv = 40, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {211,223}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[253] = { name = "Ruin Valley",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 177, rate = 0.25, minLv = 15, maxLv = 20, },
+				{ pokemonID = 21, rate = 0.20, minLv = 44, maxLv = 44, },
+				{ pokemonID = 22, rate = 0.10, minLv = 49, maxLv = 49, },
+				{ pokemonID = 52, rate = 0.10, minLv = 43, maxLv = 43, },
+				{ pokemonID = 193, rate = 0.10, minLv = 18, maxLv = 18, },
+				{ pokemonID = {194,183}, rate = 0.10, minLv = 15, maxLv = 15, },
+				{ pokemonID = 53, rate = 0.05, minLv = 49, maxLv = 52, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 41, maxLv = 41, },
+				{ pokemonID = 202, rate = 0.05, minLv = 25, maxLv = 25, },
+			},
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = {194,183}, rate = 1.00, minLv = 5, maxLv = 25, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = 60, rate = 0.60, minLv = 5, maxLv = 15, },
+				{ pokemonID = 118, rate = 0.20, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = 60, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 61, rate = 0.40, minLv = 20, maxLv = 30, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 15, maxLv = 35, },
+			},
+		},
+		[254] = { name = "Trainer Tower",
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.95, minLv = 5, maxLv = 40, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {211,223}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[255] = { name = "Canyon Entrance",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 161, rate = 0.30, minLv = 10, maxLv = 15, },
+				{ pokemonID = 21, rate = 0.20, minLv = 44, maxLv = 44, },
+				{ pokemonID = 22, rate = 0.15, minLv = 48, maxLv = 50, },
+				{ pokemonID = 231, rate = 0.15, minLv = 10, maxLv = 15, },
+				{ pokemonID = 52, rate = 0.10, minLv = 41, maxLv = 41, },
+				{ pokemonID = 53, rate = 0.05, minLv = 47, maxLv = 50, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 41, maxLv = 41, },
+			},
+		},
+		[256] = { name = "Sevault Canyon",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 74, rate = 0.20, minLv = 46, maxLv = 46, },
+				{ pokemonID = 231, rate = 0.20, minLv = 20, maxLv = 20, },
+				{ pokemonID = 22, rate = {0.10, 0.15}, minLv = 50, maxLv = 50, },
+				{ pokemonID = 52, rate = 0.10, minLv = 43, maxLv = 43, },
+				{ pokemonID = 104, rate = 0.10, minLv = 46, maxLv = 46, },
+				{ pokemonID = 105, rate = 0.10, minLv = 52, maxLv = 52, },
+				{ pokemonID = 53, rate = 0.05, minLv = 49, maxLv = 52, },
+				{ pokemonID = 95, rate = 0.05, minLv = 54, maxLv = 54, },
+				{ pokemonID = {227,-1}, rate = 0.05, minLv = 30, maxLv = 30, },
+				{ pokemonID = 246, rate = 0.05, minLv = 15, maxLv = 20, },
+			},
+			[RouteData.EncounterArea.ROCKSMASH] = {
+				{ pokemonID = 74, rate = 0.65, minLv = 25, maxLv = 40, },
+				{ pokemonID = 75, rate = 0.35, minLv = 30, maxLv = 50, },
+			},
+		},
+		[257] = { name = "Tanoby Ruins",
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = {0.95, 0.90}, minLv = 5, maxLv = 40, },
+				{ pokemonID = 73, rate = 0.05, minLv = 35, maxLv = 40, },
+				{ pokemonID = {-1,226}, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {211,223}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[270] = { name = "Berry Forest",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 17, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = {44,70}, rate = 0.20, minLv = 35, maxLv = 35, },
+				{ pokemonID = 16, rate = 0.10, minLv = 32, maxLv = 32, },
+				{ pokemonID = {43,69}, rate = 0.10, minLv = 30, maxLv = 30, },
+				{ pokemonID = 48, rate = 0.10, minLv = 34, maxLv = 34, },
+				{ pokemonID = 96, rate = 0.10, minLv = 34, maxLv = 34, },
+				{ pokemonID = 49, rate = 0.05, minLv = 37, maxLv = 40, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 31, maxLv = 31, },
+				{ pokemonID = 97, rate = 0.05, minLv = 37, maxLv = 40, },
+				{ pokemonID = 102, rate = 0.05, minLv = 35, maxLv = 35, },
+			},
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = {54,79}, rate = 0.95, minLv = 5, maxLv = 40, },
+				{ pokemonID = {55,80}, rate = 0.05, minLv = 35, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = 118, rate = 0.60, minLv = 5, maxLv = 15, },
+				{ pokemonID = 60, rate = 0.20, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = 118, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 119, rate = 0.40, minLv = 20, maxLv = 30, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 15, maxLv = 35, },
+			},
+		},
+		-- One Island: Mt. Ember [[Start]]
+		-- Serebii's Pokéarth is pretty wrong about this place for some reason, basing off bulbapedia instead which is mostly more accurate
+		-- https://bulbapedia.bulbagarden.net/wiki/Mt._Ember#Pok.C3.A9mon
+		[280] = { name = "Mt. Ember Base",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 77, rate = 0.35, minLv = 30, maxLv = 36, },
+				{ pokemonID = 22, rate = 0.25, minLv = 38, maxLv = 40, },
+				{ pokemonID = 21, rate = {0.15, 0.10}, minLv = 30, maxLv = 32, },
+				{ pokemonID = 66, rate = 0.10, minLv = 35, maxLv = 35, },
+				{ pokemonID = 74, rate = 0.10, minLv = 33, maxLv = 33, },
+				{ pokemonID = 78, rate = 0.05, minLv = 39, maxLv = 42, },
+				{ pokemonID = {-1,126}, rate = 0.05, minLv = 38, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.ROCKSMASH] = {
+				{ pokemonID = 74, rate = 0.95, minLv = 5, maxLv = 30, },
+				{ pokemonID = 75, rate = 0.05, minLv = 25, maxLv = 40, },
+			},
+		},
+		[281] = { name = "Mt. Ember Summit",
+			[RouteData.EncounterArea.STATIC] = {
+				{ pokemonID = 146, rate = 1.00, minLv = 50, maxLv = 50, },
+			},
+		},
+		[282] = { name = "Summit Path 1F",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 66, rate = 0.50, minLv = 31, maxLv = 39, },
+				{ pokemonID = 74, rate = 0.50, minLv = 29, maxLv = 37, },
+			},
+		},
+		[283] = { name = "Summit Path 2F",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 66, rate = 0.40, minLv = 32, maxLv = 36, },
+				{ pokemonID = 74, rate = 0.40, minLv = 30, maxLv = 34, },
+				{ pokemonID = 67, rate = 0.20, minLv = 38, maxLv = 40, },
+			},
+			[RouteData.EncounterArea.ROCKSMASH] = {
+				{ pokemonID = 74, rate = 0.95, minLv = 5, maxLv = 30, },
+				{ pokemonID = 75, rate = 0.05, minLv = 25, maxLv = 40, },
+			},
+		},
+		[284] = { name = "Summit Path 3F",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 66, rate = 0.50, minLv = 31, maxLv = 39, },
+				{ pokemonID = 74, rate = 0.50, minLv = 29, maxLv = 37, },
+			},
+		},
+		[285] = { name = "Ruby Path 1F",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 74, rate = 0.50, minLv = 32, maxLv = 40, },
+				{ pokemonID = 66, rate = 0.40, minLv = 34, maxLv = 38, },
+				{ pokemonID = 67, rate = 0.10, minLv = 40, maxLv = 42, },
+			},
+			[RouteData.EncounterArea.ROCKSMASH] = {
+				{ pokemonID = 74, rate = 0.65, minLv = 25, maxLv = 40, },
+				{ pokemonID = 75, rate = 0.35, minLv = 30, maxLv = 50, },
+			},
+		},
+		[286] = { name = "Ruby Path B1F",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 74, rate = 0.70, minLv = 34, maxLv = 42, },
+				{ pokemonID = 218, rate = 0.30, minLv = 24, maxLv = 30, },
+			},
+			[RouteData.EncounterArea.ROCKSMASH] = {
+				{ pokemonID = 74, rate = 0.65, minLv = 25, maxLv = 40, },
+				{ pokemonID = 75, rate = 0.35, minLv = 30, maxLv = 50, },
+			},
+		},
+		[287] = { name = "Ruby Path B2F",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 218, rate = 0.60, minLv = 22, maxLv = 32, },
+				{ pokemonID = 74, rate = 0.40, minLv = 40, maxLv = 44, },
+			},
+			[RouteData.EncounterArea.ROCKSMASH] = {
+				{ pokemonID = 74, rate = 0.65, minLv = 25, maxLv = 40, },
+				{ pokemonID = 75, rate = 0.35, minLv = 30, maxLv = 50, },
+			},
+		},
+		[288] = { name = "Ruby Path B3F",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 218, rate = 1.00, minLv = 18, maxLv = 36, },
+			},
+			[RouteData.EncounterArea.ROCKSMASH] = {
+				{ pokemonID = 218, rate = 0.90, minLv = 15, maxLv = 35, },
+				{ pokemonID = 219, rate = 0.10, minLv = 25, maxLv = 45, },
+			},
+		},
+		-- Bulbapedia says there's encounters for B4F/B5F but includes rock smash encounters
+		-- There are no rocks to smash on these floors, and I ran for a good while through both floors, no encounters
+		-- One Island: Mt. Ember [[End]]
+		[292] = { name = "Rocket Hideout", }, -- Only trainers here
 	}
 
-	return 228 -- max mapId
+	return 292 -- max mapId
 end
+
+-- Blank set for copy-paste
+-- [nil] = { name = "nil",
+-- 	[RouteData.EncounterArea.LAND] = {
+-- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
+-- 		{ pokemonID = {nil,nil}, rate = 0.00, minLv = nil, maxLv = nil, },
+-- 	},
+-- 	[RouteData.EncounterArea.SURFING] = {
+-- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
+-- 		{ pokemonID = {nil,nil}, rate = 0.00, minLv = nil, maxLv = nil, },
+-- 	},
+-- 	[RouteData.EncounterArea.OLDROD] = {
+-- 		{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+-- 	},
+-- 	[RouteData.EncounterArea.GOODROD] = {
+-- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
+-- 		{ pokemonID = {nil,nil}, rate = 0.00, minLv = nil, maxLv = nil, },
+-- 	},
+-- 	[RouteData.EncounterArea.SUPERROD] = {
+-- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
+-- 		{ pokemonID = {nil,nil}, rate = 0.00, minLv = nil, maxLv = nil, },
+-- 	},
+-- 	[RouteData.EncounterArea.ROCKSMASH] = {
+-- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
+-- 		{ pokemonID = {nil,nil}, rate = 0.00, minLv = nil, maxLv = nil, },
+-- 	},
+-- 	[RouteData.EncounterArea.STATIC] = {
+-- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
+-- 	},
+-- },
 
 -- https://github.com/pret/pokeemerald/blob/677b4fc394516deab5b5c86c94a2a1443cb52151/include/constants/layouts.h
 -- https://www.serebii.net/pokearth/hoenn/3rd/route101.shtml

--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -373,6 +373,7 @@ function RouteData.setupRouteInfoAsFRLG()
 		[15] = { name = "Celadon Gym", },
 		[20] = { name = "Fuchsia Gym", },
 		[25] = { name = "Vermilion Gym", },
+		[27] = { name = "Game Corner", },
 		[28] = { name = "Pewter Gym", },
 		[34] = { name = "Saffron Gym", },
 		[36] = { name = "Cinnabar Gym", },
@@ -956,11 +957,7 @@ function RouteData.setupRouteInfoAsFRLG()
 				{ pokemonID = 25, rate = 0.05, minLv = 3, maxLv = 5, },
 			},
 		},
-		[118] = { name = "S.S. Anne Ext.", },
-		[119] = { name = "S.S. Anne 1F", },
-		[120] = { name = "S.S. Anne 2F", },
-		[121] = { name = "S.S. Anne 3F", },
-		[122] = { name = "S.S. Anne B1F", },
+		[120] = { name = "S.S. Anne 2F", }, -- 2F corridor (Rival Fight)
 		[123] = { name = "S.S. Anne Deck", },
 		[124] = { name = "Diglett's Cave B1F",
 			[RouteData.EncounterArea.LAND] = {
@@ -1433,13 +1430,14 @@ function RouteData.setupRouteInfoAsFRLG()
 				{ pokemonID = 145, rate = 1.00, minLv = 50, maxLv = 50, },
 			},
 		},
+		[177] = { name = "S.S. Anne Rooms", },
+		[178] = { name = "S.S. Anne Rooms", },
 		[213] = { name = "Lorelei's Room", },
 		[214] = { name = "Bruno's Room", },
 		[215] = { name = "Agatha's Room", },
 		[216] = { name = "Lance's Room", },
 		[217] = { name = "Champion's Room", },
 		[228] = { name = "Saffron City Dojo", },
-
 		-- [[Sevii Isles]]
 		[230] = { name = "One Island",
 			[RouteData.EncounterArea.SURFING] = {
@@ -1622,7 +1620,7 @@ function RouteData.setupRouteInfoAsFRLG()
 				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
 			},
 		},
-		[241] = { name = "Three Island Port",
+		[241] = { name = "Three Isle Port",
 			[RouteData.EncounterArea.LAND] = {
 				{ pokemonID = 206, rate = 1.00, minLv = 5, maxLv = 35, },
 			},
@@ -1925,7 +1923,7 @@ function RouteData.setupRouteInfoAsFRLG()
 				{ pokemonID = {54,79}, rate = 0.05, minLv = 15, maxLv = 35, },
 			},
 		},
-		-- One Island: Mt. Ember [[Start]]
+		-- [[Start]] One Island: Mt. Ember
 		-- Serebii's Pokéarth is pretty wrong about this place for some reason, basing off bulbapedia instead which is mostly more accurate
 		-- https://bulbapedia.bulbagarden.net/wiki/Mt._Ember#Pok.C3.A9mon
 		[280] = { name = "Mt. Ember Base",
@@ -1982,7 +1980,7 @@ function RouteData.setupRouteInfoAsFRLG()
 				{ pokemonID = 75, rate = 0.35, minLv = 30, maxLv = 50, },
 			},
 		},
-		[286] = { name = "Ruby Path B1F",
+		[286] = { name = "Ruby Path B1F- a",
 			[RouteData.EncounterArea.LAND] = {
 				{ pokemonID = 74, rate = 0.70, minLv = 34, maxLv = 42, },
 				{ pokemonID = 218, rate = 0.30, minLv = 24, maxLv = 30, },
@@ -1992,7 +1990,7 @@ function RouteData.setupRouteInfoAsFRLG()
 				{ pokemonID = 75, rate = 0.35, minLv = 30, maxLv = 50, },
 			},
 		},
-		[287] = { name = "Ruby Path B2F",
+		[287] = { name = "Ruby Path B2F- a",
 			[RouteData.EncounterArea.LAND] = {
 				{ pokemonID = 218, rate = 0.60, minLv = 22, maxLv = 32, },
 				{ pokemonID = 74, rate = 0.40, minLv = 40, maxLv = 44, },
@@ -2011,44 +2009,310 @@ function RouteData.setupRouteInfoAsFRLG()
 				{ pokemonID = 219, rate = 0.10, minLv = 25, maxLv = 45, },
 			},
 		},
+		-- These two are the tiny rooms on the quick way back from B5F
+		[289] = { name = "Ruby Path B1F- b",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 74, rate = 0.70, minLv = 34, maxLv = 42, },
+				{ pokemonID = 218, rate = 0.30, minLv = 24, maxLv = 30, },
+			},
+			[RouteData.EncounterArea.ROCKSMASH] = {
+				{ pokemonID = 74, rate = 0.65, minLv = 25, maxLv = 40, },
+				{ pokemonID = 75, rate = 0.35, minLv = 30, maxLv = 50, },
+			},
+		},
+		[290] = { name = "Ruby Path B2F- b",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 218, rate = 0.60, minLv = 22, maxLv = 32, },
+				{ pokemonID = 74, rate = 0.40, minLv = 40, maxLv = 44, },
+			},
+			[RouteData.EncounterArea.ROCKSMASH] = {
+				{ pokemonID = 74, rate = 0.65, minLv = 25, maxLv = 40, },
+				{ pokemonID = 75, rate = 0.35, minLv = 30, maxLv = 50, },
+			},
+		},
 		-- Bulbapedia says there's encounters for B4F/B5F but includes rock smash encounters
 		-- There are no rocks to smash on these floors, and I ran for a good while through both floors, no encounters
-		-- One Island: Mt. Ember [[End]]
-		[292] = { name = "Rocket Hideout", }, -- Only trainers here
+		-- [[End]] One Island: Mt. Ember
+		[292] = { name = "Rocket Warehouse", }, -- Only trainers here
+		[293] = { name = "Icefall Cave Entrance",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 86, rate = 0.40, minLv = 43, maxLv = 47, },
+				{ pokemonID = 42, rate = 0.25, minLv = 45, maxLv = 48, },
+				{ pokemonID = 87, rate = 0.20, minLv = 49, maxLv = 53, },
+				{ pokemonID = 41, rate = 0.10, minLv = 40, maxLv = 40, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 41, maxLv = 41, },
+			},
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 86, rate = 0.60, minLv = 5, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.30, minLv = 5, maxLv = 35, },
+				{ pokemonID = 87, rate = 0.05, minLv = 35, maxLv = 40, },
+				{ pokemonID = {194,183}, rate = 0.05, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = 60, rate = 0.60, minLv = 5, maxLv = 15, },
+				{ pokemonID = 118, rate = 0.20, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = 60, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 61, rate = 0.40, minLv = 20, maxLv = 30, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 15, maxLv = 35, },
+			},
+		},
+		[294] = { name = "Icefall Cave 1F",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 220, rate = 0.50, minLv = 23, maxLv = 31, },
+				{ pokemonID = 42, rate = 0.25, minLv = 45, maxLv = 48, },
+				{ pokemonID = 41, rate = 0.10, minLv = 40, maxLv = 40, },
+				{ pokemonID = 86, rate = 0.10, minLv = 45, maxLv = 45, },
+				{ pokemonID = {225,215}, rate = 0.05, minLv = 30, maxLv = 30, },
+			},
+		},
+		[295] = { name = "Icefall Cave B1F",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 220, rate = 0.50, minLv = 23, maxLv = 31, },
+				{ pokemonID = 42, rate = 0.25, minLv = 45, maxLv = 48, },
+				{ pokemonID = 41, rate = 0.10, minLv = 40, maxLv = 40, },
+				{ pokemonID = 86, rate = 0.10, minLv = 45, maxLv = 45, },
+				{ pokemonID = {225,215}, rate = 0.05, minLv = 30, maxLv = 30, },
+			},
+		},
+		[296] = { name = "Icefall Cave Back",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 86, rate = 0.40, minLv = 43, maxLv = 47, },
+				{ pokemonID = 42, rate = 0.25, minLv = 45, maxLv = 48, },
+				{ pokemonID = 87, rate = 0.20, minLv = 49, maxLv = 53, },
+				{ pokemonID = 41, rate = 0.10, minLv = 40, maxLv = 40, },
+				{ pokemonID = {54,79}, rate = 0.05, minLv = 41, maxLv = 41, },
+			},
+			[RouteData.EncounterArea.SURFING] = {
+				{ pokemonID = 72, rate = 0.95, minLv = 5, maxLv = 45, },
+				{ pokemonID = 73, rate = 0.04, minLv = 35, maxLv = 45, },
+				{ pokemonID = 131, rate = 0.01, minLv = 30, maxLv = 45, },
+			},
+			[RouteData.EncounterArea.OLDROD] = {
+				{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
+			},
+			[RouteData.EncounterArea.GOODROD] = {
+				{ pokemonID = {116,98}, rate = 0.80, minLv = 5, maxLv = 15, },
+				{ pokemonID = 129, rate = 0.20, minLv = 5, maxLv = 15, },
+			},
+			[RouteData.EncounterArea.SUPERROD] = {
+				{ pokemonID = {116,98}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = {90,120}, rate = 0.40, minLv = 15, maxLv = 25, },
+				{ pokemonID = 130, rate = 0.15, minLv = 15, maxLv = 25, },
+				{ pokemonID = {117,99}, rate = 0.04, minLv = 25, maxLv = 35, },
+				{ pokemonID = {54,79}, rate = 0.01, minLv = 25, maxLv = 35, },
+			},
+		},
+		[298] = { name = "Trainer Tower 1F", },
+		[299] = { name = "Trainer Tower 2F", },
+		[300] = { name = "Trainer Tower 3F", },
+		[301] = { name = "Trainer Tower 4F", },
+		[302] = { name = "Trainer Tower 5F", },
+		[303] = { name = "Trainer Tower 6F", },
+		[304] = { name = "Trainer Tower 7F", },
+		[305] = { name = "Trainer Tower 8F", },
+		[317] = { name = "Pattern Bush",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = {167,165}, rate = 0.30, minLv = 9, maxLv = 14, },
+				{ pokemonID = {14,11}, rate = 0.20, minLv = 9, maxLv = 9, },
+				{ pokemonID = 214, rate = 0.20, minLv = 15, maxLv = 30, },
+				{ pokemonID = 10, rate = 0.10, minLv = 6, maxLv = 6, },
+				{ pokemonID = 13, rate = 0.10, minLv = 6, maxLv = 6, },
+				{ pokemonID = {165,167}, rate = 0.05, minLv = 9, maxLv = 14, },
+				{ pokemonID = {11,14}, rate = 0.05, minLv = 9, maxLv = 9, },
+			},
+		},
+		[321] = { name = "Lost Cave Room 1",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 92, rate = 0.25, minLv = 38, maxLv = 40, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 42, rate = 0.20, minLv = 41, maxLv = 43, },
+				{ pokemonID = {198,200}, rate = 0.05, minLv = 22, maxLv = 22, },
+			},
+		},
+		[322] = { name = "Lost Cave Room 2",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 92, rate = 0.25, minLv = 38, maxLv = 40, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 42, rate = 0.20, minLv = 41, maxLv = 43, },
+				{ pokemonID = {198,200}, rate = 0.05, minLv = 22, maxLv = 22, },
+			},
+		},
+		[323] = { name = "Lost Cave Room 3",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 92, rate = 0.25, minLv = 38, maxLv = 40, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 42, rate = 0.20, minLv = 41, maxLv = 43, },
+				{ pokemonID = {198,200}, rate = 0.05, minLv = 22, maxLv = 22, },
+			},
+		},
+		[324] = { name = "Lost Cave Room 4",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 92, rate = 0.25, minLv = 38, maxLv = 40, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 42, rate = 0.20, minLv = 41, maxLv = 43, },
+				{ pokemonID = {198,200}, rate = 0.05, minLv = 22, maxLv = 22, },
+			},
+		},
+		[325] = { name = "Lost Cave Room 5",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 92, rate = 0.25, minLv = 38, maxLv = 40, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 42, rate = 0.20, minLv = 41, maxLv = 43, },
+				{ pokemonID = {198,200}, rate = 0.05, minLv = 22, maxLv = 22, },
+			},
+		},
+		[326] = { name = "Lost Cave Room 6",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 92, rate = 0.25, minLv = 38, maxLv = 40, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 42, rate = 0.20, minLv = 41, maxLv = 43, },
+				{ pokemonID = {198,200}, rate = 0.05, minLv = 22, maxLv = 22, },
+			},
+		},
+		[327] = { name = "Lost Cave Room 7",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 92, rate = 0.25, minLv = 38, maxLv = 40, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 42, rate = 0.20, minLv = 41, maxLv = 43, },
+				{ pokemonID = {198,200}, rate = 0.05, minLv = 22, maxLv = 22, },
+			},
+		},
+		[328] = { name = "Lost Cave Room 8",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 92, rate = 0.25, minLv = 38, maxLv = 40, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 42, rate = 0.20, minLv = 41, maxLv = 43, },
+				{ pokemonID = {198,200}, rate = 0.05, minLv = 22, maxLv = 22, },
+			},
+		},
+		[329] = { name = "Lost Cave Room 9",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 92, rate = 0.25, minLv = 38, maxLv = 40, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 42, rate = 0.20, minLv = 41, maxLv = 43, },
+				{ pokemonID = {198,200}, rate = 0.05, minLv = 22, maxLv = 22, },
+			},
+		},
+		[330] = { name = "Lost Cave Room 10",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 92, rate = 0.25, minLv = 38, maxLv = 40, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 42, rate = 0.20, minLv = 41, maxLv = 43, },
+				{ pokemonID = {198,200}, rate = 0.05, minLv = 22, maxLv = 22, },
+			},
+		},
+		[331] = { name = "Lost Cave Room 11",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 92, rate = 0.20, minLv = 40, maxLv = 40, },
+				{ pokemonID = {198,200}, rate = 0.20, minLv = 15, maxLv = 22, },
+				{ pokemonID = 42, rate = 0.10, minLv = 41, maxLv = 41, },
+			},
+		},
+		[332] = { name = "Lost Cave Room 12",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 92, rate = 0.20, minLv = 40, maxLv = 40, },
+				{ pokemonID = {198,200}, rate = 0.20, minLv = 15, maxLv = 22, },
+				{ pokemonID = 42, rate = 0.10, minLv = 41, maxLv = 41, },
+			},
+		},
+		[333] = { name = "Lost Cave Room 13",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 92, rate = 0.20, minLv = 40, maxLv = 40, },
+				{ pokemonID = {198,200}, rate = 0.20, minLv = 15, maxLv = 22, },
+				{ pokemonID = 42, rate = 0.10, minLv = 41, maxLv = 41, },
+			},
+		},
+		[334] = { name = "Lost Cave Room 14",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 93, rate = 0.30, minLv = 44, maxLv = 52, },
+				{ pokemonID = 41, rate = 0.20, minLv = 37, maxLv = 37, },
+				{ pokemonID = 92, rate = 0.20, minLv = 40, maxLv = 40, },
+				{ pokemonID = {198,200}, rate = 0.20, minLv = 15, maxLv = 22, },
+				{ pokemonID = 42, rate = 0.10, minLv = 41, maxLv = 41, },
+			},
+		},
+		[335] = { name = "Monean Chamber",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 201, rate = 1.00, minLv = 25, maxLv = 25, },
+			},
+		},
+		[336] = { name = "Liptoo Chamber",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 201, rate = 1.00, minLv = 25, maxLv = 25, },
+			},
+		},
+		[337] = { name = "Weepth Chamber",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 201, rate = 1.00, minLv = 25, maxLv = 25, },
+			},
+		},
+		[338] = { name = "Dilford Chamber",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 201, rate = 1.00, minLv = 25, maxLv = 25, },
+			},
+		},
+		[339] = { name = "Scufib Chamber",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 201, rate = 1.00, minLv = 25, maxLv = 25, },
+			},
+		},
+		[340] = { name = "Altering Cave",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 41, rate = 1.00, minLv = 6, maxLv = 16, },
+			},
+		},
+		[342] = { name = "Birth Island",
+			[RouteData.EncounterArea.STATIC] = {
+				{ pokemonID = 386, rate = 1.00, minLv = 30, maxLv = 30, },
+			},
+		},
+		[345] = { name = "Navel Rock Summit",
+			[RouteData.EncounterArea.STATIC] = {
+				{ pokemonID = 250, rate = 1.00, minLv = 70, maxLv = 70, },
+			},
+		},
+		[346] = { name = "Navel Rock Base",
+			[RouteData.EncounterArea.STATIC] = {
+				{ pokemonID = 249, rate = 1.00, minLv = 70, maxLv = 70, },
+			},
+		},
+		[362] = { name = "Rixy Chamber",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 201, rate = 1.00, minLv = 25, maxLv = 25, },
+			},
+		},
+		[363] = { name = "Viapois Chamber",
+			[RouteData.EncounterArea.LAND] = {
+				{ pokemonID = 201, rate = 1.00, minLv = 25, maxLv = 25, },
+			},
+		},
 	}
 
-	return 292 -- max mapId
+	return 363 -- max mapId
 end
-
--- Blank set for copy-paste
--- [nil] = { name = "nil",
--- 	[RouteData.EncounterArea.LAND] = {
--- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
--- 		{ pokemonID = {nil,nil}, rate = 0.00, minLv = nil, maxLv = nil, },
--- 	},
--- 	[RouteData.EncounterArea.SURFING] = {
--- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
--- 		{ pokemonID = {nil,nil}, rate = 0.00, minLv = nil, maxLv = nil, },
--- 	},
--- 	[RouteData.EncounterArea.OLDROD] = {
--- 		{ pokemonID = 129, rate = 1.00, minLv = 5, maxLv = 5, },
--- 	},
--- 	[RouteData.EncounterArea.GOODROD] = {
--- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
--- 		{ pokemonID = {nil,nil}, rate = 0.00, minLv = nil, maxLv = nil, },
--- 	},
--- 	[RouteData.EncounterArea.SUPERROD] = {
--- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
--- 		{ pokemonID = {nil,nil}, rate = 0.00, minLv = nil, maxLv = nil, },
--- 	},
--- 	[RouteData.EncounterArea.ROCKSMASH] = {
--- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
--- 		{ pokemonID = {nil,nil}, rate = 0.00, minLv = nil, maxLv = nil, },
--- 	},
--- 	[RouteData.EncounterArea.STATIC] = {
--- 		{ pokemonID = nil, rate = 0.00, minLv = nil, maxLv = nil, },
--- 	},
--- },
 
 -- https://github.com/pret/pokeemerald/blob/677b4fc394516deab5b5c86c94a2a1443cb52151/include/constants/layouts.h
 -- https://www.serebii.net/pokearth/hoenn/3rd/route101.shtml

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -311,8 +311,12 @@ function TrackerScreen.buildCarousel()
 			local routeEncounters = Tracker.getRouteEncounters(Battle.CurrentRoute.mapId, Battle.CurrentRoute.encounterArea)
 			local totalSeen = #routeEncounters
 
-			TrackerScreen.Buttons.RouteSummary.text = Battle.CurrentRoute.encounterArea .. ": Seen " .. totalSeen .. "/" .. totalPossible .. " " .. Constants.Words.POKEMON
-
+			if Battle.CurrentRoute.encounterArea == RouteData.EncounterArea.ROCKSMASH then
+				TrackerScreen.Buttons.RouteSummary.text = "Rock Smash: " .. totalSeen .. "/" .. totalPossible .. " " .. Constants.Words.POKEMON
+			else
+				TrackerScreen.Buttons.RouteSummary.text = Battle.CurrentRoute.encounterArea .. ": Seen " .. totalSeen .. "/" .. totalPossible .. " " .. Constants.Words.POKEMON
+			end
+			
 			return { TrackerScreen.Buttons.RouteSummary } 
 		end,
 	}


### PR DESCRIPTION
Resolves #191 
- Adds a bunch of data for the Sevii Isles routes/locations for wild pokemon (and empty encounter tables for future trainer info)
- Adds a check to distinguish rock smash encounters using `GAME_STATS_USED_ROCK_SMASH` (to tell a rock has been smashed) and `gSpecialVar_Result` (which stores the result of the wild encounter roll)
- Adds in map IDs for Celadon Game Corner (for the rocket grunt) and the rooms on-board the SS Anne
