### PR TITLE
add new game check for trainer id

### DIFF
--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -158,7 +158,7 @@ function Program.updatePokemonTeams()
 
 			if Program.validPokemonData(newPokemonData) then
 				-- Sets the player's trainerID as soon as they get their first Pokemon
-				if Tracker.Data.isNewGame and (newPokemonData.trainerID ~= nil or newPokemonData.trainerID ~= 0) then
+				if Tracker.Data.isNewGame and newPokemonData.trainerID ~= nil and newPokemonData.trainerID ~= 0 then
 					if Tracker.Data.trainerID == nil or Tracker.Data.trainerID == 0 then
 						Tracker.Data.trainerID = newPokemonData.trainerID
 					elseif Tracker.Data.trainerID ~= newPokemonData.trainerID then
@@ -168,12 +168,12 @@ function Program.updatePokemonTeams()
 						Tracker.Data.trainerID = newPokemonData.trainerID
 					end
 
-					-- Remove trainerID value from the pokemon data itself since it's now owned by the player, saves data space
-					newPokemonData.trainerID = nil
-
 					-- Unset the new game flag
 					Tracker.Data.isNewGame = false
 				end
+
+				-- Remove trainerID value from the pokemon data itself since it's now owned by the player, saves data space
+				newPokemonData.trainerID = nil
 
 				Tracker.addUpdatePokemon(newPokemonData, personality, true)
 			end

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -418,6 +418,7 @@ function Tracker.resetData()
 		},
 		gameStatsFishing = Utils.getGameStat(Constants.GAME_STATS.FISHING_CAPTURES), -- Tally of fishing encounters, to track when one occurs
 		gameStatsRockSmash = Utils.getGameStat(Constants.GAME_STATS.USED_ROCK_SMASH), -- Tally of rock smash uses, to track encounters
+		isNewGame = true, -- Flag for new game, to check if stored trainerID is correct
 	}
 end
 


### PR DESCRIPTION
Addition to help with #186 (if not a full solution)

Adds in a new game flag for checking trainer ID. The linked issue is usually due to reloading a rom that has the same rom hash as the one that was already open (re-randomising the seed changes this rom hash usually from what i saw) so this mainly covers if you reload the current rom to begin a new game (for example maybe you want a new vanilla playthrough instead)

The process by which this works is as follows:

- Store a `isNewGame` flag in `Tracker.Data` and initialise to true by default if no tracker data loaded (i.e. rom hash alone has determined that it's a different rom)
- If `isNewGame` is false then check if player currently has any pokemon in the current party (i.e. if there's any pokemon in `Tracker.Data.ownTeam`)
  - If there are no pokemon in the current party then set `isNewGame` to true
- If `isNewGame` is true when the player has a valid pokemon, then read the trainer id as we currently do
  - If the trainer id in the current tracker data is 0 or nil (from data reset) then set the newly read trainer id as the trainer id as is currently done
  - If the newly read trainer id is different to the one stored currently in `Tracker.Data` (i.e. old data has been loaded in) then reset the tracker data. After the reset then set the trainer id to the newly read id.
- Once we set a trainer id from the last step, set `isNewGame` to false

This just expands upon the existing trainer id check to set a trainer id so no additional memory reads

The only time this should reset the tracker data outside of how it's currently being reset is if the trainer id we read is different to the one that's currently stored while the `isNewGame` flag is set to true, so should avoid accidental deletion of data.

EDIT: a possible scenario in which this would fail is if the tracker is loaded up mid-game with no tracker data to load, and the pokemon in the first slot of the party is a traded pokemon with a different trainer id. As such the better workaround may be to just rework [reading trainer id from `gSaveBlock2`](https://github.com/besteon/Ironmon-Tracker/issues/186#issuecomment-1214878898) instead in a way that minimises how much we make the reads / minimises performance impact