### PR TITLE
Feature: Adding option to disable carousel on the main Tracker screen

### DIFF
--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -85,7 +85,7 @@ Constants.OrderedLists = {
 		"spe",
 	},
 	OPTIONS = {
-		"Show tips on startup",
+		"Disable mainscreen carousel",
 		"Auto swap to enemy",
 		"Hide stats until summary shown",
 		"Right justified numbers",
@@ -119,7 +119,7 @@ Constants.OrderedLists = {
 		"Lower box background",
 		"Main background",
 	},
-	TIPS = {
+	TIPS = { -- currently disabled, may use later
 		"Helpful tips are shown down here.", -- Skipped after it's shown once
 		"Tracked data is auto-saved after every battle.",
 		"Switch " .. Constants.Words.POKEMON .. " views by pressing the 'Start' button.", -- referenced by Options.initialize()

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -6,7 +6,7 @@ Options = {
 	ROMS_FOLDER = "",
 
 	-- 'Default' set of Options, but will get replaced by what's in Settings.ini
-	["Show tips on startup"] = true,
+	["Disable mainscreen carousel"] = false,
 	["Auto swap to enemy"] = true,
 	["Hide stats until summary shown"] = false,
 	["Right justified numbers"] = false,

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -6,8 +6,8 @@ SetupScreen = {
 }
 
 SetupScreen.OptionKeys = {
-	"Show tips on startup",
 	"Right justified numbers",
+	"Disable mainscreen carousel",
 	"Track PC Heals",
 	"PC heals count downward",
 	"Animated Pokemon popout",

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -251,7 +251,7 @@ function TrackerScreen.buildCarousel()
 	-- NOTES
 	TrackerScreen.CarouselItems[TrackerScreen.CarouselTypes.NOTES] = {
 		type = TrackerScreen.CarouselTypes.NOTES,
-		isVisible = function() return not Tracker.Data.isViewingOwn or (Options["Show tips on startup"] and Tracker.getPokemon(1, true) == nil) end,
+		isVisible = function() return not Tracker.Data.isViewingOwn end, --or (Tracker.getPokemon(1, true) == nil) end, -- add in later for tracked data loaded info
 		framesToShow = 180,
 		getContentList = function(pokemon)
 			-- If the player doesn't have a Pokemon, display something else useful instead
@@ -272,7 +272,7 @@ function TrackerScreen.buildCarousel()
 	TrackerScreen.CarouselItems[TrackerScreen.CarouselTypes.LAST_ATTACK] = {
 		type = TrackerScreen.CarouselTypes.LAST_ATTACK,
 		-- Don't show the last attack information while the enemy is attacking, or it spoils the move & damage
-		isVisible = function() return Options["Show last damage calcs"] and Battle.inBattle and not Battle.enemyHasAttacked and Battle.lastEnemyMoveId ~= 0 end,
+		isVisible = function() return (not Tracker.Data.isViewingOwn or not Options["Disable mainscreen carousel"]) and Options["Show last damage calcs"] and Battle.inBattle and not Battle.enemyHasAttacked and Battle.lastEnemyMoveId ~= 0 end,
 		framesToShow = 180,
 		getContentList = function()
 			local lastAttackMsg
@@ -303,7 +303,7 @@ function TrackerScreen.buildCarousel()
 	-- ROUTE INFO
 	TrackerScreen.CarouselItems[TrackerScreen.CarouselTypes.ROUTE_INFO] = {
 		type = TrackerScreen.CarouselTypes.ROUTE_INFO,
-		isVisible = function() return Battle.inBattle and Battle.CurrentRoute.hasInfo end,
+		isVisible = function() return (not Tracker.Data.isViewingOwn or not Options["Disable mainscreen carousel"]) and Battle.inBattle and Battle.CurrentRoute.hasInfo end,
 		framesToShow = 180,
 		getContentList = function(pokemon)
 			local routeInfo = RouteData.Info[Battle.CurrentRoute.mapId]
@@ -320,14 +320,6 @@ function TrackerScreen.buildCarousel()
 			return { TrackerScreen.Buttons.RouteSummary } 
 		end,
 	}
-
-	-- Easter Egg for the "-69th" seed
-	if Options["Show tips on startup"] then
-		local romnumber = string.match(gameinfo.getromname(), '[0-9]+')
-		if romnumber ~= nil and romnumber ~= "" and romnumber:sub(-2) == "69" then
-			table.insert(Constants.OrderedLists.TIPS, "This seed ends in 69. Nice.")
-		end
-	end
 end
 
 -- Returns the current visible carousel. If unavailable, looks up the next visible carousel
@@ -345,7 +337,7 @@ function TrackerScreen.getCurrentCarouselItem()
 		Program.Frames.carouselActive = 0
 
 		-- When carousel switches to the Notes display, prepare the next tip message to display
-		if nextCarousel ~= carousel and TrackerScreen.carouselIndex == TrackerScreen.CarouselTypes.NOTES and Options["Show tips on startup"] then
+		if false and nextCarousel ~= carousel and TrackerScreen.carouselIndex == TrackerScreen.CarouselTypes.NOTES then -- currently disabled, will use later
 			local numTips = #Constants.OrderedLists.TIPS
 			if TrackerScreen.tipMessageIndex == numTips then
 				TrackerScreen.tipMessageIndex = 2 -- Skip "helpful tip" message if that's next up


### PR DESCRIPTION
There have been a few requests to be able to further disable the carousel from changing the screen. Notably, the main tracker screen with the badges. Any movement there is very distracting. This feature includes an option for that.

I've also removed startup tips since, well, after several users tested it, they weren't really doing what I had hoped.