### PR TITLE
Quick-load error updates and ability crash fix

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -285,8 +285,8 @@ function Main.GenerateNextRom()
 
 	-- If something went wrong and the ROM wasn't generated to the ROM path
 	if not Main.FileExists(nextrompath) then
-		print("Failed to generate a new ROM.")
-		Main.DisplayError("Failed to generate a new ROM.\n\nFix required files: Tracker Settings (gear icon) -> Tracker Setup -> Quick-load")
+		print("The Randomizer ZX program failed to generate a ROM.")
+		Main.DisplayError("The Randomizer ZX program failed to generate a ROM.\n\nThis is likely because you need to install \"Java 64-bit Offline.\"")
 		return nil
 	end
 

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -574,3 +574,17 @@ function Utils.extractFileNameFromPath(path)
 
 	return ""
 end
+
+function Utils.extractFileExtensionFromPath(path)
+	if path == nil or path == "" then return "" end
+
+	local extStartIndex = path:match("^.*()%.") -- file extension
+	if extStartIndex ~= nil then
+		local extension = path:sub(extStartIndex + 1)
+		if extension ~= nil then
+			return extension:lower()
+		end
+	end
+
+	return ""
+end

--- a/ironmon_tracker/screens/QuickloadScreen.lua
+++ b/ironmon_tracker/screens/QuickloadScreen.lua
@@ -158,11 +158,15 @@ function QuickloadScreen.handleSetRandomizerJar(button)
 
 	local file = forms.openfile("SELECT JAR", path, filterOptions)
 	if file ~= "" then
-		-- TODO: Maybe have a check to verify a JAR file was actually selected?
-		Options.FILES[button.labelText] = file
-		button.isSet = true
-		button.text = "Clear"
-		Options.forceSave()
+		local extension = Utils.extractFileExtensionFromPath(file)
+		if extension == "jar" then
+			Options.FILES[button.labelText] = file
+			button.isSet = true
+			button.text = "Clear"
+			Options.forceSave()
+		else
+			Main.DisplayError("The file selected is not the Randomizer JAR file.\n\nPlease select the JAR file in the Randomizer ZX folder.")
+		end
 	end
 end
 
@@ -172,13 +176,15 @@ function QuickloadScreen.handleSetSourceRom(button)
 
 	local file = forms.openfile("SELECT A ROM", path, filterOptions)
 	if file ~= "" then
-		-- TODO: Maybe have a check to verify a GBA file was actually selected?
-		Options.FILES[button.labelText] = file
-		button.isSet = true
-		button.text = "Clear"
-
-		-- Save these changes to the file to avoid case where user resets before clicking the Back button
-		Options.forceSave()
+		local extension = Utils.extractFileExtensionFromPath(file)
+		if extension == "gba" then
+			Options.FILES[button.labelText] = file
+			button.isSet = true
+			button.text = "Clear"
+			Options.forceSave()
+		else
+			Main.DisplayError("The file selected is not a GBA ROM file.\n\nPlease select a GBA file: has the file extension \".gba\"")
+		end
 	end
 end
 
@@ -197,13 +203,15 @@ function QuickloadScreen.handleSetCustomSettings(button)
 
 	local file = forms.openfile("SELECT RNQS", path, filterOptions)
 	if file ~= "" then
-		-- TODO: Maybe have a check to verify a RNQS file was actually selected?
-		Options.FILES[button.labelText] = file
-		button.isSet = true
-		button.text = "Clear"
-
-		-- Save these changes to the file to avoid case where user resets before clicking the Back button
-		Options.forceSave()
+		local extension = Utils.extractFileExtensionFromPath(file)
+		if extension == "rnqs" then
+			Options.FILES[button.labelText] = file
+			button.isSet = true
+			button.text = "Clear"
+			Options.forceSave()
+		else
+			Main.DisplayError("The file selected is not a Randomier Settings file.\n\nPlease select an RNQS file: has the file extension \".rnqs\"")
+		end
 	end
 end
 

--- a/ironmon_tracker/screens/QuickloadScreen.lua
+++ b/ironmon_tracker/screens/QuickloadScreen.lua
@@ -210,7 +210,7 @@ function QuickloadScreen.handleSetCustomSettings(button)
 			button.text = "Clear"
 			Options.forceSave()
 		else
-			Main.DisplayError("The file selected is not a Randomier Settings file.\n\nPlease select an RNQS file: has the file extension \".rnqs\"")
+			Main.DisplayError("The file selected is not a Randomizer Settings file.\n\nPlease select an RNQS file: has the file extension \".rnqs\"")
 		end
 	end
 end

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -95,7 +95,7 @@ TrackerScreen.Buttons = {
 			if not self:isVisible() then return end
 			if not RouteData.hasRouteEncounterArea(Battle.CurrentRoute.mapId, Battle.CurrentRoute.encounterArea) then return end
 
-			local routeInfo = { 
+			local routeInfo = {
 				mapId = Battle.CurrentRoute.mapId,
 				encounterArea = Battle.CurrentRoute.encounterArea,
 			}
@@ -112,13 +112,10 @@ TrackerScreen.Buttons = {
 		onClick = function(self)
 			if not self:isVisible() then return end
 			local pokemon = Tracker.getViewedPokemon()
-			local pokemonID = 0
-			local trackedAbilities = {}
 			if pokemon ~= nil then
-				pokemonID = pokemon.pokemonID
+				local trackedAbilities = Tracker.getAbilities(pokemon.pokemonID)
+				InfoScreen.changeScreenView(InfoScreen.Screens.ABILITY_INFO, trackedAbilities[1].id)
 			end
-			local trackedAbilities = Tracker.getAbilities(pokemon.pokemonID)
-			InfoScreen.changeScreenView(InfoScreen.Screens.ABILITY_INFO, trackedAbilities[1].id)
 		end
 	},
 	AbilityLower = {
@@ -131,18 +128,15 @@ TrackerScreen.Buttons = {
 		onClick = function(self)
 			if not self:isVisible() then return end
 			local pokemon = Tracker.getViewedPokemon()
-			local pokemonID = 0
-			local abilityNum = 0
 			if pokemon ~= nil then
-				pokemonID = pokemon.pokemonID
-				abilityNum = pokemon.abilityNum
-			end
-			if Tracker.Data.isViewingOwn then
-				local abilityId = PokemonData.getAbilityId(pokemonID, abilityNum)
+				local abilityId
+				if Tracker.Data.isViewingOwn then
+					abilityId = PokemonData.getAbilityId(pokemon.pokemonID, pokemon.abilityNum)
+				else
+					local trackedAbilities = Tracker.getAbilities(pokemon.pokemonID)
+					abilityId = trackedAbilities[2].id
+				end
 				InfoScreen.changeScreenView(InfoScreen.Screens.ABILITY_INFO, abilityId)
-			else
-				local trackedAbilities = Tracker.getAbilities(pokemonID)
-				InfoScreen.changeScreenView(InfoScreen.Screens.ABILITY_INFO, trackedAbilities[2].id)
 			end
 		end
 	},
@@ -185,7 +179,7 @@ TrackerScreen.Buttons = {
 		isVisible = function() return TrackerScreen.carouselIndex == TrackerScreen.CarouselTypes.ROUTE_INFO end,
 		onClick = function(self)
 			if not self:isVisible() then return end
-			local routeInfo = { 
+			local routeInfo = {
 				mapId = Battle.CurrentRoute.mapId,
 				encounterArea = Battle.CurrentRoute.encounterArea,
 			}
@@ -328,7 +322,7 @@ function TrackerScreen.buildCarousel()
 			end
 
 			TrackerScreen.Buttons.LastAttackSummary.text = lastAttackMsg
-			return { TrackerScreen.Buttons.LastAttackSummary } 
+			return { TrackerScreen.Buttons.LastAttackSummary }
 		end,
 	}
 
@@ -348,8 +342,8 @@ function TrackerScreen.buildCarousel()
 			else
 				TrackerScreen.Buttons.RouteSummary.text = Battle.CurrentRoute.encounterArea .. ": Seen " .. totalSeen .. "/" .. totalPossible .. " " .. Constants.Words.POKEMON
 			end
-			
-			return { TrackerScreen.Buttons.RouteSummary } 
+
+			return { TrackerScreen.Buttons.RouteSummary }
 		end,
 	}
 end
@@ -636,7 +630,7 @@ function TrackerScreen.drawPokemonInfoArea(pokemon)
 			-- Auto-tracking PC Heals button
 			Drawing.drawButton(TrackerScreen.Buttons.PCHealAutoTracking, shadowcolor)
 		end
-	elseif Battle.inBattle then 
+	elseif Battle.inBattle then
 		-- For now, only show route info while in Battle; later find a way to alway show
 		local routeName = Constants.BLANKLINE
 		if RouteData.hasRoute(Battle.CurrentRoute.mapId) then


### PR DESCRIPTION
Changing up some of the error messages for the quick-load feature to be more clear, especially for the case of the user missing 64-bit java.

Also fixing a weird bug where clicking the ability area before a game starts causes a tracker crash.