### PR TITLE
Bugs: Last Damage inaccuracy and Stat reveal during evo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ Settings.ini
 *.tdat
 *.gba
 *.log
+*Attempts.txt
 ironmon_tracker/images/pokemonAnimated/*.gif

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -1,4 +1,4 @@
-Main = { TrackerVersion = "0.6.2b" } -- The latest version of the tracker. Should be updated with each PR.
+Main = { TrackerVersion = "0.6.2c" } -- The latest version of the tracker. Should be updated with each PR.
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -191,8 +191,8 @@ function Main.LoadNextRom()
 	elseif Options["Generate ROM each time"] then
 		nextRom = Main.GenerateNextRom()
 	else
-		print("ERROR: Quick-load feature is currently disabled.")
-		Main.DisplayError("Quick-load feature is currently disabled.\n\nEnable this at: Tracker Settings (gear icon) -> Tracker Setup -> Quick-load")
+		print("ERROR: The Quick-load feature is currently disabled.")
+		Main.DisplayError("The Quick-load feature is currently disabled.\n\nEnable this at: Tracker Settings (gear icon) -> Tracker Setup -> Quick-load")
 	end
 
 	if nextRom ~= nil then
@@ -217,8 +217,8 @@ function Main.GetNextRomFromFolder()
 	print("Attempting to load next ROM in sequence from ROMs Folder...")
 
 	if Options.FILES["ROMs Folder"] == nil or Options.FILES["ROMs Folder"] == "" then
-		print("ERROR: ROMs Folder unspecified\n")
-		Main.DisplayError("ROMs Folder unspecified.\n\nFix this at: Tracker Settings (gear icon) -> Tracker Setup -> Quick-load")
+		print("ERROR: Either the ROMs Folder is incorrect, or current loaded ROM is not in that folder.\n")
+		Main.DisplayError("Either the ROMs Folder is incorrect, or current loaded ROM is not in that folder.\n\nFix this at: Tracker Settings (gear icon) -> Tracker Setup -> Quick-load")
 		return nil
 	end
 
@@ -244,7 +244,7 @@ function Main.GetNextRomFromFolder()
 		nextrompath = Options.FILES["ROMs Folder"] .. "/" .. nextromname .. ".gba"
 		if not Main.FileExists(nextrompath) then
 			-- This means there doesn't exist a ROM file with spaces or underscores
-			print("ERROR: Next ROM not found\n")
+			print("Unable to find next ROM: " .. nextromname .. ".gba\n")
 			Main.DisplayError("Unable to find next ROM: " .. nextromname .. ".gba\n\nMake sure your ROMs are numbered and the ROMs folder is correct.")
 			return nil
 		end
@@ -278,10 +278,6 @@ function Main.GenerateNextRom()
 		nextrompath
 	)
 
-	-- TODO:: work out how to read after performing the return
-	--   Zac: Unsure if any change needs to happen here, works for me
-	-- if we can do that, we can generate a new seed whilst the current seed is loading
-	-- if we can do that, earlier logic to delete would change to delete + rename next seed to current
 	print("Generating next ROM: " .. nextromname)
 	local pipe = io.popen(javacommand)
 	local output = pipe:read("*all")

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -1,4 +1,4 @@
-Main = { TrackerVersion = "0.6.1c" } -- The latest version of the tracker. Should be updated with each PR.
+Main = { TrackerVersion = "0.6.2" } -- The latest version of the tracker. Should be updated with each PR.
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -1,4 +1,4 @@
-Main = { TrackerVersion = "0.6.2a" } -- The latest version of the tracker. Should be updated with each PR.
+Main = { TrackerVersion = "0.6.2b" } -- The latest version of the tracker. Should be updated with each PR.
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",
@@ -185,10 +185,14 @@ end
 function Main.LoadNextRom()
 	console.clear() -- Clearing the console for each new game helps with troubleshooting issues
 
+	local wasSoundOn = client.GetSoundOn()
+
 	local nextRom
 	if Options["Use premade ROMs"] then
+		client.SetSoundOn(false)
 		nextRom = Main.GetNextRomFromFolder()
 	elseif Options["Generate ROM each time"] then
+		client.SetSoundOn(false)
 		nextRom = Main.GenerateNextRom()
 	else
 		print("ERROR: The Quick-load feature is currently disabled.")
@@ -198,15 +202,16 @@ function Main.LoadNextRom()
 	if nextRom ~= nil then
 		Tracker.resetData()
 		print("New ROM \"" .. nextRom.name .. "\" is ready to load. Tracker data has been reset.")
-		local wasSoundOn = client.GetSoundOn()
-		client.SetSoundOn(false)
 		if client.getversion() ~= "2.9" then
 			client.closerom() -- This appears to not be needed for Bizhawk 2.9+
 		end
 		client.openrom(nextRom.path)
-		client.SetSoundOn(wasSoundOn)
 	else
 		print("\n--- Unable to Quick-load a new ROM, reloading previous ROM.")
+	end
+
+	if client.GetSoundOn() ~= wasSoundOn then
+		client.SetSoundOn(wasSoundOn)
 	end
 
 	Main.loadNextSeed = false

--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ We'd ideally like to support all non-English versions if we can, see [here](http
 
 ## Latest Changes
 
-- **_NEW!!_ Animated Pokémon Popout, Support for Randomized Pokémon Types & Moves (try it!)**
+- **_NEW!!_ Ability Info Look-up, and Quick-Load Reset can now automatically randomize a ROM for you!**
 
-![image](https://user-images.githubusercontent.com/4258818/184241184-77186359-247e-422c-ace3-3cd4bf905bf5.png)
-![image](https://user-images.githubusercontent.com/4258818/183508785-68ac2986-80c3-4f4a-85ee-b21e260450bf.png)
+![image](https://user-images.githubusercontent.com/4258818/186506615-bfa9da6a-deaf-46b1-83e5-0667995b610e.png)
 
 See the project's Wiki for a full [version changelog](https://github.com/besteon/Ironmon-Tracker/wiki/Version-Changelog).
 

--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -347,6 +347,9 @@ function Battle.beginNewBattle()
 	-- If this is a new battle, reset views and other pokemon tracker info
 	Battle.inBattle = true
 	Battle.turnCount = 0
+	Battle.prevDamageTotal = 0
+	Battle.damageReceived = 0
+	Battle.enemyHasAttacked = false
 	Battle.Synchronize.turnCount = 0
 	Battle.Synchronize.attacker = -1
 	Battle.Synchronize.battlerTarget = -1


### PR DESCRIPTION
This fixes two recent issues. One is seen when you begin a battle and the info stored about that last battle doesnt get cleared out. The other bug is that the tracker reveals information about an evolved pokemon while learning a move, giving you information you shouldnt have yet; you dont have access to the summary screen.