### PR TITLE
Make evolution / next learned move stand out more, add stone evos

### DIFF
--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -119,9 +119,9 @@ function Program.update()
 		end
 	end
 
-	-- Only update "Heals in Bag", "PC Heals", and "Badge Data" info every 3 seconds (3 seconds * 60 frames/sec)
+	-- Only update "Heals in Bag", Evolution Stones, "PC Heals", and "Badge Data" info every 3 seconds (3 seconds * 60 frames/sec)
 	if Program.Frames.three_sec_update == 0 then
-		Program.updateBagHealingItems()
+		Program.updateBagItems()
 		Program.updatePCHeals()
 		Program.updateBadgesObtained()
 	end
@@ -487,19 +487,22 @@ function Program.validPokemonData(pokemonData)
 	return true
 end
 
-function Program.updateBagHealingItems()
+function Program.updateBagItems()
 	if not Tracker.Data.isViewingOwn then return end
 
 	local leadPokemon = Tracker.getPokemon(Tracker.Data.ownViewSlot, true)
 	if leadPokemon ~= nil then
-		local healingItems = Program.calcBagHealingItems(leadPokemon.stats.hp)
+		local healingItems, evolutionStones = Program.getBagItems()
 		if healingItems ~= nil then
-			Tracker.Data.healingItems = healingItems
+			Tracker.Data.healingItems = Program.calcBagHealingItems(leadPokemon.stats.hp, healingItems)
+		end
+		if evolutionStones ~= nil then
+			Tracker.Data.evolutionStones = evolutionStones
 		end
 	end
 end
 
-function Program.calcBagHealingItems(pokemonMaxHP)
+function Program.calcBagHealingItems(pokemonMaxHP, healingItemsInBag)
 	local totals = {
 		healing = 0,
 		numHeals = 0,
@@ -511,12 +514,6 @@ function Program.calcBagHealingItems(pokemonMaxHP)
 	end
 
 	-- Formatted as: healingItemsInBag[itemID] = quantity
-	local healingItemsInBag = Program.getHealingItems()
-	if healingItemsInBag == nil then
-		return totals
-	end
-
-	-- for _, item in pairs(MiscData.healingItems) do
 	for itemID, quantity in pairs(healingItemsInBag) do
 		local healItemData = MiscData.HealingItems[itemID]
 		if healItemData ~= nil and quantity > 0 then
@@ -539,11 +536,17 @@ function Program.calcBagHealingItems(pokemonMaxHP)
 	return totals
 end
 
-function Program.getHealingItems()
-	-- I believe this key has to be looked-up each time, as the ptr changes periodically
-	local key = Utils.getEncryptionKey(2) -- Want a 16-bit key
-
+function Program.getBagItems()
 	local healingItems = {}
+	local evoStones = {
+		[93] = 0, -- Sun Stone
+		[94] = 0, -- Moon Stone
+		[95] = 0, -- Fire Stone
+		[96] = 0, -- Thunder Stone
+		[97] = 0, -- Water Stone
+		[98] = 0, -- Leaf Stone
+	}
+
 	local saveBlock1Addr = Utils.getSaveBlock1Addr()
 	local addressesToScan = {
 		[saveBlock1Addr + GameSettings.bagPocket_Items_offset] = GameSettings.bagPocket_Items_Size,
@@ -554,13 +557,19 @@ function Program.getHealingItems()
 			--read 4 bytes at once, should be less expensive than reading two sets of 2 bytes.
 			local itemid_and_quantity = Memory.readdword(address + i * 0x4)
 			local itemID = Utils.getbits(itemid_and_quantity, 0, 16)
-			if itemID ~= 0 and MiscData.HealingItems[itemID] ~= nil then
+			if itemID ~= 0 then
 				local quantity = Utils.getbits(itemid_and_quantity, 16, 16)
+				local key = Utils.getEncryptionKey(2) -- Want a 16-bit key
 				if key ~= nil then quantity = bit.bxor(quantity, key) end
-				healingItems[itemID] = quantity
+
+				if MiscData.HealingItems[itemID] ~= nil then
+					healingItems[itemID] = quantity
+				elseif MiscData.evolutionStones[itemID] ~= nil then
+					evoStones[itemID] = quantity
+				end
 			end
 		end
 	end
-
-	return healingItems
+	
+	return healingItems, evoStones
 end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -26,6 +26,17 @@ Program.Screens = {
 	MANAGE_DATA = TrackedDataScreen.drawScreen,
 }
 
+Program.GameData = {
+	evolutionStones = { -- The evolution stones currently in bag
+			[93] = 0, -- Sun Stone
+			[94] = 0, -- Moon Stone
+			[95] = 0, -- Fire Stone
+			[96] = 0, -- Thunder Stone
+			[97] = 0, -- Water Stone
+			[98] = 0, -- Leaf Stone
+	},
+}
+
 function Program.initialize()
 	Program.currentScreen = Program.Screens.TRACKER
 
@@ -497,7 +508,7 @@ function Program.updateBagItems()
 			Tracker.Data.healingItems = Program.calcBagHealingItems(leadPokemon.stats.hp, healingItems)
 		end
 		if evolutionStones ~= nil then
-			Tracker.Data.evolutionStones = evolutionStones
+			Program.GameData.evolutionStones = evolutionStones
 		end
 	end
 end
@@ -564,7 +575,7 @@ function Program.getBagItems()
 
 				if MiscData.HealingItems[itemID] ~= nil then
 					healingItems[itemID] = quantity
-				elseif MiscData.evolutionStones[itemID] ~= nil then
+				elseif MiscData.EvolutionStones[itemID] ~= nil then
 					evoStones[itemID] = quantity
 				end
 			end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -547,6 +547,7 @@ function Program.getBagItems()
 		[98] = 0, -- Leaf Stone
 	}
 
+	local key = Utils.getEncryptionKey(2) -- Want a 16-bit key
 	local saveBlock1Addr = Utils.getSaveBlock1Addr()
 	local addressesToScan = {
 		[saveBlock1Addr + GameSettings.bagPocket_Items_offset] = GameSettings.bagPocket_Items_Size,
@@ -559,7 +560,6 @@ function Program.getBagItems()
 			local itemID = Utils.getbits(itemid_and_quantity, 0, 16)
 			if itemID ~= 0 then
 				local quantity = Utils.getbits(itemid_and_quantity, 16, 16)
-				local key = Utils.getEncryptionKey(2) -- Want a 16-bit key
 				if key ~= nil then quantity = bit.bxor(quantity, key) end
 
 				if MiscData.HealingItems[itemID] ~= nil then

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -434,6 +434,14 @@ function Tracker.resetData()
 		gameStatsFishing = Utils.getGameStat(Constants.GAME_STATS.FISHING_CAPTURES), -- Tally of fishing encounters, to track when one occurs
 		gameStatsRockSmash = Utils.getGameStat(Constants.GAME_STATS.USED_ROCK_SMASH), -- Tally of rock smash uses, to track encounters
 		isNewGame = true, -- Flag for new game, to check if stored trainerID is correct
+		evolutionStones = { -- The evolution stones currently in bag
+			[93] = 0, -- Sun Stone
+			[94] = 0, -- Moon Stone
+			[95] = 0, -- Fire Stone
+			[96] = 0, -- Thunder Stone
+			[97] = 0, -- Water Stone
+			[98] = 0, -- Leaf Stone
+		},
 	}
 end
 

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -434,14 +434,6 @@ function Tracker.resetData()
 		gameStatsFishing = Utils.getGameStat(Constants.GAME_STATS.FISHING_CAPTURES), -- Tally of fishing encounters, to track when one occurs
 		gameStatsRockSmash = Utils.getGameStat(Constants.GAME_STATS.USED_ROCK_SMASH), -- Tally of rock smash uses, to track encounters
 		isNewGame = true, -- Flag for new game, to check if stored trainerID is correct
-		evolutionStones = { -- The evolution stones currently in bag
-			[93] = 0, -- Sun Stone
-			[94] = 0, -- Moon Stone
-			[95] = 0, -- Fire Stone
-			[96] = 0, -- Thunder Stone
-			[97] = 0, -- Water Stone
-			[98] = 0, -- Leaf Stone
-		},
 	}
 end
 

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -427,14 +427,14 @@ function Utils.isReadyToEvolveByStone(evoMethod)
 		return false
 	end
 
-	for itemID, quantity in pairs(Tracker.Data.evolutionStones) do
+	for itemID, quantity in pairs(Program.GameData.evolutionStones) do
 		-- Check through the possible evolutions with the stones available
 		if quantity > 0 then
 			-- Special check for the level/water stone evos
 			if itemID == 97 and evoMethod:match("(WTR)") ~= nil then
 				return true
 			end
-			for _, possibleEvolution in pairs(MiscData.evolutionStones[itemID].evolutions) do
+			for _, possibleEvolution in pairs(MiscData.EvolutionStones[itemID].evolutions) do
 				if possibleEvolution == evoMethod then
 					return true
 				end

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -166,12 +166,15 @@ function Utils.getMovesLearnedHeader(pokemonID, level)
 		end
 	end
 
-	local header = movesLearned .. "/" .. #allMoveLevels
+	local header = "Move ~ " .. movesLearned .. "/" .. #allMoveLevels
 	if foundNextMove then
+		local nextMoveSpacing = (string.len(header) + 3) * 4 + string.len(tostring(movesLearned)) + string.len(tostring(#allMoveLevels))
 		header = header .. " (" .. nextMoveLevel .. ")"
+		return header, nextMoveLevel, nextMoveSpacing
+	else
+		return header, nil, nil
 	end
 
-	return header
 end
 
 function Utils.getDetailedEvolutionsInfo(evoMethod)
@@ -414,6 +417,32 @@ function Utils.isReadyToEvolveByLevel(evoMethod, level)
 	evoMethod = tonumber(evoMethod:match("%d+")) -- Becomes nil if there's no numbers found
 
 	return evoMethod ~= nil and (level + 1) >= evoMethod
+end
+
+-- Checks if the player has a usable stone in their bag to evolve the pokémon
+function Utils.isReadyToEvolveByStone(evoMethod)
+	evoMethod = evoMethod or PokemonData.Evolutions.NONE
+
+	if evoMethod == PokemonData.Evolutions.NONE then
+		return false
+	end
+
+	for itemID, quantity in pairs(Tracker.Data.evolutionStones) do
+		-- Check through the possible evolutions with the stones available
+		if quantity > 0 then
+			-- Special check for the level/water stone evos
+			if itemID == 97 and evoMethod:match("(WTR)") ~= nil then
+				return true
+			end
+			for _, possibleEvolution in pairs(MiscData.evolutionStones[itemID].evolutions) do
+				if possibleEvolution == evoMethod then
+					return true
+				end
+			end
+		end
+	end
+
+	return false
 end
 
 -- Returns the text color for PC heal tracking

--- a/ironmon_tracker/data/MiscData.lua
+++ b/ironmon_tracker/data/MiscData.lua
@@ -328,7 +328,7 @@ MiscData.StatusItems = {
 	},
 }
 
-MiscData.evolutionStones = {
+MiscData.EvolutionStones = {
 	[93] = {
 		id = 93,
 		name = "Sun Stone",

--- a/ironmon_tracker/data/MiscData.lua
+++ b/ironmon_tracker/data/MiscData.lua
@@ -327,3 +327,42 @@ MiscData.StatusItems = {
 		pocket = MiscData.BagPocket.Berries,
 	},
 }
+
+MiscData.evolutionStones = {
+	[93] = {
+		id = 93,
+		name = "Sun Stone",
+		evolutions = {PokemonData.Evolutions.SUN, PokemonData.Evolutions.LEAF_SUN, PokemonData.Evolutions.STONES},
+		pocket = MiscData.BagPocket.Items,
+	},
+	[94] = {
+		id = 94,
+		name = "Moon Stone",
+		evolutions = {PokemonData.Evolutions.MOON, PokemonData.Evolutions.STONES},
+		pocket = MiscData.BagPocket.Items,
+	},
+	[95] = {
+		id = 95,
+		name = "Fire Stone",
+		evolutions = {PokemonData.Evolutions.FIRE, PokemonData.Evolutions.STONES},
+		pocket = MiscData.BagPocket.Items,
+	},
+	[96] = {
+		id = 96,
+		name = "Thunder Stone",
+		evolutions = {PokemonData.Evolutions.THUNDER, PokemonData.Evolutions.STONES},
+		pocket = MiscData.BagPocket.Items,
+	},
+	[97] = {
+		id = 97,
+		name = "Water Stone",
+		evolutions = {PokemonData.Evolutions.WATER, PokemonData.Evolutions.STONES},
+		pocket = MiscData.BagPocket.Items,
+	},
+	[98] = {
+		id = 98,
+		name = "Leaf Stone",
+		evolutions = {PokemonData.Evolutions.LEAF, PokemonData.Evolutions.LEAF_SUN},
+		pocket = MiscData.BagPocket.Items,
+	},
+}

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -560,7 +560,7 @@ function TrackerScreen.drawPokemonInfoArea(pokemon)
 	local levelEvoText = "Lv." .. pokemon.level .. " ("
 	local evoDetails = pokemon.evolution
 	local evoSpacing = pkmnStatOffsetX + string.len(levelEvoText) * 3 + string.len(pokemon.level) * 2
-	
+
 	-- Determine if evolution is possible/soon for own pokemon
 	local evoTextColor = Theme.COLORS["Default text"]
 	if Tracker.Data.isViewingOwn then
@@ -570,11 +570,11 @@ function TrackerScreen.drawPokemonInfoArea(pokemon)
 			evoDetails = "SOON"
 			evoTextColor = Theme.COLORS["Positive text"]
 		elseif evoDetails ~= Constants.BLANKLINE then
-			evoTextColor = Theme.COLORS["Negative text"]
+			evoTextColor = Theme.COLORS["Intermediate text"]
 		end
 	end
 	levelEvoText = levelEvoText .. evoDetails .. ")"
-	
+
 	-- DRAW POKEMON INFO
 	Drawing.drawText(Constants.SCREEN.WIDTH + pkmnStatOffsetX, pkmnStatStartY, pokemon.name, Theme.COLORS["Default text"], shadowcolor)
 	Drawing.drawText(Constants.SCREEN.WIDTH + pkmnStatOffsetX, pkmnStatStartY + (pkmnStatOffsetY * 1), "HP:", Theme.COLORS["Default text"], shadowcolor)
@@ -739,7 +739,7 @@ function TrackerScreen.drawMovesArea(pokemon, opposingPokemon)
 
 	-- Draw over next move level in header to indicate whether close to new move or not
 	if nextMoveLevel ~= nil and nextMoveSpacing ~= nil and Tracker.Data.isViewingOwn then
-		local nextMoveColor = Theme.COLORS["Negative text"]
+		local nextMoveColor = Theme.COLORS["Intermediate text"]
 		if pokemon.level + 1 >= nextMoveLevel then
 			nextMoveColor = Theme.COLORS["Positive text"]
 		end

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -557,24 +557,34 @@ function TrackerScreen.drawPokemonInfoArea(pokemon)
 		hpTextColor = Theme.COLORS["Intermediate text"]
 	end
 
-	-- If the evolution is happening soon (next level or friendship is ready, change font color)
-	local evoDetails = "(" .. pokemon.evolution .. ")"
-	local levelEvoTextColor = Theme.COLORS["Default text"]
+	local levelEvoText = "Lv." .. pokemon.level .. " ("
+	local evoDetails = pokemon.evolution
+	local evoSpacing = pkmnStatOffsetX + string.len(levelEvoText) * 3 + string.len(pokemon.level) * 2
+	
+	-- Determine if evolution is possible/soon for own pokemon
+	local evoTextColor = Theme.COLORS["Default text"]
 	if Tracker.Data.isViewingOwn then
-		if Utils.isReadyToEvolveByLevel(pokemon.evolution, pokemon.level) then
-			levelEvoTextColor = Theme.COLORS["Positive text"]
-		elseif pokemon.friendship >= Program.friendshipRequired and pokemon.evolution == PokemonData.Evolutions.FRIEND then
-			evoDetails = "(SOON)"
-			levelEvoTextColor = Theme.COLORS["Positive text"]
+		if Utils.isReadyToEvolveByLevel(evoDetails, pokemon.level) or Utils.isReadyToEvolveByStone(evoDetails) then
+			evoTextColor = Theme.COLORS["Positive text"]
+		elseif pokemon.friendship >= Program.friendshipRequired and evoDetails == PokemonData.Evolutions.FRIEND then
+			evoDetails = "SOON"
+			evoTextColor = Theme.COLORS["Positive text"]
+		elseif evoDetails ~= Constants.BLANKLINE then
+			evoTextColor = Theme.COLORS["Negative text"]
 		end
 	end
-	local levelEvoText = "Lv." .. pokemon.level .. " " .. evoDetails
-
+	levelEvoText = levelEvoText .. evoDetails .. ")"
+	
 	-- DRAW POKEMON INFO
 	Drawing.drawText(Constants.SCREEN.WIDTH + pkmnStatOffsetX, pkmnStatStartY, pokemon.name, Theme.COLORS["Default text"], shadowcolor)
 	Drawing.drawText(Constants.SCREEN.WIDTH + pkmnStatOffsetX, pkmnStatStartY + (pkmnStatOffsetY * 1), "HP:", Theme.COLORS["Default text"], shadowcolor)
 	Drawing.drawText(Constants.SCREEN.WIDTH + 52, pkmnStatStartY + (pkmnStatOffsetY * 1), hpText, hpTextColor, shadowcolor)
-	Drawing.drawText(Constants.SCREEN.WIDTH + pkmnStatOffsetX, pkmnStatStartY + (pkmnStatOffsetY * 2), levelEvoText, levelEvoTextColor, shadowcolor)
+	Drawing.drawText(Constants.SCREEN.WIDTH + pkmnStatOffsetX, pkmnStatStartY + (pkmnStatOffsetY * 2), levelEvoText, Theme.COLORS["Default text"], shadowcolor)
+
+	if Tracker.Data.isViewingOwn and evoDetails ~= Constants.BLANKLINE then
+		-- Draw over the evo method in the new color to reflect if evo is possible/soon
+		Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, pkmnStatStartY + (pkmnStatOffsetY * 2), evoDetails, evoTextColor, shadowcolor)
+	end
 
 	-- Tracker.Data.isViewingOwn and
 	if pokemon.status ~= MiscData.StatusType.None then
@@ -708,7 +718,7 @@ end
 function TrackerScreen.drawMovesArea(pokemon, opposingPokemon)
 	local shadowcolor = Utils.calcShadowColor(Theme.COLORS["Lower box background"])
 
-	local movesLearnedHeader = "Move ~  " .. Utils.getMovesLearnedHeader(pokemon.pokemonID, pokemon.level)
+	local movesLearnedHeader, nextMoveLevel, nextMoveSpacing = Utils.getMovesLearnedHeader(pokemon.pokemonID, pokemon.level)
 	local moveTableHeaderHeightDiff = 13
 	local moveOffsetY = 94
 
@@ -726,6 +736,15 @@ function TrackerScreen.drawMovesArea(pokemon, opposingPokemon)
 	Drawing.drawText(Constants.SCREEN.WIDTH + movePPOffset, moveOffsetY - moveTableHeaderHeightDiff, "PP", Theme.COLORS["Header text"], bgHeaderShadow)
 	Drawing.drawText(Constants.SCREEN.WIDTH + movePowerOffset, moveOffsetY - moveTableHeaderHeightDiff, "Pow", Theme.COLORS["Header text"], bgHeaderShadow)
 	Drawing.drawText(Constants.SCREEN.WIDTH + moveAccOffset, moveOffsetY - moveTableHeaderHeightDiff, "Acc", Theme.COLORS["Header text"], bgHeaderShadow)
+
+	-- Draw over next move level in header to indicate whether close to new move or not
+	if nextMoveLevel ~= nil and nextMoveSpacing ~= nil and Tracker.Data.isViewingOwn then
+		local nextMoveColor = Theme.COLORS["Negative text"]
+		if pokemon.level + 1 >= nextMoveLevel then
+			nextMoveColor = Theme.COLORS["Positive text"]
+		end
+		Drawing.drawText(Constants.SCREEN.WIDTH + nextMoveSpacing, moveOffsetY - moveTableHeaderHeightDiff, nextMoveLevel, nextMoveColor, bgHeaderShadow)
+	end
 
 	-- Draw the Moves view box
 	gui.defaultTextBackground(Theme.COLORS["Lower box background"])


### PR DESCRIPTION
This achieves a couple of things:
- Adjusts the evolution method and level of next learned move colours to make it stand out more and reflect when player's pokemon is close to / able to evolve/learn a new move
  - Closes #98 
  - Currently uses negative text when not close/possible, positive text when close/possible but this could be tweaked to just positive text when close/possible if wanted
  - Achieved by redrawing the text for evo method / next move level with the adjusted colour over the existing text. To be honest, the formulae I used to calculate the spacing/offset for these was found through trial and error. I don't know *why* they work but from my testing they do work with the variable length of the overall line of text due to level numbers
- Slightly reworks the heals in bag updates to also get the amount of evolution stones the player has in each bag
  - This was done without any additional memory reads, as evolution stones also reside in the items pocket.
  - This rework allows for easy extension into also counting the amount of status heals in the bag if we want to do that at any point
- From the tracked evolution stones in bag, the tracker will inform the player that they have a stone that can evolve their current mon

Example images and video of power-levelling through an evo line / entire moveset below:
![Untitled](https://user-images.githubusercontent.com/106463662/188328601-4a0b711c-3f80-4afa-9539-aada578e5775.png)

https://user-images.githubusercontent.com/106463662/188328612-9c82f06e-0e78-49d3-9499-c18a559a0c3b.mp4

