### PR TITLE
Merging Bugfixes into Staging [Sept 10th]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,19 +1,20 @@
 {
-  "Lua.diagnostics.globals": [
-    "event",
-    "emu",
-    "client",
-    "gui",
-    "userdata",
-    "gameinfo",
-    "bit",
-    "memory",
-    "love",
-    "joypad",
-    "input",
-    "forms",
-    "console"
-  ],
-  "Lua.runtime.version": "Lua 5.1",
-  "Lua.workspace.checkThirdParty": false
+	"Lua.diagnostics.globals": [
+		"event",
+		"emu",
+		"client",
+		"gui",
+		"userdata",
+		"gameinfo",
+		"bit",
+		"memory",
+		"love",
+		"joypad",
+		"input",
+		"forms",
+		"console",
+		"debug"
+	],
+	"Lua.runtime.version": "Lua 5.1",
+	"Lua.workspace.checkThirdParty": false
 }

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -1,4 +1,4 @@
-Main = { TrackerVersion = "0.6.2c" } -- The latest version of the tracker. Should be updated with each PR.
+Main = { TrackerVersion = "0.6.3" } -- The latest version of the tracker. Should be updated with each PR.
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",
@@ -332,7 +332,7 @@ end
 function Main.ReadAttemptsCounter()
 	local romname = gameinfo.getromname()
 	local romnumber = string.match(romname, '[0-9]+') or "1" -- backup attempts count from filename
-	local romprefix = string.match(romname, '[^0-9]+') -- remove numbers
+	local romprefix = string.match(romname, '[^0-9]+') or "" -- remove numbers
 	romprefix = romprefix:gsub(" AutoRandomized", "") -- remove quickload post-fix
 
 	local filename = romprefix .. " Attempts.txt"

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -80,7 +80,16 @@ function Main.Initialize()
 	end
 
 	-- Working directory, used for absolute paths
-	Main.Directory = os.getenv("PWD") or io.popen("cd"):read()
+	local function exeCD() return io.popen("cd") end
+	local success, ret, err = xpcall(exeCD, debug.traceback)
+	if success then
+		Main.OS = "Windows"
+		Main.Directory = ret:read()
+	else
+		Main.OS = "Linux"
+		Main.Directory = nil -- will return "" from Utils function
+		print(err)
+	end
 
 	print("Successfully loaded required tracker files")
 	return true
@@ -265,6 +274,12 @@ function Main.GetNextRomFromFolder()
 end
 
 function Main.GenerateNextRom()
+	if Main.OS ~= "Windows" then
+		print("The auto-generate a new ROM feature is currently not supported on non-Windows OS.")
+		Main.DisplayError("The auto-generate a new ROM feature is currently not supported on non-Windows OS.\n\nPlease use the other Quick-load option: From a ROMs Folder.")
+		return nil
+	end
+
 	if not (Main.FileExists(Options.FILES["Randomizer JAR"]) and Main.FileExists(Options.FILES["Settings File"]) and Main.FileExists(Options.FILES["Source ROM"])) then
 		print("Files missing that are required for Quick-load to generate a new ROM.")
 		Main.DisplayError("Files missing that are required for Quick-load to generate a new ROM.\n\nFix these at: Tracker Settings (gear icon) -> Tracker Setup -> Quick-load")

--- a/ironmon_tracker/Theme.lua
+++ b/ironmon_tracker/Theme.lua
@@ -111,8 +111,7 @@ end
 function Theme.loadPresets(filename)
 	if not Main.FileExists(filename) then return end
 
-	local index = 1 -- If theme name is missing, use this to make a unique one "Untitled #"
-	for line in io.lines(filename) do
+	for index, line in ipairs(Utils.readLinesFromFile(filename)) do
 		local firstHexIndex = line:find("%x%x%x%x%x%x")
 		if firstHexIndex ~= nil then
 			local themeString = line:sub(firstHexIndex)
@@ -125,7 +124,6 @@ function Theme.loadPresets(filename)
 
 			Theme.PresetStrings[themeName] = themeString
 			table.insert(Theme.PresetsOrdered, themeName)
-			index = index + 1
 		end
 	end
 end

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -470,7 +470,8 @@ function Tracker.loadData(filepath)
 				Tracker.Data[k] = v
 			end
 		end
-		local fileNameIndex = string.match(filepath, "^.*()\\")
+		local slashpattern = Utils.inlineIf(Main.OS == "Windows", "^.*()\\", "^.*()/")
+		local fileNameIndex = string.match(filepath, slashpattern)
 		local filename = string.sub(filepath, Utils.inlineIf(fileNameIndex ~= nil, fileNameIndex, 0) + 1)
 
 		Tracker.DataMessage = "Tracker data loaded from file: " .. filename

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -569,6 +569,26 @@ function Utils.readTableFromFile(filename)
 	return tableData
 end
 
+-- Returns a table that contains an entry for each line from a file
+function Utils.readLinesFromFile(filename)
+	local lines = {}
+
+	local file = io.open(filename, "r")
+	if file ~= nil then
+		local fileContents = file:read("*a")
+		if fileContents ~= nil and fileContents ~= "" then
+			for line in fileContents:gmatch("([^\r\n]+)\r?\n") do
+				if line ~= nil then
+					table.insert(lines, line)
+				end
+			end
+		end
+		file:close()
+	end
+
+	return lines
+end
+
 --sets the form location relative to the game window
 --this function does what the built in forms.setlocation function supposed to do
 --currently that function is bugged and should be fixed in 2.9
@@ -638,7 +658,8 @@ end
 function Utils.extractFileNameFromPath(path)
 	if path == nil or path == "" then return "" end
 
-	local nameStartIndex = path:match("^.*()\\") -- path to file
+	local slashpattern = Utils.inlineIf(Main.OS == "Windows", "^.*()\\", "^.*()/")
+	local nameStartIndex = path:match(slashpattern) -- path to file
 	local nameEndIndex = path:match("^.*()%.") -- file extension
 	if nameStartIndex ~= nil and nameEndIndex ~= nil then
 		local filename = path:sub(nameStartIndex + 1, nameEndIndex - 1)

--- a/ironmon_tracker/screens/QuickloadScreen.lua
+++ b/ironmon_tracker/screens/QuickloadScreen.lua
@@ -131,12 +131,13 @@ end
 
 function QuickloadScreen.handleSetRomFolder(button)
 	local path = Options.FILES[button.labelText]
-	local filterOptions = "ROM File (*.GBA)|*.GBA|All files (*.*)|*.*"
+	local filterOptions = "ROM File (*.GBA)|*.gba|All files (*.*)|*.*"
 
 	local file = forms.openfile("SELECT A ROM", path, filterOptions)
 	if file ~= "" then
-		-- Since the user had to pick a file, strip out the file name to just get the folder.
-		file = file:sub(0, file:match("^.*()\\") - 1)
+		-- Since the user had to pick a file, strip out the file name to just get the folder path
+		local slashpattern = Utils.inlineIf(Main.OS == "Windows", "^.*()\\", "^.*()/")
+		file = file:sub(0, file:match(slashpattern) - 1)
 
 		if file == nil then
 			Options.FILES[button.labelText] = ""
@@ -154,7 +155,7 @@ end
 
 function QuickloadScreen.handleSetRandomizerJar(button)
 	local path = Options.FILES[button.labelText]
-	local filterOptions = "JAR File (*.JAR)|*.JAR|All files (*.*)|*.*"
+	local filterOptions = "JAR File (*.JAR)|*.jar|All files (*.*)|*.*"
 
 	local file = forms.openfile("SELECT JAR", path, filterOptions)
 	if file ~= "" then
@@ -172,7 +173,7 @@ end
 
 function QuickloadScreen.handleSetSourceRom(button)
 	local path = Options.FILES[button.labelText]
-	local filterOptions = "GBA File (*.GBA)|*.GBA|All files (*.*)|*.*"
+	local filterOptions = "GBA File (*.GBA)|*.gba|All files (*.*)|*.*"
 
 	local file = forms.openfile("SELECT A ROM", path, filterOptions)
 	if file ~= "" then
@@ -190,7 +191,7 @@ end
 
 function QuickloadScreen.handleSetCustomSettings(button)
 	local path = Options.FILES[button.labelText]
-	local filterOptions = "RNQS File (*.RNQS)|*.RNQS|All files (*.*)|*.*"
+	local filterOptions = "RNQS File (*.RNQS)|*.rnqs|All files (*.*)|*.*"
 
 	-- If the custom settings file hasn't ever been set, show the folder containing preloaded setting files
 	if path == "" or not Main.FileExists(path) then

--- a/ironmon_tracker/screens/TrackedDataScreen.lua
+++ b/ironmon_tracker/screens/TrackedDataScreen.lua
@@ -108,7 +108,7 @@ end
 
 function TrackedDataScreen.openLoadDataPrompt()
 	local suggestedFileName = gameinfo.getromname() .. Constants.Extensions.TRACKED_DATA
-	local filterOptions = "Tracker Data (*.TDAT)|*.TDAT|All files (*.*)|*.*"
+	local filterOptions = "Tracker Data (*.TDAT)|*.tdat|All files (*.*)|*.*"
 
 	local workingDir = Utils.getWorkingDirectory()
 	if workingDir ~= "" then


### PR DESCRIPTION
Summary of fixes:
- Update version number to get ready for release 0.6.3
- Fixed ReadAttemptsCounter `nil` exception when rom filename was only numbers "123.gba"
- Cleanup spaces vs tabs with `settings.json`
- Fixed `io.lines()` breaking at end of file for `ThemePresets.txt`
- Fixed files not showing up for Open File dialog prompts
- Added a way to determine what Operating System the Tracker is running on, stored in `Main.OS`
   - As a result, this allows workarounds for bypassing `popen` errors and `\` versus `/` usage