### PR TITLE
Feature: Version Update Checking

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -97,10 +97,9 @@ function Main.Initialize()
 			Main.Directory = nil -- will return "" from Utils function
 			print(err)
 		end
+
 		Main.CheckForVersionUpdate()
 	end
-
-
 
 	print("Successfully loaded required tracker files")
 	return true

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -251,9 +251,9 @@ function Main.NotifyUpdatePopUp(latestVersion)
 	forms.setproperty(form, "Left", client.xpos() + actualLocation['x'] )
 	forms.setproperty(form, "Top", client.ypos() + actualLocation['y'] + 64) -- so we are below the ribbon menu
 
-	forms.label(form, "New Tracker Version Available!", 89, 15, 410, 20)
-	forms.label(form, "New version: v" .. latestVersion, 89, 42, 410, 20)
-	forms.label(form, "Current version: v" .. Main.TrackerVersion, 89, 60, 410, 20)
+	forms.label(form, "New Tracker Version Available!", 89, 15, 255, 20)
+	forms.label(form, "New version: v" .. latestVersion, 89, 42, 255, 20)
+	forms.label(form, "Current version: v" .. Main.TrackerVersion, 89, 60, 255, 20)
 
 	local offsetY = 85
 

--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -28,6 +28,11 @@ Constants.Extensions = {
 	TRACKED_DATA = ".tdat",
 }
 
+Constants.Release = {
+	VERSION_URL = "https://api.github.com/repos/besteon/Ironmon-Tracker/releases/latest",
+	DOWNLOAD_URL = "https://github.com/besteon/Ironmon-Tracker/releases/latest",
+}
+
 Constants.ButtonTypes = {
 	FULL_BORDER = 1,
 	NO_BORDER = 2,


### PR DESCRIPTION
This adds support for the Tracker to check this repository for release updates. It does so by comparing major, minor, and patch version numbers. As such, the version schema moving forward will be `[Major].[Minor].[Patch]` , eg `6.3.0`

![image](https://user-images.githubusercontent.com/4258818/189514449-c060ff73-c05a-4edd-99ad-474310cd6cff.png)

When a new release goes out, if the `Major` or `Minor` patch number changes, then the user will be alerted that an update is available. This means that we can push hotfix updates regularly using the `Patch` number, without continuing to alert everyone about updates.

This feature offers a **Remind me later** option if the user wants to be reminded later to update. I think one possible flaw with this is using the Quick-load feature will likely trigger the version update reminder, every time. Unsure if there is a good way to go about this to differentiate between reloading the script from a quick-load and reloading the script on a different day.