### PR TITLE
Iconsets: Author credits and periodic icon change

### DIFF
--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -71,7 +71,7 @@ Options.IconSetMap = {
 		extension = ".png",
 		yOffset = 4,
 		adjustQuestionMark = false,
-		author = "Fellshadow"
+		author = "Fellshadow",
 	}
 }
 

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -47,6 +47,7 @@ Options.IconSetMap = {
 		extension = ".gif",
 		yOffset = 0,
 		adjustQuestionMark = true, -- Whether to adjust the question mark icons in routeInfo screen
+		author = "Besteon",
 	},
 	["2"] = {
 		name = "Stadium",
@@ -54,6 +55,7 @@ Options.IconSetMap = {
 		extension = ".png",
 		yOffset = 4,
 		adjustQuestionMark = false,
+		author = "AmberCyprian",
 	},
 	["3"] = {
 		name = "Gen 7+",
@@ -61,6 +63,7 @@ Options.IconSetMap = {
 		extension = ".png",
 		yOffset = 2,
 		adjustQuestionMark = true,
+		author = "kittenchilly",
 	},
 	["4"] = {
 		name = "Explorers",
@@ -68,6 +71,7 @@ Options.IconSetMap = {
 		extension = ".png",
 		yOffset = 4,
 		adjustQuestionMark = false,
+		author = "Fellshadow"
 	}
 }
 

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -3,6 +3,7 @@ SetupScreen = {
 	textColor = "Lower box text",
 	borderColor = "Lower box border",
 	boxFillColor = "Lower box background",
+	iconChangeInterval = 5,
 }
 
 SetupScreen.OptionKeys = {
@@ -18,11 +19,16 @@ SetupScreen.Buttons = {
 	ChoosePortrait = {
 		type = Constants.ButtonTypes.NO_BORDER,
 		text = Constants.Words.POKEMON .. " icon set:  " .. Options.IconSetMap[Options["Pokemon icon set"]].name,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 2, Constants.SCREEN.MARGIN + 13, 65, 11 },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 2, Constants.SCREEN.MARGIN + 12, 65, 11 },
+	},
+	PortraitAuthor = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		text = "Added By:  " .. Options.IconSetMap[Options["Pokemon icon set"]].author,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 2, Constants.SCREEN.MARGIN + 22, 65, 11 },
 	},
 	PokemonIcon = {
 		type = Constants.ButtonTypes.POKEMON_ICON,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 52, Constants.SCREEN.MARGIN + 19, 32, 32 },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 52, Constants.SCREEN.MARGIN + 27, 32, 32 },
 		pokemonID = 1,
 		getIconPath = function(self)
 			local iconset = Options.IconSetMap[Options["Pokemon icon set"]]
@@ -37,22 +43,24 @@ SetupScreen.Buttons = {
 	CycleIconForward = {
 		type = Constants.ButtonTypes.PIXELIMAGE,
 		image = Constants.PixelImages.NEXT_BUTTON,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 94, Constants.SCREEN.MARGIN + 33, 10, 10, },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 94, Constants.SCREEN.MARGIN + 42, 10, 10, },
 		onClick = function(self)
 			local currIndex = tonumber(Options["Pokemon icon set"])
 			local nextSet = tostring((currIndex % Options.IconSetMap.totalCount) + 1)
 			SetupScreen.Buttons.ChoosePortrait.text = Constants.Words.POKEMON .. " icon set:  " .. Options.IconSetMap[nextSet].name
+			SetupScreen.Buttons.PortraitAuthor.text = "Added By:  " .. Options.IconSetMap[nextSet].author
 			Options.updateSetting("Pokemon icon set", nextSet)
 		end
 	},
 	CycleIconBackward = {
 		type = Constants.ButtonTypes.PIXELIMAGE,
 		image = Constants.PixelImages.PREVIOUS_BUTTON,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 34, Constants.SCREEN.MARGIN + 33, 10, 10, },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 34, Constants.SCREEN.MARGIN + 42, 10, 10, },
 		onClick = function(self)
 			local currIndex = tonumber(Options["Pokemon icon set"])
 			local prevSet = tostring((currIndex - 2 ) % Options.IconSetMap.totalCount + 1)
 			SetupScreen.Buttons.ChoosePortrait.text = Constants.Words.POKEMON .. " icon set:  " .. Options.IconSetMap[prevSet].name
+			SetupScreen.Buttons.PortraitAuthor.text = "Added By:  " .. Options.IconSetMap[prevSet].author
 			Options.updateSetting("Pokemon icon set", prevSet)
 		end
 	},
@@ -86,7 +94,7 @@ SetupScreen.Buttons = {
 
 function SetupScreen.initialize()
 	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4
-	local startY = Constants.SCREEN.MARGIN + 55
+	local startY = Constants.SCREEN.MARGIN + 63
 	local linespacing = Constants.SCREEN.LINESPACING + 1
 
 	for _, optionKey in ipairs(SetupScreen.OptionKeys) do
@@ -126,6 +134,7 @@ function SetupScreen.initialize()
 	end
 
 	SetupScreen.Buttons.ChoosePortrait.text = Constants.Words.POKEMON .. " icon set:  " .. Options.IconSetMap[Options["Pokemon icon set"]].name
+	SetupScreen.Buttons.PortraitAuthor.text = "Added By:  " .. Options.IconSetMap[Options["Pokemon icon set"]].author
 	-- Randomize what Pokemon icon is shown
 	SetupScreen.Buttons.PokemonIcon.pokemonID = Utils.randomPokemonID()
 
@@ -214,4 +223,13 @@ function SetupScreen.drawScreen()
 	for _, button in pairs(SetupScreen.Buttons) do
 		Drawing.drawButton(button, shadowcolor)
 	end
+
+	-- Randomize the pokemon shown every iconChangeInterval
+	-- Tracker screen redraw occurs every Program.Frames.waitToDraw frames,
+	-- so overall interval is effectively iconChangeInterval * Program.Frames.waitToDraw frames
+	if SetupScreen.iconChangeInterval == 0 then
+		SetupScreen.Buttons.PokemonIcon.pokemonID = Utils.randomPokemonID()
+	end
+
+	SetupScreen.iconChangeInterval = (SetupScreen.iconChangeInterval - 1) % 5
 end

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -23,7 +23,7 @@ SetupScreen.Buttons = {
 	},
 	PortraitAuthor = {
 		type = Constants.ButtonTypes.NO_BORDER,
-		text = "Added By:  " .. Options.IconSetMap[Options["Pokemon icon set"]].author,
+		text = "Added by:  " .. Options.IconSetMap[Options["Pokemon icon set"]].author,
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 2, Constants.SCREEN.MARGIN + 22, 65, 11 },
 	},
 	PokemonIcon = {
@@ -48,7 +48,7 @@ SetupScreen.Buttons = {
 			local currIndex = tonumber(Options["Pokemon icon set"])
 			local nextSet = tostring((currIndex % Options.IconSetMap.totalCount) + 1)
 			SetupScreen.Buttons.ChoosePortrait.text = Constants.Words.POKEMON .. " icon set:  " .. Options.IconSetMap[nextSet].name
-			SetupScreen.Buttons.PortraitAuthor.text = "Added By:  " .. Options.IconSetMap[nextSet].author
+			SetupScreen.Buttons.PortraitAuthor.text = "Added by:  " .. Options.IconSetMap[nextSet].author
 			Options.updateSetting("Pokemon icon set", nextSet)
 		end
 	},
@@ -60,7 +60,7 @@ SetupScreen.Buttons = {
 			local currIndex = tonumber(Options["Pokemon icon set"])
 			local prevSet = tostring((currIndex - 2 ) % Options.IconSetMap.totalCount + 1)
 			SetupScreen.Buttons.ChoosePortrait.text = Constants.Words.POKEMON .. " icon set:  " .. Options.IconSetMap[prevSet].name
-			SetupScreen.Buttons.PortraitAuthor.text = "Added By:  " .. Options.IconSetMap[prevSet].author
+			SetupScreen.Buttons.PortraitAuthor.text = "Added by:  " .. Options.IconSetMap[prevSet].author
 			Options.updateSetting("Pokemon icon set", prevSet)
 		end
 	},
@@ -134,7 +134,7 @@ function SetupScreen.initialize()
 	end
 
 	SetupScreen.Buttons.ChoosePortrait.text = Constants.Words.POKEMON .. " icon set:  " .. Options.IconSetMap[Options["Pokemon icon set"]].name
-	SetupScreen.Buttons.PortraitAuthor.text = "Added By:  " .. Options.IconSetMap[Options["Pokemon icon set"]].author
+	SetupScreen.Buttons.PortraitAuthor.text = "Added by:  " .. Options.IconSetMap[Options["Pokemon icon set"]].author
 	-- Randomize what Pokemon icon is shown
 	SetupScreen.Buttons.PokemonIcon.pokemonID = Utils.randomPokemonID()
 

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -3,7 +3,7 @@ SetupScreen = {
 	textColor = "Lower box text",
 	borderColor = "Lower box border",
 	boxFillColor = "Lower box background",
-	iconChangeInterval = 5,
+	iconChangeInterval = 10,
 }
 
 SetupScreen.OptionKeys = {
@@ -37,6 +37,7 @@ SetupScreen.Buttons = {
 		end,
 		onClick = function(self)
 			self.pokemonID = Utils.randomPokemonID()
+			SetupScreen.iconChangeInterval = 10
 			Program.redraw(true)
 		end
 	},
@@ -49,6 +50,7 @@ SetupScreen.Buttons = {
 			local nextSet = tostring((currIndex % Options.IconSetMap.totalCount) + 1)
 			SetupScreen.Buttons.ChoosePortrait.text = Constants.Words.POKEMON .. " icon set:  " .. Options.IconSetMap[nextSet].name
 			SetupScreen.Buttons.PortraitAuthor.text = "Added by:  " .. Options.IconSetMap[nextSet].author
+			SetupScreen.iconChangeInterval = 10
 			Options.updateSetting("Pokemon icon set", nextSet)
 		end
 	},
@@ -61,6 +63,7 @@ SetupScreen.Buttons = {
 			local prevSet = tostring((currIndex - 2 ) % Options.IconSetMap.totalCount + 1)
 			SetupScreen.Buttons.ChoosePortrait.text = Constants.Words.POKEMON .. " icon set:  " .. Options.IconSetMap[prevSet].name
 			SetupScreen.Buttons.PortraitAuthor.text = "Added by:  " .. Options.IconSetMap[prevSet].author
+			SetupScreen.iconChangeInterval = 10
 			Options.updateSetting("Pokemon icon set", prevSet)
 		end
 	},
@@ -231,5 +234,5 @@ function SetupScreen.drawScreen()
 		SetupScreen.Buttons.PokemonIcon.pokemonID = Utils.randomPokemonID()
 	end
 
-	SetupScreen.iconChangeInterval = (SetupScreen.iconChangeInterval - 1) % 5
+	SetupScreen.iconChangeInterval = (SetupScreen.iconChangeInterval - 1) % 10
 end


### PR DESCRIPTION
Small update:
- Adds credits for who added each icon set
   - Sources for each iconset in our tracker are actual game sprites/portraits so don't know if we need to explicitly credit those anywhere, not sure where there'd be room to do so (could maybe be in README and/or one of the wiki pages if we wanted them?)
- Adds an interval at which the icon randomly changes, in addition to being able to click to cycle them
   - Interval is currently set to effectively every 180 frames, after accounting for the current screen redraw interval (30 frames)
   - Could maybe remove the click functionality if wanted, kept it in if you wanna spam-click to view a bunch in a row lol
   
This screen is now looking a little cramped tbh lol tried to space it out best I could
Don't think we're planning to add new settings here soon anyways (and can deal with the space at that time)

One suggestion I have, if we ever make any new add-ons, would be to have the tracker add-ons be a separate menu screen on the tracker options (either accessed from the setup menu or the navigation menu)

![image](https://user-images.githubusercontent.com/106463662/193861804-952be1ad-0c22-4a46-893e-910d1173e067.png)