### PR TITLE
Repel overflow fix

### DIFF
--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -177,7 +177,7 @@ function Program.updateRepelSteps()
 	-- Game uses a variable for the repel steps remaining, which remains at 0 when there's no active repel
 	local saveblock1Addr = Utils.getSaveBlock1Addr()
 	local repelStepCountOffset = Utils.inlineIf(GameSettings.game == 3, 0x40, 0x42)
-	local repelStepCount = Memory.readword(saveblock1Addr + GameSettings.gameVarsOffset + repelStepCountOffset)
+	local repelStepCount = Memory.readbyte(saveblock1Addr + GameSettings.gameVarsOffset + repelStepCountOffset)
 	if repelStepCount ~= nil and repelStepCount > 0 then
 		Program.ActiveRepel.inUse = true
 		if repelStepCount ~= Program.ActiveRepel.stepCount then


### PR DESCRIPTION
- Variables like the various step counters are stored in an array of words in the saveBlock. For reasons that are yet unclear, sometimes the upper byte is populated with garbage data when using the intro skip patch. This data in the upper byte never clears even when the repel runs out, causing the Repel display to think that there are not only always steps remaining on a repel, but also that it is a ridiculously high number, causing the display to overflow its bounds.
- TL;DR: we're reading the whole word when the data we need is entirely in the first byte.
- Tested for all combinations of patched/unpatched FireRed, both the intro skip and the new hidden item patch.