### PR TITLE
Custom Startup Pokemon Icon

### DIFF
--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -108,6 +108,7 @@ Constants.OrderedLists = {
 		"Use premade ROMs",
 		"Generate ROM each time",
 		"Display repel usage",
+		"Startup Pokemon displayed",
 	},
 	CONTROLS = {
 		"Load next seed",

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -71,6 +71,17 @@ Options.IconSetMap = {
 	}
 }
 
+-- This determines what icon to show on each Startup Screen
+-- random: changes randomly each seed
+-- attempts: shows a Pokemon based on the attempt count, eg. "attempt 25" would show Pikachu
+-- [ID_NUM]: shows the same Pokemon every time, eg. "set as 213" would always show Shuckle
+Options.StartupIcon = {
+	random = "Random",
+	attempts = "Attempts",
+}
+
+Options["Startup Pokemon displayed"] = Options.StartupIcon.attempts
+
 function Options.initialize()
 	-- Check if the Toggle View controller button is not default, and update the tip message if so.
 	local toggleViewValue = Options.CONTROLS["Toggle view"]

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -130,7 +130,7 @@ function PokemonData.checkIfDataIsRandomized()
 	if not areTypesRandomized or not areAbilitiesRandomized then
 		types = PokemonData.readPokemonTypesFromMemory(131) -- Lapras
 		abilities = PokemonData.readPokemonAbilitiesFromMemory(131) -- Lapras
-	
+
 		if types ~= nil and (types[1] ~= PokemonData.Types.WATER or types[2] ~= PokemonData.Types.ICE) then
 			areTypesRandomized = true
 		end
@@ -140,7 +140,7 @@ function PokemonData.checkIfDataIsRandomized()
 	end
 
 	PokemonData.IsRand.pokemonTypes = areTypesRandomized
-	-- For now, read in all ability data since it's not stored in the PokemonData.Pokemon below 
+	-- For now, read in all ability data since it's not stored in the PokemonData.Pokemon below
 	areAbilitiesRandomized = true
 	PokemonData.IsRand.pokemonAbilities = areAbilitiesRandomized
 
@@ -161,6 +161,26 @@ end
 function PokemonData.isImageIDValid(pokemonID)
 	--Eggs (412), Ghosts (413), and placeholder (0)
 	return PokemonData.isValid(pokemonID) or pokemonID == 412 or pokemonID == 413 or pokemonID == 0
+end
+
+function PokemonData.getIdFromName(pokemonName)
+	for id, pokemon in pairs(PokemonData.Pokemon) do
+		if pokemon.name == pokemonName then
+			return id
+		end
+	end
+
+	return nil
+end
+
+function PokemonData.toList()
+	local allPokemon = {}
+	for _, pokemon in pairs(PokemonData.Pokemon) do
+		if pokemon.bst ~= Constants.BLANKLINE then -- Skip fake Pokemon
+			table.insert(allPokemon, pokemon.name)
+		end
+	end
+	return allPokemon
 end
 
 PokemonData.TypeIndexMap = {

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -342,12 +342,7 @@ function InfoScreen.openPokemonInfoWindow()
 	Utils.setFormLocation(pokedexLookup, 100, 50)
 
 	local pokemonName = PokemonData.Pokemon[InfoScreen.infoLookup].name -- infoLookup = pokemonID
-	local pokedexData = {}
-	for _, data in pairs(PokemonData.Pokemon) do
-		if data.bst ~= Constants.BLANKLINE then
-			table.insert(pokedexData, data.name)
-		end
-	end
+	local pokedexData = PokemonData.toList()
 
 	forms.label(pokedexLookup, "Choose a Pokemon to look up:", 49, 10, 250, 20)
 	local pokedexDropdown = forms.dropdown(pokedexLookup, {["Init"]="Loading Pokedex"}, 50, 30, 145, 30)
@@ -358,14 +353,7 @@ function InfoScreen.openPokemonInfoWindow()
 
 	forms.button(pokedexLookup, "Look up", function()
 		local pokemonNameFromForm = forms.gettext(pokedexDropdown)
-		local pokemonId
-
-		for id, data in pairs(PokemonData.Pokemon) do
-			if data.name == pokemonNameFromForm then
-				pokemonId = id
-				break
-			end
-		end
+		local pokemonId = PokemonData.getIdFromName(pokemonNameFromForm)
 
 		if pokemonId ~= nil and pokemonId ~= 0 then
 			InfoScreen.infoLookup = pokemonId


### PR DESCRIPTION
This is a new feature to allow the user to set the Pokemon icon that is shown on the startup screen. They can choose to show their favorite Pokemon every time game resets, or they can have it based off of the # of attempts, or be completely random.

![image](https://user-images.githubusercontent.com/4258818/193955348-2e240ef8-78b0-40fe-a690-4e4dd6412a0a.png)
