### PR TITLE
Return/Frustration now calculated if close to max

### DIFF
--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -375,6 +375,34 @@ function Utils.calculateHighHPBasedDamage(movePower, currentHP, maxHP)
 	return tostring(roundedPower)
 end
 
+-- For Return & Frustration
+-- Only shows if close to max strength; won't return exact values to avoid revealing friendship amount
+function Utils.calculateFriendshipBasedDamage(movePower, friendship)
+	if movePower ~= ">FR" and movePower ~= "<FR" then
+		return movePower
+	end
+
+	if friendship == nil or friendship < 0 then
+		friendship = 0
+	elseif friendship > 255 then
+		friendship = 255
+	end
+
+	-- Invert if based on unhappiness
+	if movePower == "<FR" then
+		friendship = 255 - friendship
+	end
+
+	local basePower = math.max(friendship / 2.5, 1) -- minimum of 1
+
+	-- Don't reveal calculated power if not near max power (100-102)
+	if basePower < 100 then
+		return movePower
+	else
+		return tostring(math.floor(basePower)) -- remove decimals
+	end
+end
+
 function Utils.calculateWeatherBall(moveType, movePower)
 	if not Battle.inBattle then
 		return moveType, movePower

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -868,12 +868,17 @@ function TrackerScreen.drawMovesArea(pokemon, opposingPokemon)
 				-- Calculate the power of Low Kick (weight-based moves) in battle
 				local targetWeight = PokemonData.Pokemon[opposingPokemon.pokemonID].weight
 				movePower = Utils.calculateWeightBasedDamage(movePower, targetWeight)
-			elseif Tracker.Data.isViewingOwn and (moveData.id == "175" or moveData.id == "179") then
-				-- Calculate the power of Flail & Reversal moves for player only
-				movePower = Utils.calculateLowHPBasedDamage(movePower, pokemon.curHP, pokemon.stats.hp)
-			elseif Tracker.Data.isViewingOwn and (moveData.id == "284" or moveData.id == "323") then
-				-- Calculate the power of Eruption & Water Spout moves for the player only
-				movePower = Utils.calculateHighHPBasedDamage(movePower, pokemon.curHP, pokemon.stats.hp)
+			elseif Tracker.Data.isViewingOwn then
+				if moveData.id == "175" or moveData.id == "179" then
+					-- Calculate the power of Flail & Reversal moves for player only
+					movePower = Utils.calculateLowHPBasedDamage(movePower, pokemon.curHP, pokemon.stats.hp)
+				elseif moveData.id == "284" or moveData.id == "323" then
+					-- Calculate the power of Eruption & Water Spout moves for the player only
+					movePower = Utils.calculateHighHPBasedDamage(movePower, pokemon.curHP, pokemon.stats.hp)
+				elseif moveData.id == "216" or moveData.id == "218" then
+					-- Calculate the power of Return & Frustration moves for the player only
+					movePower = Utils.calculateFriendshipBasedDamage(movePower, pokemon.friendship)
+				end
 			end
 		end
 


### PR DESCRIPTION
Small update here to have Return & Frustration show a calculated power value if it's close to being maxed. In such cases, it will only reveal if the power is calculated to be 100 or greater.

The logic is available to reveal the power regardless of friendship/happiness value, but that is generally regarded as hidden information and should not be revealed. This PR is more of a small quality of life update to let you know it's been maxed out.