### PR TITLE
Bugfixes: power plant encounters

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -62,6 +62,8 @@ function Main.Initialize()
 		return false
 	end
 
+	math.randomseed(os.time()) -- Set seed based on epoch seconds; required for other features
+
 	-- Attempt to load the required tracker files
 	for _, file in ipairs(Main.TrackerFiles) do
 		local path = Main.DataFolder .. file

--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -72,24 +72,6 @@ Constants.MoveTypeColors = {
 	unknown = 0xFF68A090, -- For the "Curse" move in Gen 2 - 4
 }
 
--- Auto PC Heal tracking will only work in these locations
-Constants.HealLocations = {
-	FRLG = {
-		[1] = true, -- Mom's house
-		[8] = true, -- Most Pokemon Centers
-		[212] = true, -- Indigo Plateau
-		[271] = true, -- One Island
-	},
-	RSE = {
-		[54] = true, -- Mom's house
-		[61] = true, -- Most Pokemon Centers
-		[71] = true, -- Lavaridge Town
-		[270] = true, -- Pokemon League Emerald ONLY
-		[271] = true, -- Pokemon League Ruby/Sapphire ONLY
-		-- Note: There is incorrect overlap for 270 and 271, but I think this is acceptable/rare
-	},
-}
-
 Constants.GAME_STATS = { -- Enums for in-game stats
 	-- https://github.com/pret/pokefirered/blob/master/include/constants/game_stat.h
 	FISHING_CAPTURES = 12, -- Deceptive name, gets incremented when fishing encounter happens

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -62,9 +62,6 @@ function Program.initialize()
 	PokemonData.readDataFromMemory()
 	MoveData.readDataFromMemory()
 
-	-- Set seed based on epoch seconds; required for other features
-	math.randomseed(os.time())
-
 	-- At some point we might want to implement this so that wild encounter data is automatic
 	-- RouteData.readWildPokemonInfoFromMemory()
 end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -374,17 +374,13 @@ function Program.updatePCHeals()
 	-- Does not include whiteouts, as those don't increment either of these gamestats
 
 	-- Save blocks move and are re-encrypted right as the battle starts
-	if Battle.inBattle then return end
+	if Battle.inBattle then
+		return
+	end
 
 	-- Make sure the player is in a map location that can perform a PC heal
-	if GameSettings.game == 3 then -- FRLG
-		if not Constants.HealLocations.FRLG[Battle.CurrentRoute.mapId] then
-			return
-		end
-	else -- RSE
-		if not Constants.HealLocations.RSE[Battle.CurrentRoute.mapId] then
-			return
-		end
+	if not RouteData.Locations.CanPCHeal[Battle.CurrentRoute.mapId] then
+		return
 	end
 
 	local gameStat_UsedPokecenter = Utils.getGameStat(Constants.GAME_STATS.USED_POKECENTER)

--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -1448,10 +1448,11 @@ function RouteData.setupRouteInfoAsFRLG()
 				{ pokemonID = 81, rate = 0.30, minLv = 22, maxLv = 25, },
 				{ pokemonID = 100, rate = 0.30, minLv = 22, maxLv = 25, },
 				{ pokemonID = 25, rate = 0.25, minLv = 22, maxLv = 26, },
-				{ pokemonID = 82, rate = 0.10, minLv = 31, maxLv = 34, },
-				{ pokemonID = 125, rate = 0.05, minLv = 32, maxLv = 35, },
+				{ pokemonID = {82,82}, rate = {0.10,0.15}, minLv = 31, maxLv = 34, },
+				{ pokemonID = {125,-1}, rate = 0.05, minLv = 32, maxLv = 35, },
 			},
 			[RouteData.EncounterArea.STATIC] = {
+				{ pokemonID = 101, rate = 1.00, minLv = 34, maxLv = 34, },
 				{ pokemonID = 145, rate = 1.00, minLv = 50, maxLv = 50, },
 			},
 		},

--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -56,6 +56,12 @@ RouteData.Rods = {
 	[264] = RouteData.EncounterArea.SUPERROD,
 }
 
+-- Allows the Tracker to verify if data can be updated based on the location of the player
+RouteData.Locations = {
+	CanPCHeal = {},
+	CanObtainBadge = {}, -- Currently unused for the time being
+}
+
 function RouteData.setupRouteInfo(gameId)
 	local maxMapId = 0
 
@@ -367,6 +373,23 @@ end
 -- https://github.com/pret/pokefirered/blob/918ed2d31eeeb036230d0912cc2527b83788bc85/include/constants/layouts.h
 -- https://www.serebii.net/pokearth/kanto/3rd/route1.shtml
 function RouteData.setupRouteInfoAsFRLG()
+	RouteData.Locations.CanPCHeal = {
+		[1] = true, -- Mom's house
+		[8] = true, -- Most Pokemon Centers
+		[212] = true, -- Indigo Plateau
+		[271] = true, -- One Island
+	}
+	RouteData.Locations.CanObtainBadge = {
+		[12] = true,
+		[15] = true,
+		[20] = true,
+		[25] = true,
+		[28] = true,
+		[34] = true,
+		[36] = true,
+		[37] = true,
+	}
+
 	RouteData.Info = {
 		[1] = { name = "Mom's House", },
 		[5] = { name = "Oak's Lab", },
@@ -2342,6 +2365,25 @@ function RouteData.setupRouteInfoAsRSE()
 	-- Ruby/Sapphire has LAYOUT_LILYCOVE_CITY_EMPTY_MAP 108, offset all "mapId > 107" by +1
 	local isGameEmerald = GameSettings.versioncolor == "Emerald"
 	local offset = Utils.inlineIf(isGameEmerald, 0, 1)
+
+	RouteData.Locations.CanPCHeal = {
+		[54] = true, -- Mom's house
+		[61] = true, -- Most Pokemon Centers
+		[71] = true, -- Lavaridge Town
+		[270 + offset] = true, -- Pokemon League
+	}
+	RouteData.Locations.CanObtainBadge = {
+		[65] = true,
+		[69] = true,
+		[70] = true,
+		[79] = true,
+		[89] = true,
+		[94] = true,
+		[100] = true,
+		[108] = true,
+		[109] = true,
+		[110] = true,
+	}
 
 	RouteData.Info = {}
 


### PR DESCRIPTION
Summary of fixes:
- _(Minor)_ Random seed set is now done as soon as possible in case other files need access to random numbers
- _(Minor)_ Auto PC Heal validation checks are a tad more accurate, and now live in RouteData instead of Constants
- Fixed Power Plant encounter tables for static encounter missing (FRLG) and for electabuzz's absence in Leaf Green