### PR TITLE
Last seen level of encountered Pokemon now tracked

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -505,6 +505,9 @@ end
 function Battle.endCurrentBattle()
 	if not Battle.inBattle then return end
 
+	-- Only record Last Level Seen after the battle, so the info shown doesn't get overwritten by current level
+	Tracker.recordLastLevelsSeen()
+
 	--Most of the time, Run Away message is present only after the battle ends
 	Battle.battleMsg = Memory.readdword(GameSettings.gBattlescriptCurrInstr)
 	if Battle.battleMsg == GameSettings.BattleScript_RanAwayUsingMonAbility then

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -373,6 +373,31 @@ function Tracker.getHiddenPowerType()
 	end
 end
 
+-- Note the last level seen of each Pokemon on the enemy team
+function Tracker.recordLastLevelsSeen()
+	for _, pokemon in pairs(Tracker.Data.otherPokemon) do
+		if pokemon ~= nil and pokemon.level ~= nil and pokemon.level > 0 and pokemon.level <= 100 then
+			local trackedPokemon = Tracker.getOrCreateTrackedPokemon(pokemon.pokemonID)
+
+			if trackedPokemon.encounters == nil then
+				trackedPokemon.encounters = { wild = 0, trainer = 0 }
+			end
+
+			trackedPokemon.encounters.lastlevel = pokemon.level
+		end
+	end
+end
+
+-- Returns the level of the Pokemon last time it was seen; returns nil if never seen before
+function Tracker.getLastLevelSeen(pokemonID)
+	local trackedPokemon = Tracker.getOrCreateTrackedPokemon(pokemonID)
+	if trackedPokemon.encounters == nil then
+		return nil
+	else
+		return trackedPokemon.encounters.lastlevel
+	end
+end
+
 function Tracker.getDefaultPokemon()
 	return {
 		pokemonID = 0,


### PR DESCRIPTION
This adds support for tracking and displaying the last level seen for an encountered Pokemon. This helps match move data tracked from previous encounters with the newly encountered, likely higher level Pokemon. To make space for displaying this feature, the old "HP: ?/?" useless text has been removed when viewing the enemy Pokemon.

When encountering a Pokemon for the first time, a blank line is shown:

![image](https://user-images.githubusercontent.com/4258818/195971473-2909d4ae-fb68-4e75-bd94-eda55e10ab3f.png)

Future encounters will show the level of the previously encountered Pokemon:

![image](https://user-images.githubusercontent.com/4258818/195971483-68708cef-3067-4295-bb03-0ffdcf97825a.png)