### PR TITLE
Backup last seed before loading the next one

### DIFF
--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -437,6 +437,11 @@ function SaveCurrentRom(filename)
 		currentrom:close()
 		historyrom = historyrom:seek("end")
 		historyrom:close()
+
+		olderromfilename = string.format("seed-%s %s", Main.ReadAttemptsCounter() - 5, filename)
+		if Main.FileExists(olderromfilename) then
+			os.remove(olderromfilename)
+		end
 	end
 end
 

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -422,10 +422,10 @@ end
 
 function Main.SaveCurrentRom(filename)
 	if Main.FileExists(filename) then
-		Main.CopyFile(filename, string.format("seed-%s %s", Main.ReadAttemptsCounter(), filename))
-		Main.CopyFile(string.format("%s.log", filename), string.format("seed-%s %s.log", Main.ReadAttemptsCounter(), filename))
+		Main.CopyFile(filename, string.format("seed-%s %s", Main.currentSeed, filename))
+		Main.CopyFile(string.format("%s.log", filename), string.format("seed-%s %s.log", Main.currentSeed, filename))
 
-		olderromfilename = string.format("seed-%s %s", Main.ReadAttemptsCounter() - 5, filename)
+		olderromfilename = string.format("seed-%s %s", Main.currentSeed - 5, filename)
 		if Main.FileExists(olderromfilename) then
 			os.remove(olderromfilename)
 			os.remove(string.format("%s.log", olderromfilename))

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -428,6 +428,7 @@ function SaveCurrentRom(filename)
 		olderromfilename = string.format("seed-%s %s", Main.ReadAttemptsCounter() - 5, filename)
 		if Main.FileExists(olderromfilename) then
 			os.remove(olderromfilename)
+			os.remove(string.format("%s.log", olderromfilename))
 		end
 	end
 end

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -420,7 +420,7 @@ function Main.GenerateNextRom()
 	}
 end
 
-function SaveCurrentRom(filename)
+function Main.SaveCurrentRom(filename)
 	if Main.FileExists(filename) then
 		Main.CopyFile(filename, string.format("seed-%s %s", Main.ReadAttemptsCounter(), filename))
 		Main.CopyFile(string.format("%s.log", filename), string.format("seed-%s %s.log", Main.ReadAttemptsCounter(), filename))

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -422,24 +422,29 @@ end
 
 function Main.SaveCurrentRom(filename)
 	local newseedfilename = filename:gsub(Constants.Files.PostFixes.AUTORANDOMIZED, Constants.Files.PostFixes.PREVIOUSATTEMPT)
-	Main.CopyFile(filename, newseedfilename)
-	Main.CopyFile(string.format("%s.log", filename), string.format("%s.log", newseedfilename))
+	if Main.CopyFile(filename, newseedfilename, true) then
+		Main.CopyFile(string.format("%s.log", filename), string.format("%s.log", newseedfilename), true)
+	end
 end
 
-function Main.CopyFile(filename, newfilename)
-	if Main.FileExists(filename) then
-		local original = io.open(filename, "rb")
-		local copy = io.open(newfilename, "wb")
-
-		local nextBlock = original:read(2^13)
-		while nextBlock ~= nil do
-			copy:write(nextBlock)
-			nextBlock = original:read(2^13)
-		end
-
-		original:close()
-		copy:close()
+function Main.CopyFile(filename, newfilename, overwrite)
+	if not Main.FileExists(filename) or (Main.FileExists(newfilename) and not overwrite) then
+		return false
 	end
+	
+	local original = io.open(filename, "rb")
+	local copy = io.open(newfilename, "wb")
+
+	local nextBlock = original:read(2^13)
+	while nextBlock ~= nil do
+		copy:write(nextBlock)
+		nextBlock = original:read(2^13)
+	end
+
+	original:close()
+	copy:close()
+	
+	return true
 end
 
 -- Increment the attempts counter through a .txt file

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -430,11 +430,15 @@ end
 -- Copy a file
 -- last argument can be used to overwrite or append, defaults to neither (returns if file exists)
 function Main.CopyFile(filename, newfilename, overwriteappend)
-	if not Main.FileExists(filename) or (Main.FileExists(newfilename) and not (overwriteappend == "overwrite" or overwriteappend == "append")) then
+	local original = io.open(filename, "rb")
+	if original == nil then
+		print(string.format("Error: Unable to create a backup copy of %s."), filename)
+		return false
+	elseif (Main.FileExists(newfilename) and not (overwriteappend == "overwrite" or overwriteappend == "append")) then
+		print(string.format("Error: Can't overwrite file %s."), newfilename)
 		return false
 	end
 
-	local original = io.open(filename, "rb")
 	local copy = ""
 	if overwriteappend == "append" then
 		copy = io.open(newfilename, "ab")
@@ -443,6 +447,10 @@ function Main.CopyFile(filename, newfilename, overwriteappend)
 		copy = io.open(newfilename, "wb")
 	end
 
+	if copy == nil then
+		print(string.format("Error: Failed to write to file %s."), newfilename)
+		return false
+	end
 
 	local nextBlock = original:read(2^13)
 	while nextBlock ~= nil do

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -421,8 +421,9 @@ function Main.GenerateNextRom()
 end
 
 function Main.SaveCurrentRom(filename)
-	Main.CopyFile(filename, string.format("prev-seed %s", filename))
-	Main.CopyFile(string.format("%s.log", filename), string.format("prev-seed %s.log", filename))
+	local newseedfilename = filename:gsub(Constants.Files.PostFixes.AUTORANDOMIZED, Constants.Files.PostFixes.PREVIOUSATTEMPT)
+	Main.CopyFile(filename, newseedfilename)
+	Main.CopyFile(string.format("%s.log", filename), string.format("%s.log", newseedfilename))
 end
 
 function Main.CopyFile(filename, newfilename)

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -440,14 +440,12 @@ function Main.CopyFile(filename, newfilename)
 	while true do
 		local originalBlock = original:read(2^13)
 		if not originalBlock then 
-			original = original:seek("end")
 		  break
 		end
 		copy:write(originalBlock)
 	end
 
 	original:close()
-	copy = copy:seek("end")
 	copy:close()
 end
 

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -422,27 +422,32 @@ end
 
 function SaveCurrentRom(filename)
 	if Main.FileExists(filename) then
-		local currentrom = io.open(filename, "rb")
-		local historyrom = io.open(string.format("seed-%s %s", Main.ReadAttemptsCounter(), filename), "wb")
-
-		while true do
-			local currentromBlock = currentrom:read(2^13)
-			if not currentromBlock then 
-			  currentrom = currentrom:seek("end")
-			  break
-			end
-			historyrom:write(currentromBlock)
-		end
-
-		currentrom:close()
-		historyrom = historyrom:seek("end")
-		historyrom:close()
+		Main.CopyFile(filename, string.format("seed-%s %s", Main.ReadAttemptsCounter(), filename))
+		Main.CopyFile(string.format("%s.log", filename), string.format("seed-%s %s.log", Main.ReadAttemptsCounter(), filename))
 
 		olderromfilename = string.format("seed-%s %s", Main.ReadAttemptsCounter() - 5, filename)
 		if Main.FileExists(olderromfilename) then
 			os.remove(olderromfilename)
 		end
 	end
+end
+
+function Main.CopyFile(filename, newfilename)
+	local original = io.open(filename, "rb")
+	local copy = io.open(newfilename, "wb")
+
+	while true do
+		local originalBlock = original:read(2^13)
+		if not originalBlock then 
+			original = original:seek("end")
+		  break
+		end
+		copy:write(originalBlock)
+	end
+
+	original:close()
+	copy = copy:seek("end")
+	copy:close()
 end
 
 -- Increment the attempts counter through a .txt file

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -422,14 +422,8 @@ end
 
 function Main.SaveCurrentRom(filename)
 	if Main.FileExists(filename) then
-		Main.CopyFile(filename, string.format("seed-%s %s", Main.currentSeed, filename))
-		Main.CopyFile(string.format("%s.log", filename), string.format("seed-%s %s.log", Main.currentSeed, filename))
-
-		olderromfilename = string.format("seed-%s %s", Main.currentSeed - 5, filename)
-		if Main.FileExists(olderromfilename) then
-			os.remove(olderromfilename)
-			os.remove(string.format("%s.log", olderromfilename))
-		end
+		Main.CopyFile(filename, string.format("prev-seed %s", filename))
+		Main.CopyFile(string.format("%s.log", filename), string.format("prev-seed %s.log", filename))
 	end
 end
 

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -430,12 +430,10 @@ function Main.CopyFile(filename, newfilename)
 		local original = io.open(filename, "rb")
 		local copy = io.open(newfilename, "wb")
 
-		while true do
-			local originalBlock = original:read(2^13)
-			if not originalBlock then
-		  	break
-			end
-			copy:write(originalBlock)
+		local nextBlock = original:read(2^13)
+		while nextBlock ~= nil do
+			copy:write(nextBlock)
+			nextBlock = original:read(2^13)
 		end
 
 		original:close()

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -421,26 +421,26 @@ function Main.GenerateNextRom()
 end
 
 function Main.SaveCurrentRom(filename)
-	if Main.FileExists(filename) then
-		Main.CopyFile(filename, string.format("prev-seed %s", filename))
-		Main.CopyFile(string.format("%s.log", filename), string.format("prev-seed %s.log", filename))
-	end
+	Main.CopyFile(filename, string.format("prev-seed %s", filename))
+	Main.CopyFile(string.format("%s.log", filename), string.format("prev-seed %s.log", filename))
 end
 
 function Main.CopyFile(filename, newfilename)
-	local original = io.open(filename, "rb")
-	local copy = io.open(newfilename, "wb")
+	if Main.FileExists(filename) then
+		local original = io.open(filename, "rb")
+		local copy = io.open(newfilename, "wb")
 
-	while true do
-		local originalBlock = original:read(2^13)
-		if not originalBlock then 
-		  break
+		while true do
+			local originalBlock = original:read(2^13)
+			if not originalBlock then
+		  	break
+			end
+			copy:write(originalBlock)
 		end
-		copy:write(originalBlock)
-	end
 
-	original:close()
-	copy:close()
+		original:close()
+		copy:close()
+	end
 end
 
 -- Increment the attempts counter through a .txt file

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -422,18 +422,27 @@ end
 
 function Main.SaveCurrentRom(filename)
 	local newseedfilename = filename:gsub(Constants.Files.PostFixes.AUTORANDOMIZED, Constants.Files.PostFixes.PREVIOUSATTEMPT)
-	if Main.CopyFile(filename, newseedfilename, true) then
-		Main.CopyFile(string.format("%s.log", filename), string.format("%s.log", newseedfilename), true)
+	if Main.CopyFile(filename, newseedfilename, "overwrite") then
+		Main.CopyFile(string.format("%s.log", filename), string.format("%s.log", newseedfilename), "overwrite")
 	end
 end
 
-function Main.CopyFile(filename, newfilename, overwrite)
-	if not Main.FileExists(filename) or (Main.FileExists(newfilename) and not overwrite) then
+-- Copy a file
+-- last argument can be used to overwrite or append, defaults to neither (returns if file exists)
+function Main.CopyFile(filename, newfilename, overwriteappend)
+	if not Main.FileExists(filename) or (Main.FileExists(newfilename) and not (overwriteappend == "overwrite" or overwriteappend == "append")) then
 		return false
 	end
-	
+
 	local original = io.open(filename, "rb")
-	local copy = io.open(newfilename, "wb")
+	local copy = ""
+	if overwriteappend == "append" then
+		copy = io.open(newfilename, "ab")
+		copy:seek("end")
+	else
+		copy = io.open(newfilename, "wb")
+	end
+
 
 	local nextBlock = original:read(2^13)
 	while nextBlock ~= nil do
@@ -443,7 +452,7 @@ function Main.CopyFile(filename, newfilename, overwrite)
 
 	original:close()
 	copy:close()
-	
+
 	return true
 end
 

--- a/Ironmon-Tracker.lua
+++ b/Ironmon-Tracker.lua
@@ -388,6 +388,8 @@ function Main.GenerateNextRom()
 	local nextromname = string.format("%s %s%s", filename, Constants.Files.PostFixes.AUTORANDOMIZED, Constants.Files.Extensions.GBA_ROM)
 	local nextrompath = Utils.getWorkingDirectory() .. nextromname
 
+	Main.SaveCurrentRom(nextromname)
+
 	Main.IncrementAttemptsCounter(attemptsfile, 1)
 
 	local javacommand = string.format(
@@ -416,6 +418,26 @@ function Main.GenerateNextRom()
 	 	name = nextromname,
 	 	path = nextrompath,
 	}
+end
+
+function SaveCurrentRom(filename)
+	if Main.FileExists(filename) then
+		local currentrom = io.open(filename, "rb")
+		local historyrom = io.open(string.format("seed-%s %s", Main.ReadAttemptsCounter(), filename), "wb")
+
+		while true do
+			local currentromBlock = currentrom:read(2^13)
+			if not currentromBlock then 
+			  currentrom = currentrom:seek("end")
+			  break
+			end
+			historyrom:write(currentromBlock)
+		end
+
+		currentrom:close()
+		historyrom = historyrom:seek("end")
+		historyrom:close()
+	end
 end
 
 -- Increment the attempts counter through a .txt file

--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -10,6 +10,7 @@ Constants.Files = {
 	PostFixes = {
 		ATTEMPTS_FILE = "Attempts.txt",
 		AUTORANDOMIZED = "AutoRandomized",
+		PREVIOUSATTEMPT = "PreviousAttempt",
 		AUTOSAVE = "AutoSave",
 	},
 	Extensions = {


### PR DESCRIPTION
This PR intends to save the last seed played when the user requests a new one, so they can go back to it (for log review or when reset was unintended).