### PR TITLE
Enhancement: Exposing the Accuracy and Evasion stat changes

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -249,7 +249,9 @@ function Battle.updateTrackedInfo()
 							if not battlerTransformData.isOwn then
 								local lastMoveByBattler = Memory.readword(GameSettings.gBattleResults + 0x22 + ((Battle.battler % 2) * 0x2))
 								local battlerMon = Tracker.getPokemon(battlerTransformData.slot,battlerTransformData.isOwn)
-								Tracker.TrackMove(battlerMon.pokemonID, lastMoveByBattler, battlerMon.level)
+								if battlerMon ~= nil then
+									Tracker.TrackMove(battlerMon.pokemonID, lastMoveByBattler, battlerMon.level)
+								end
 							end
 						else
 							--Only track moves for enemies; our moves could be TM moves, or moves we didn't forget from earlier levels

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -812,9 +812,20 @@ function TrackerScreen.drawStatsArea(pokemon)
 		statOffsetY = statOffsetY + 10
 	end
 
-	-- Draw BST
-	Drawing.drawText(statOffsetX, statOffsetY, "BST", Theme.COLORS["Default text"], shadowcolor)
-	Drawing.drawNumber(statOffsetX + 25, statOffsetY, pokemon.bst, 3, Theme.COLORS["Default text"], shadowcolor)
+	-- Draw BST or ACC/EVA
+	-- The "ACC" and "EVA" stats occupy the same space as the "BST". Prioritize showing ACC/EVA if either has changed during battle (6 is neutral)
+	local useAccEvaInstead = Battle.inBattle and (pokemon.statStages.acc ~= 6 or pokemon.statStages.eva ~= 6)
+	if useAccEvaInstead then
+		Drawing.drawText(statOffsetX - 1, statOffsetY + 1, "Acc", Theme.COLORS["Default text"], shadowcolor)
+		Drawing.drawText(statOffsetX + 27, statOffsetY + 1, "Eva", Theme.COLORS["Default text"], shadowcolor)
+		local accIntensity = pokemon.statStages.acc - 6
+		local evaIntensity = pokemon.statStages.eva - 6
+		Drawing.drawChevrons(statOffsetX + 15, statOffsetY + 5, accIntensity, 3)
+		Drawing.drawChevrons(statOffsetX + 22, statOffsetY + 5, evaIntensity, 3)
+	else
+		Drawing.drawText(statOffsetX, statOffsetY, "BST", Theme.COLORS["Default text"], shadowcolor)
+		Drawing.drawNumber(statOffsetX + 25, statOffsetY, pokemon.bst, 3, Theme.COLORS["Default text"], shadowcolor)
+	end
 
 	-- If controller is in use and highlighting any stats, draw that
 	Drawing.drawInputOverlay()


### PR DESCRIPTION
resolves #288 

The Acc/Eva stats will only be displayed if all of the following are true:
1. At least one of the two stats has changed
2. You are in battle (implied)

Also snuck in a small nil check for something lua-check was yelling about

![image](https://user-images.githubusercontent.com/4258818/200736220-96470cfc-bfef-4705-8345-6366040ee933.png)