### PR TITLE
Quick hotfixes for upcoming 7.0.0 Release

### DIFF
--- a/ironmon_tracker/screens/UpdateScreen.lua
+++ b/ironmon_tracker/screens/UpdateScreen.lua
@@ -146,7 +146,7 @@ function UpdateScreen.executeBatchOperations()
 	-- Each individual command listed in order, to be appended together later
 	local batchCommands = {
 		'(echo Downloading the latest Ironmon Tracker version.',
-		string.format('curl -L "%s" -o "%s"', Constants.Release.TAR_URL, archiveName),
+		string.format('curl -L "%s" -o "%s" --ssl-no-revoke', Constants.Release.TAR_URL, archiveName),
 		'echo; && echo Extracting downloaded files.', -- "echo;" prints a new line
 		string.format('tar -xf "%s" && del "%s"', archiveName, archiveName),
 		'echo; && echo Applying the update; copying over files.',


### PR DESCRIPTION
This adds two small fixes. This is important as one of them might be preventing automatic updating for some users (ssl revoke).

Summary of changes:
- This adds a `--ssl-no-revoke` parameter to the `curl` calls for version checking and archive downloading. In some rare cases, the curl would fail if this param is not present.
- Adding more logical version check comparison. Instead of simply a "not equals" to determine if a new version is out, this will now properly check to see if that version is "newer" than the current one.

