### PR TITLE
Merging Bugfixes into Staging: Several nil checks and RSE RouteInfo additions

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -555,12 +555,6 @@ function Battle.endCurrentBattle()
 		RightOwn = 2,
 		RightOther = 2,
 	}
-	Battle.isTransformed = {
-		LeftOwn = false,
-		LeftOther = false,
-		RightOwn = false,
-		RightOther = false,
-	}
 	Battle.BattleAbilities = {
 		[0] = {},
 		[1] = {},

--- a/ironmon_tracker/Debug/Symbols.lua
+++ b/ironmon_tracker/Debug/Symbols.lua
@@ -88,7 +88,7 @@ function Symbols.populateSymbolsMap()
 		local gameValues = Symbols.symbolSources[i]
 		gameValues.symbols = {}
 		for j = 1, #Symbols.symbolSearch, 1 do
-			local symbolFile = io.open(gameValues.fileName,"r")
+			local symbolFile = io.open(gameValues.fileName,"r") or ""
 			local found = false
 			local variableName = Symbols.symbolSearch[j][1]
 			if Symbols.FRToOtherGameNameMap[variableName] ~= nil and Symbols.FRToOtherGameNameMap[variableName][gameValues.gameType] ~= nil then
@@ -128,7 +128,7 @@ function Symbols.writeSymbolsToFile()
 							offsetGE = "0x" .. string.format("%x",(tonumber(prevSym,16)) + 0x4226)
 						end
 						writeFile:write(" " .. offsetSP .. ", " .. offsetIT .. ", " .. offsetFR .. ", " .. offsetGE .. ",")
-					end	
+					end
 					writeFile:write("},\n\t{")
 					Symbols.gameType = gameValues.gameType
 				end

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -417,6 +417,10 @@ end
 
 -- Creates a backup copy of a ROM 'filename' and its log file, labeling them as "PreviousAttempt"
 function Main.SaveCurrentRom(filename)
+	if filename == nil then
+		return
+	end
+
 	local filenameCopy = filename:gsub(Constants.Files.PostFixes.AUTORANDOMIZED, Constants.Files.PostFixes.PREVIOUSATTEMPT)
 	if Main.CopyFile(filename, filenameCopy, "overwrite") then
 		local logFilename = string.format("%s.log", filename)
@@ -428,9 +432,13 @@ end
 -- Copies 'filename' to 'nameOfCopy' with option to overwrite the file if it exists, or append to it
 -- overwriteOrAppend: 'overwrite' replaces any existing file, 'append' adds to it instead, otherwise no change if file already exists
 function Main.CopyFile(filename, nameOfCopy, overwriteOrAppend)
+	if filename == nil or filename == "" then
+		return false
+	end
+
 	local originalFile = io.open(filename, "rb")
 	if originalFile == nil then
-		print(string.format("Error: Unable to create a backup copy of %s, file doesn't exist."), filename)
+		-- The originalFile to copy doesn't exist, simply do nothing and don't copy
 		return false
 	end
 
@@ -438,7 +446,7 @@ function Main.CopyFile(filename, nameOfCopy, overwriteOrAppend)
 
 	-- If the file exists but the option to overwrite/append was not specified, avoid altering the file
 	if Main.FileExists(nameOfCopy) and not (overwriteOrAppend == "overwrite" or overwriteOrAppend == "append") then
-		print(string.format("Error: Unable to modify file %s, no overwrite/append option specified."), nameOfCopy)
+		print(string.format('Error: Unable to modify file "%s", no overwrite/append option specified.'), nameOfCopy or "N/A")
 		return false
 	end
 
@@ -451,7 +459,7 @@ function Main.CopyFile(filename, nameOfCopy, overwriteOrAppend)
 	end
 
 	if copyOfFile == nil then
-		print(string.format("Error: Failed to write to file %s."), nameOfCopy)
+		print(string.format('Error: Failed to write to file "%s"'), nameOfCopy or "N/A")
 		return false
 	end
 

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -228,7 +228,8 @@ function Main.CheckForVersionUpdate(forcedCheck)
 
 	-- Only notify about updates once per day
 	if forcedCheck or todaysDate ~= Main.Version.dateChecked then
-		local pipe = io.popen("curl " .. Constants.Release.VERSION_URL) or ""
+		local update_cmd = string.format('curl "%s" --ssl-no-revoke', Constants.Release.VERSION_URL)
+		local pipe = io.popen(update_cmd) or ""
 		if pipe ~= "" then
 			local response = pipe:read("*all") or ""
 

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -503,7 +503,7 @@ function Tracker.loadData(filepath)
 		end
 		local slashpattern = Utils.inlineIf(Main.OS == "Windows", "^.*()\\", "^.*()/")
 		local fileNameIndex = string.match(filepath, slashpattern)
-		local filename = string.sub(filepath, Utils.inlineIf(fileNameIndex ~= nil, fileNameIndex, 0) + 1) or ""
+		local filename = string.sub(filepath, (fileNameIndex or 0) + 1) or ""
 
 		Tracker.DataMessage = Tracker.LoadStatusMessages.fromFile .. Utils.inlineIf(filename ~= "", ": " .. filename, "")
 	else

--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -253,6 +253,8 @@ function RouteData.getEncounterAreaPokemon(mapId, encounterArea)
 
 	local pIndex = RouteData.getIndexForGameVersion()
 	local areaInfo = {}
+	-- Eventually fix this by more clearly separating a route's name from its encounters. eg. (encounters.wild)
+---@diagnostic disable-next-line: param-type-mismatch
 	for _, encounter in pairs(RouteData.Info[mapId][encounterArea]) do
 		local pokemonID
 		if type(encounter.pokemonID) == "number" then

--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -3818,6 +3818,8 @@ function RouteData.setupRouteInfoAsRSE()
 	}
 
 	RouteData.Info[270 + offset] = { name = Constants.Words.POKEMON .. " League PC", }
+	RouteData.Info[271 + offset] = { name = "Weather Institute 1F", }
+	RouteData.Info[272 + offset] = { name = "Weather Institute 2F", }
 	RouteData.Info[285 + offset] = { name = "Victory Road B1F",
 		[RouteData.EncounterArea.LAND] = {
 			{ pokemonID = 42, rate = 0.35, },

--- a/ironmon_tracker/screens/QuickloadScreen.lua
+++ b/ironmon_tracker/screens/QuickloadScreen.lua
@@ -137,9 +137,9 @@ function QuickloadScreen.handleSetRomFolder(button)
 	if file ~= "" then
 		-- Since the user had to pick a file, strip out the file name to just get the folder path
 		local slashpattern = Utils.inlineIf(Main.OS == "Windows", "^.*()\\", "^.*()/")
-		file = file:sub(0, file:match(slashpattern) - 1)
+		file = file:sub(0, (file:match(slashpattern) or 1) - 1)
 
-		if file == nil then
+		if file == nil or file == "" then
 			Options.FILES[button.labelText] = ""
 			button.isSet = false
 			button.text = " SET"

--- a/ironmon_tracker/screens/UpdateScreen.lua
+++ b/ironmon_tracker/screens/UpdateScreen.lua
@@ -115,6 +115,11 @@ function UpdateScreen.performAutoUpdate()
 	local wasSoundOn = client.GetSoundOn()
 	client.SetSoundOn(false)
 
+	-- Don't bother saving tracked data if the player doesn't have a Pokemon yet
+	if Options["Auto save tracked game data"] and Tracker.getPokemon(1, true) ~= nil then
+		Tracker.saveData()
+	end
+
 	gui.clearImageCache() -- Required to make Bizhawk release images so that they can be replaced
 	emu.frameadvance() -- Required to allow the redraw to occur before batch commands begin
 

--- a/ironmon_tracker/screens/UpdateScreen.lua
+++ b/ironmon_tracker/screens/UpdateScreen.lua
@@ -146,7 +146,7 @@ function UpdateScreen.executeBatchOperations()
 	-- Each individual command listed in order, to be appended together later
 	local batchCommands = {
 		'(echo Downloading the latest Ironmon Tracker version.',
-		string.format('curl -L "%s" -o "%s"', Constants.Release.TAR_URL, archiveName),
+		string.format('curl -L "%s" -o "%s" --ssl-no-revoke', Constants.Release.TAR_URL, archiveName),
 		'echo; && echo Extracting downloaded files.', -- "echo;" prints a new line
 		string.format('tar -xf "%s" && del "%s"', archiveName, archiveName),
 		'echo; && echo Applying the update; copying over files.',


### PR DESCRIPTION
Summary of fixes:
- Fixed a critical missing nil check when Quickloading for the very first time
   - no original autorandomized file to copy
- When performing an auto-update, the Tracked Data is now first saved to the TDAT file, then the update occurs
- Added two extra routes names for trainer battles in RSE:
   - Weather Institute 1F
   - Weather Institute 2F
- Cleaning up some unused variables in `Battle.lua`
- Fixed a missing nil check when using ROM Folder Quickload without first restarting Bizhawk
