### PR TITLE
New Feature: Pedometer, an optional step counter

### DIFF
--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -87,6 +87,7 @@ Constants.MoveTypeColors = {
 
 Constants.GAME_STATS = { -- Enums for in-game stats
 	-- https://github.com/pret/pokefirered/blob/master/include/constants/game_stat.h
+	GAME_STAT_STEPS = 5,
 	FISHING_CAPTURES = 12, -- Deceptive name, gets incremented when fishing encounter happens
 	USED_POKECENTER = 15,
 	RESTED_AT_HOME = 16,
@@ -140,6 +141,7 @@ Constants.OrderedLists = {
 		"Generate ROM each time",
 		"Display repel usage",
 		"Startup Pokemon displayed",
+		"Display pedometer",
 	},
 	CONTROLS = {
 		"Load next seed",

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -31,6 +31,7 @@ Options = {
 	["Use premade ROMs"] = false,
 	["Generate ROM each time"] = false,
 	["Display repel usage"] = false,
+	["Display pedometer"] = false,
 
 	CONTROLS = {
 		["Load next seed"] = "A, B, Start",

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -45,6 +45,14 @@ Program.GameData = {
 	},
 }
 
+Program.Pedometer = {
+	totalSteps = 0, -- updated from GAME_STATS
+	lastResetCount = 0, -- num steps since last "reset", for counting new steps
+	goalSteps = 0, -- num steps that is set by the user as a milestone goal to reach, 0 to disable
+	getCurrentStepcount = function(self) return math.max(self.totalSteps - self.lastResetCount, 0) end,
+	isInUse = function(self) return Options["Display pedometer"] and not Battle.inBattle and not Program.inStartMenu end,
+}
+
 function Program.initialize()
 	-- If an update is available, offer that up first before going to the Tracker StartupScreen
 	if Main.Version.showUpdate then
@@ -148,6 +156,11 @@ function Program.update()
 				if not Program.inStartMenu then
 					Program.updateRepelSteps()
 				end
+			end
+
+			-- Update step count only if the option is enabled
+			if Program.Pedometer:isInUse() then
+				Program.Pedometer.totalSteps = Utils.getGameStat(Constants.GAME_STATS.GAME_STAT_STEPS)
 			end
 		end
 	end

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -29,10 +29,15 @@ function Utils.centerTextOffset(text, charSize, width)
 	return (width - (charSize * text:len())) / 2
 end
 
--- Accepts a positive or negative integer and returns a string formatted as "12,345"
-function Utils.formatNumberWithCommas(integer)
-	if integer == nil then return "" end
-	return tostring(math.floor(integer)):reverse():gsub("(%d%d%d)","%1,"):gsub(",(%-?)$","%1"):reverse()
+-- Accepts a number, positive or negative and with/without fractions, and returns a string formatted as "12,345.6789"
+function Utils.formatNumberWithCommas(number)
+	local _, _, minus, int, fraction = tostring(number):find('([-]?)(%d+)([.]?%d*)')
+
+	-- reverse the int-string and append a comma to all blocks of 3 digits
+	int = int:reverse():gsub("(%d%d%d)", "%1,")
+
+  -- reverse the int-string back remove an optional comma and put the optional minus and fractional part back
+  return minus .. int:reverse():gsub("^,", "") .. fraction
 end
 
 function Utils.randomPokemonID()

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -29,6 +29,12 @@ function Utils.centerTextOffset(text, charSize, width)
 	return (width - (charSize * text:len())) / 2
 end
 
+-- Accepts a positive or negative integer and returns a string formatted as "12,345"
+function Utils.formatNumberWithCommas(integer)
+	if integer == nil then return "" end
+	return tostring(math.floor(integer)):reverse():gsub("(%d%d%d)","%1,"):gsub(",(%-?)$","%1"):reverse()
+end
+
 function Utils.randomPokemonID()
 	local pokemonID = math.random(PokemonData.totalPokemon - 25)
 	if pokemonID > 251 then

--- a/ironmon_tracker/screens/GameOptionsScreen.lua
+++ b/ironmon_tracker/screens/GameOptionsScreen.lua
@@ -15,6 +15,7 @@ GameOptionsScreen.OptionKeys = {
 	"Count enemy PP usage",
 	"Show last damage calcs",
 	"Reveal info if randomized",
+	"Display pedometer",
 }
 
 GameOptionsScreen.Buttons = {
@@ -22,7 +23,7 @@ GameOptionsScreen.Buttons = {
 		type = Constants.ButtonTypes.FULL_BORDER,
 		text = "  Estimate " .. Constants.Words.POKEMON .. "'s Potential",
 		ivText = "",
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 5, Constants.SCREEN.MARGIN + 114, 130, 11 },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 5, Constants.SCREEN.MARGIN + 122, 130, 11 },
 		onClick = function() GameOptionsScreen.displayJudgeMessage() end
 	},
 	Back = {
@@ -40,7 +41,7 @@ GameOptionsScreen.Buttons = {
 
 function GameOptionsScreen.initialize()
 	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 3
-	local startY = Constants.SCREEN.MARGIN + 14
+	local startY = Constants.SCREEN.MARGIN + 13
 
 	for _, optionKey in ipairs(GameOptionsScreen.OptionKeys) do
 		GameOptionsScreen.Buttons[optionKey] = {


### PR DESCRIPTION
This is a commonly requested feature option, to be able to count steps you take during gameplay. Luckily, this stat is already tracked by the game itself.

#### What this feature offers:
- An option under **Gameplay Options** to enable or disable; it's disabled by default
- When enabled, it occupies the same space on the Main Tracker screen as the Badges carousel
   - Disabling the main screen carousel option forces the pedometer to display instead of the badges
- The step counter shows total number of steps taken so far (max of 999,999; not sure what the real cap is)
- Clicking "**Reset**" will temporarily clear this out, starting back over at 0. Click it again to go back to showing the Total steps
- Clicking "**Goal**" will prompt the player to enter a number of steps to use as a goal post or milestone. When the step counter displays a number equal to or greater to the goal number, it will highlight to show that the goal has been reached.
   - When a goal is set, then the button color changes to indicate that a current goal is active

#### Functionality notes:
- None of this information is saved between runs. The total steps are tracked by the game itself, so no need to track them in the Tracker.
- The player will have to manually set the step goal each time they start a new run or load up an old game. This info isn't saved. I don't think it needs to be saved, since the purpose and use-case may change from game-to-game
- The Gameplay Options screen is getting crowded. We're gonna need to come up with a better organization method soonish

![image](https://user-images.githubusercontent.com/4258818/201466841-3238c458-d23b-4c9b-bdd3-fca2ba01d03c.png)
