### PR TITLE
Merging Bugfixes into Staging: Low Kick vs Tower-Ghost fix

### DIFF
--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -144,7 +144,7 @@ end
 function Utils.calculateMoveStars(pokemonID, level)
 	local stars = { "", "", "", "" }
 
-	if pokemonID == nil or pokemonID == 0 or level == nil or level == 1 then
+	if not PokemonData.isValid(pokemonID) or level == nil or level == 1 then
 		return stars
 	end
 
@@ -435,7 +435,7 @@ end
 
 -- Returns a number between 0 and 1, where 1 is best possible IVs and 0 is no IVs
 function Utils.estimateIVs(pokemon)
-	if pokemon == nil or pokemon.pokemonID == 0 then
+	if pokemon == nil or not PokemonData.isValid(pokemon.pokemonID) then
 		return 0
 	end
 

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -329,6 +329,11 @@ end
 
 -- For Low Kick & Grass Knot. Weight in kg. Bounds are inclusive per decompiled code.
 function Utils.calculateWeightBasedDamage(movePower, weight)
+	-- For unknown Pokemon such as unidentified ghost pokemon (e.g. Silph Scope required)
+	if weight == 0.0 then
+		return "0"
+	end
+
 	-- For randomized move powers, unsure what these two moves get changed to
 	if weight < 10.0 then
 		return "20"

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -148,7 +148,10 @@ function PokemonData.checkIfDataIsRandomized()
 end
 
 function PokemonData.getAbilityId(pokemonID, abilityNum)
-	if abilityNum == nil then return 0 end
+	if abilityNum == nil or not PokemonData.isValid(pokemonID) then
+		return 0
+	end
+
 	local pokemon = PokemonData.Pokemon[pokemonID]
 	local abilityId = pokemon.abilities[abilityNum + 1] -- stored from memory as [0 or 1]
 	return abilityId

--- a/ironmon_tracker/screens/GameOptionsScreen.lua
+++ b/ironmon_tracker/screens/GameOptionsScreen.lua
@@ -73,7 +73,7 @@ end
 
 function GameOptionsScreen.displayJudgeMessage()
 	local leadPokemon = Battle.getViewedPokemon(true)
-	if leadPokemon ~= nil then
+	if leadPokemon ~= nil and PokemonData.isValid(leadPokemon.pokemonID) then
 		-- https://bulbapedia.bulbagarden.net/wiki/Stats_judge
 		local result
 		local ivEstimate = Utils.estimateIVs(leadPokemon) * 186

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -341,7 +341,12 @@ function InfoScreen.openPokemonInfoWindow()
 	Program.activeFormId = pokedexLookup
 	Utils.setFormLocation(pokedexLookup, 100, 50)
 
-	local pokemonName = PokemonData.Pokemon[InfoScreen.infoLookup].name -- infoLookup = pokemonID
+	local pokemonName
+	if PokemonData.isValid(InfoScreen.infoLookup) then -- infoLookup = pokemonID
+		pokemonName = PokemonData.Pokemon[InfoScreen.infoLookup].name
+	else
+		pokemonName = ""
+	end
 	local pokedexData = PokemonData.toList()
 
 	forms.label(pokedexLookup, "Choose a Pokemon to look up:", 49, 10, 250, 20)

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -469,7 +469,7 @@ function TrackerScreen.updateButtonStates()
 end
 
 function TrackerScreen.openNotePadWindow(pokemonId)
-	if pokemonId == nil or pokemonId == 0 then return end
+	if not PokemonData.isValid(pokemonId) then return end
 
 	Program.destroyActiveForm()
 	local noteForm = forms.newform(465, 220, "Leave a Note", function() client.unpause() end)
@@ -960,7 +960,14 @@ function TrackerScreen.drawMovesArea(pokemon, opposingPokemon)
 		if Options["Calculate variable damage"] then
 			if moveData.id == "67" and Battle.inBattle and opposingPokemon ~= nil then
 				-- Calculate the power of Low Kick (weight-based moves) in battle
-				local targetWeight = PokemonData.Pokemon[opposingPokemon.pokemonID].weight
+				local targetWeight
+				if opposingPokemon.weight ~= nil then
+					targetWeight = opposingPokemon.weight
+				elseif PokemonData.Pokemon[opposingPokemon.pokemonID] ~= nil then
+					targetWeight = PokemonData.Pokemon[opposingPokemon.pokemonID].weight
+				else
+					targetWeight = 0
+				end
 				movePower = Utils.calculateWeightBasedDamage(movePower, targetWeight)
 			elseif Tracker.Data.isViewingOwn then
 				if moveData.id == "175" or moveData.id == "179" then


### PR DESCRIPTION
Summary of fixes:
- Fixed an issue where encountering an unidentified ghost Pokemon in the Pokemon Tower while having the move Low Kick would cause the Tracker to crash
- Subsequently fixed other potential look ups where trying to get a Pokemon not within the data set.