### PR TITLE
Enhancement: Reorganizing the Nav Menu layout

### DIFF
--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -44,6 +44,7 @@ Constants.Release = {
 	VERSION_URL = "https://api.github.com/repos/besteon/Ironmon-Tracker/releases/latest",
 	DOWNLOAD_URL = "https://github.com/besteon/Ironmon-Tracker/releases/latest",
 	TAR_URL = "https://github.com/besteon/Ironmon-Tracker/archive/main.tar.gz",
+	WIKI_URL = "https://github.com/besteon/Ironmon-Tracker/wiki",
 }
 
 Constants.ButtonTypes = {
@@ -187,6 +188,7 @@ Constants.OrderedLists = {
 }
 
 Constants.PixelImages = {
+	BLANK = { { 0 } }, -- Helpful for padding out certain buttons
 	GEAR = {
 		{0,0,0,1,1,0,0,0},
 		{0,1,1,1,1,1,1,0},

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -101,6 +101,8 @@ function Input.checkMouseInput(xmouse, ymouse)
 		Input.checkButtonsClicked(xmouse, ymouse, UpdateScreen.Buttons)
 	elseif Program.currentScreen == Program.Screens.SETUP then
 		Input.checkButtonsClicked(xmouse, ymouse, SetupScreen.Buttons)
+	elseif Program.currentScreen == Program.Screens.EXTRAS then
+		Input.checkButtonsClicked(xmouse, ymouse, ExtrasScreen.Buttons)
 	elseif Program.currentScreen == Program.Screens.QUICKLOAD then
 		Input.checkButtonsClicked(xmouse, ymouse, QuickloadScreen.Buttons)
 	elseif Program.currentScreen == Program.Screens.GAME_SETTINGS then

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -41,6 +41,7 @@ function Main.Initialize()
 		"/screens/StartupScreen.lua",
 		"/screens/UpdateScreen.lua",
 		"/screens/SetupScreen.lua",
+		"/screens/ExtrasScreen.lua",
 		"/screens/QuickloadScreen.lua",
 		"/screens/GameOptionsScreen.lua",
 		"/screens/TrackedDataScreen.lua",
@@ -196,6 +197,7 @@ function Main.Run()
 		StartupScreen.initialize()
 		UpdateScreen.initialize()
 		SetupScreen.initialize()
+		ExtrasScreen.initialize()
 		QuickloadScreen.initialize()
 		GameOptionsScreen.initialize()
 		TrackedDataScreen.initialize()

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -5,7 +5,7 @@ Main.Version = { major = "7", minor = "0", patch = "1" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",
-	Contributors = { "UTDZac", "Fellshadow", "bdjeffyp", "OnlySpaghettiCode", "thisisatest", "Amber Cyprian", "ninjafriend", "kittenchilly", "Kurumas", "davidhouweling", "AKD", "rcj001", "GB127", },
+	Contributors = { "UTDZac", "Fellshadow", "bdjeffyp", "OnlySpaghettiCode", "ninjafriend", "Amber Cyprian", "thisisatest", "kittenchilly", "Kurumas", "davidhouweling", "AKD", "rcj001", "GB127", },
 }
 
 -- Returns false if an error occurs that completely prevents the Tracker from functioning; otherwise, returns true

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -5,7 +5,7 @@ Main.Version = { major = "7", minor = "0", patch = "1" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",
-	Contributors = { "UTDZac", "Fellshadow", "bdjeffyp", "OnlySpaghettiCode", "ninjafriend", "Amber Cyprian", "thisisatest", "kittenchilly", "Kurumas", "davidhouweling", "AKD", "rcj001", "GB127", },
+	Contributors = { "UTDZac", "Fellshadow", "ninjafriend", "OnlySpaghettiCode", "bdjeffyp", "Amber Cyprian", "thisisatest", "kittenchilly", "Kurumas", "davidhouweling", "AKD", "rcj001", "GB127", },
 }
 
 -- Returns false if an error occurs that completely prevents the Tracker from functioning; otherwise, returns true

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -28,6 +28,7 @@ Program.Screens = {
 	STARTUP = StartupScreen.drawScreen,
 	UPDATE = UpdateScreen.drawScreen,
 	SETUP = SetupScreen.drawScreen,
+	EXTRAS = ExtrasScreen.drawScreen,
 	QUICKLOAD = QuickloadScreen.drawScreen,
 	GAME_SETTINGS = GameOptionsScreen.drawScreen,
 	THEME = Theme.drawScreen,

--- a/ironmon_tracker/screens/ExtrasScreen.lua
+++ b/ironmon_tracker/screens/ExtrasScreen.lua
@@ -1,0 +1,136 @@
+ExtrasScreen = {
+	Labels = {
+		header = "Tracker Extras",
+	},
+	Colors = {
+		text = "Lower box text",
+		border = "Lower box border",
+		boxFill = "Lower box background",
+	},
+}
+
+ExtrasScreen.OptionKeys = {
+	"Show random ball picker",
+	"Display repel usage",
+	"Display pedometer",
+	"Animated Pokemon popout", -- Text referenced in initialize()
+}
+
+ExtrasScreen.Buttons = {
+	EstimateIVs = {
+		type = Constants.ButtonTypes.FULL_BORDER,
+		text = " Estimate " .. Constants.Words.POKEMON .. " IV Potential",
+		ivText = "",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 5, Constants.SCREEN.MARGIN + 109, 130, 11 },
+		onClick = function() ExtrasScreen.displayJudgeMessage() end
+	},
+	Back = {
+		type = Constants.ButtonTypes.FULL_BORDER,
+		text = "Back",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 112, Constants.SCREEN.MARGIN + 135, 24, 11 },
+		onClick = function(self)
+			ExtrasScreen.Buttons.EstimateIVs.ivText = "" -- keep hidden
+			-- Save all of the Options to the Settings.ini file, and navigate back to the main Tracker screen
+			Main.SaveSettings()
+			Program.changeScreenView(Program.Screens.NAVIGATION)
+		end
+	},
+}
+
+function ExtrasScreen.initialize()
+	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4
+	local startY = Constants.SCREEN.MARGIN + 14
+	local linespacing = Constants.SCREEN.LINESPACING + 1
+
+	for _, optionKey in ipairs(ExtrasScreen.OptionKeys) do
+		ExtrasScreen.Buttons[optionKey] = {
+			type = Constants.ButtonTypes.CHECKBOX,
+			text = optionKey,
+			clickableArea = { startX, startY, Constants.SCREEN.RIGHT_GAP - 12, 8 },
+			box = {	startX, startY, 8, 8 },
+			toggleState = Options[optionKey],
+			toggleColor = "Positive text",
+			onClick = function(self)
+				-- Toggle the setting and store the change to be saved later in Settings.ini
+				self.toggleState = not self.toggleState
+				Options.updateSetting(self.text, self.toggleState)
+
+				-- If Animated Pokemon popout is turned on, create the popup form, or destroy it.
+				if self.text == "Animated Pokemon popout" then
+					if self.toggleState then
+						Drawing.AnimatedPokemon:create()
+					else
+						Drawing.AnimatedPokemon:destroy()
+					end
+				end
+			end
+		}
+		startY = startY + linespacing
+	end
+
+	for _, button in pairs(ExtrasScreen.Buttons) do
+		button.textColor = ExtrasScreen.Colors.text
+		button.boxColors = { ExtrasScreen.Colors.border, ExtrasScreen.Colors.boxFill }
+	end
+
+	local animatedAddonInstalled = Main.FileExists(Utils.getWorkingDirectory() .. Main.DataFolder .. "/images/pokemonAnimated/abra.gif")
+	local animatedBtnOption = ExtrasScreen.Buttons["Animated Pokemon popout"]
+	if not animatedAddonInstalled and animatedBtnOption ~= nil then
+		animatedBtnOption.disabled = true
+	end
+end
+
+function ExtrasScreen.displayJudgeMessage()
+	local leadPokemon = Battle.getViewedPokemon(true)
+	if leadPokemon ~= nil and PokemonData.isValid(leadPokemon.pokemonID) then
+		-- https://bulbapedia.bulbagarden.net/wiki/Stats_judge
+		local result
+		local ivEstimate = Utils.estimateIVs(leadPokemon) * 186
+		if ivEstimate >= 151 then
+			result = "Outstanding!!!"
+		elseif ivEstimate >= 121 and ivEstimate <= 150 then
+			result = "Quite impressive!!"
+		elseif ivEstimate >= 91 and ivEstimate <= 120 then
+			result = "Above average!"
+		else
+			result = "Decent."
+		end
+
+		ExtrasScreen.Buttons.EstimateIVs.ivText = PokemonData.Pokemon[leadPokemon.pokemonID].name .. " is: " .. result
+
+		-- Joey's Rattata meme (saving for later)
+		-- local topPercentile = math.max(100 - 100 * Utils.estimateIVs(leadPokemon), 1)
+		-- local percentText = string.format("%g", string.format("%d", topPercentile)) .. "%" -- %g removes insignificant 0's
+		-- message = "In the top " .. percentText .. " of  " .. PokemonData.Pokemon[leadPokemon.pokemonID].name
+	else
+		ExtrasScreen.Buttons.EstimateIVs.ivText = "Estimate is unavailable."
+	end
+	Program.redraw(true)
+end
+
+-- DRAWING FUNCTIONS
+function ExtrasScreen.drawScreen()
+	Drawing.drawBackgroundAndMargins()
+	gui.defaultTextBackground(Theme.COLORS[ExtrasScreen.Colors.boxFill])
+
+	local shadowcolor = Utils.calcShadowColor(Theme.COLORS[ExtrasScreen.Colors.boxFill])
+	local topboxX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN
+	local topboxY = Constants.SCREEN.MARGIN + 10
+	local topboxWidth = Constants.SCREEN.RIGHT_GAP - (Constants.SCREEN.MARGIN * 2)
+	local topboxHeight = Constants.SCREEN.HEIGHT - (Constants.SCREEN.MARGIN * 2) - 10
+
+	-- Draw header text
+	local headerShadow = Utils.calcShadowColor(Theme.COLORS["Main background"])
+	Drawing.drawText(topboxX + 33, Constants.SCREEN.MARGIN - 2, ExtrasScreen.Labels.header:upper(), Theme.COLORS["Header text"], headerShadow)
+
+	-- Draw top border box
+	gui.drawRectangle(topboxX, topboxY, topboxWidth, topboxHeight, Theme.COLORS[ExtrasScreen.Colors.border], Theme.COLORS[ExtrasScreen.Colors.boxFill])
+
+	-- Draw all buttons
+	for _, button in pairs(ExtrasScreen.Buttons) do
+		Drawing.drawButton(button, shadowcolor)
+	end
+
+	local ivBtn = ExtrasScreen.Buttons.EstimateIVs
+	Drawing.drawText(topboxX + 4, ivBtn.box[2] + ivBtn.box[4] + 1, ivBtn.ivText, Theme.COLORS[ivBtn.textColor], shadowcolor)
+end

--- a/ironmon_tracker/screens/GameOptionsScreen.lua
+++ b/ironmon_tracker/screens/GameOptionsScreen.lua
@@ -7,7 +7,6 @@ GameOptionsScreen = {
 
 GameOptionsScreen.OptionKeys = {
 	"Auto swap to enemy",
-	"Show random ball picker",
 	"Hide stats until summary shown",  -- Text referenced in initialize()
 	"Show physical special icons",
 	"Show move effectiveness",
@@ -15,23 +14,14 @@ GameOptionsScreen.OptionKeys = {
 	"Count enemy PP usage",
 	"Show last damage calcs",
 	"Reveal info if randomized",
-	"Display pedometer",
 }
 
 GameOptionsScreen.Buttons = {
-	EstimateIVs = {
-		type = Constants.ButtonTypes.FULL_BORDER,
-		text = "  Estimate " .. Constants.Words.POKEMON .. "'s Potential",
-		ivText = "",
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 5, Constants.SCREEN.MARGIN + 122, 130, 11 },
-		onClick = function() GameOptionsScreen.displayJudgeMessage() end
-	},
 	Back = {
 		type = Constants.ButtonTypes.FULL_BORDER,
 		text = "Back",
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 112, Constants.SCREEN.MARGIN + 135, 24, 11 },
 		onClick = function(self)
-			GameOptionsScreen.Buttons.EstimateIVs.ivText = "" -- keep hidden
 			-- Save all of the Options to the Settings.ini file, and navigate back to the main Tracker screen
 			Main.SaveSettings()
 			Program.changeScreenView(Program.Screens.NAVIGATION)
@@ -41,7 +31,8 @@ GameOptionsScreen.Buttons = {
 
 function GameOptionsScreen.initialize()
 	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 3
-	local startY = Constants.SCREEN.MARGIN + 13
+	local startY = Constants.SCREEN.MARGIN + 14
+	local linespacing = Constants.SCREEN.LINESPACING + 1
 
 	for _, optionKey in ipairs(GameOptionsScreen.OptionKeys) do
 		GameOptionsScreen.Buttons[optionKey] = {
@@ -63,41 +54,13 @@ function GameOptionsScreen.initialize()
 				Options.updateSetting(self.text, self.toggleState)
 			end
 		}
-		startY = startY + Constants.SCREEN.LINESPACING
+		startY = startY + linespacing
 	end
 
 	for _, button in pairs(GameOptionsScreen.Buttons) do
 		button.textColor = GameOptionsScreen.textColor
 		button.boxColors = { GameOptionsScreen.borderColor, GameOptionsScreen.boxFillColor }
 	end
-end
-
-function GameOptionsScreen.displayJudgeMessage()
-	local leadPokemon = Battle.getViewedPokemon(true)
-	if leadPokemon ~= nil then
-		-- https://bulbapedia.bulbagarden.net/wiki/Stats_judge
-		local result
-		local ivEstimate = Utils.estimateIVs(leadPokemon) * 186
-		if ivEstimate >= 151 then
-			result = "Outstanding!!!"
-		elseif ivEstimate >= 121 and ivEstimate <= 150 then
-			result = "Quite impressive!!"
-		elseif ivEstimate >= 91 and ivEstimate <= 120 then
-			result = "Above average!"
-		else
-			result = "Decent."
-		end
-
-		GameOptionsScreen.Buttons.EstimateIVs.ivText = PokemonData.Pokemon[leadPokemon.pokemonID].name .. " is: " .. result
-
-		-- Joey's Rattata meme (saving for later)
-		-- local topPercentile = math.max(100 - 100 * Utils.estimateIVs(leadPokemon), 1)
-		-- local percentText = string.format("%g", string.format("%d", topPercentile)) .. "%" -- %g removes insignificant 0's
-		-- message = "In the top " .. percentText .. " of  " .. PokemonData.Pokemon[leadPokemon.pokemonID].name
-	else
-		GameOptionsScreen.Buttons.EstimateIVs.ivText = "Estimate is unavailable."
-	end
-	Program.redraw(true)
 end
 
 -- DRAWING FUNCTIONS
@@ -122,7 +85,4 @@ function GameOptionsScreen.drawScreen()
 	for _, button in pairs(GameOptionsScreen.Buttons) do
 		Drawing.drawButton(button, shadowcolor)
 	end
-
-	local ivEstimate = GameOptionsScreen.Buttons.EstimateIVs
-	Drawing.drawText(topboxX + 4, ivEstimate.box[2] + ivEstimate.box[4] + 1, ivEstimate.ivText, Theme.COLORS[ivEstimate.textColor], shadowcolor)
 end

--- a/ironmon_tracker/screens/NavigationMenu.lua
+++ b/ironmon_tracker/screens/NavigationMenu.lua
@@ -1,5 +1,5 @@
 NavigationMenu = {
-	headerText = "Navigation Menu",
+	headerText = "Tracker Settings",
 	textColor = "Default text",
 	borderColor = "Upper box border",
 	boxFillColor = "Upper box background",
@@ -8,19 +8,39 @@ NavigationMenu = {
 
 NavigationMenu.Buttons = {
 	SetupAndOptions = {
-		text = "Tracker Setup",
+		text = "Setup",
 		image = Constants.PixelImages.NOTEPAD,
 		isVisible = function() return not NavigationMenu.showCredits end,
 		onClick = function() Program.changeScreenView(Program.Screens.SETUP) end
 	},
+	Extras = {
+		text = "Extras",
+		image = Constants.PixelImages.POKEBALL,
+		isVisible = function() return not NavigationMenu.showCredits end,
+		onClick = function() Program.changeScreenView(Program.Screens.EXTRAS) end
+	},
 	GameplaySettings = {
-		text = "Gameplay Options",
+		text = "Gameplay",
 		image = Constants.PixelImages.PHYSICAL,
 		isVisible = function() return not NavigationMenu.showCredits end,
 		onClick = function() Program.changeScreenView(Program.Screens.GAME_SETTINGS) end
 	},
+	QuickloadSettings = {
+		text = "Quickload",
+		image = Constants.PixelImages.CLOCK,
+		isVisible = function() return not NavigationMenu.showCredits end,
+		updateText = function (self)
+			if Options[QuickloadScreen.OptionKeys[1]] or Options[QuickloadScreen.OptionKeys[2]] then
+				self.textColor = NavigationMenu.textColor
+			else
+				-- If neither quickload option is enabled (somehow), then highlight it to draw user's attention
+				self.textColor = "Intermediate text"
+			end
+		end,
+		onClick = function() Program.changeScreenView(Program.Screens.QUICKLOAD) end
+	},
 	ThemeCustomization = {
-		text = "Customize Theme",
+		text = "Theme",
 		image = Constants.PixelImages.MAGNIFYING_GLASS,
 		isVisible = function() return not NavigationMenu.showCredits end,
 		onClick = function()
@@ -29,7 +49,7 @@ NavigationMenu.Buttons = {
 		end
 	},
 	ManageTrackedData = {
-		text = "Manage Tracked Data",
+		text = "Data",
 		image = Constants.PixelImages.GEAR,
 		isVisible = function() return not NavigationMenu.showCredits end,
 		onClick = function() Program.changeScreenView(Program.Screens.MANAGE_DATA) end
@@ -37,6 +57,8 @@ NavigationMenu.Buttons = {
 	CheckForUpdates = {
 		text = "Check for Updates", -- Can also be "New Update Available" or "No Updates Available"
 		image = Constants.PixelImages.INSTALL_BOX,
+		type = Constants.ButtonTypes.FULL_BORDER,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 15, Constants.SCREEN.MARGIN + 112, 110, 15 },
 		isVisible = function(self) return not NavigationMenu.showCredits end,
 		onClick = function(self)
 			-- Don't check for updates if they've already been checked since in this NavigationMenu (resets after clicking Back)
@@ -54,21 +76,21 @@ NavigationMenu.Buttons = {
 			end
 		end
 	},
-	-- Goodbye Mirage Button. You were fun. I don't think anyone found you :(
-	-- MirageButton = {
-	-- 	text = "It's a secret...",
-	-- 	image = Constants.PixelImages.MAP_PINDROP,
-	-- 	timesClicked = 0,
-	-- 	canBeSeenToday = false,
-	-- 	isVisible = function(self) return self.canBeSeenToday and self.timesClicked <= 3 and not NavigationMenu.showCredits end,
-	-- 	onClick = function(self)
-	-- 		if not self:isVisible() then return end
-	-- 		-- A non-functional button only appears very rarely, and will disappear after it's clicked a few times
-	-- 		self.timesClicked = self.timesClicked + 1
-	-- 		self.textColor = Utils.inlineIf(self.timesClicked % 2 == 0, NavigationMenu.textColor, "Intermediate text")
-	-- 		Program.redraw(true)
-	-- 	end
-	-- },
+	MirageButton = {
+		text = "It's a secret...",
+		image = Constants.PixelImages.MAP_PINDROP,
+		type = Constants.ButtonTypes.FULL_BORDER,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 15, Constants.SCREEN.MARGIN + 91, 110, 15 },
+		timesClicked = 0,
+		canBeSeenToday = false,
+		isVisible = function(self) return self.canBeSeenToday and self.timesClicked <= 3 and not NavigationMenu.showCredits end,
+		onClick = function(self)
+			-- A non-functional button only appears very rarely, and will disappear after it's clicked a few times
+			self.timesClicked = self.timesClicked + 1
+			self.textColor = Utils.inlineIf(self.timesClicked % 2 == 0, NavigationMenu.textColor, "Intermediate text")
+			Program.redraw(true)
+		end
+	},
 	Credits = {
 		type = Constants.ButtonTypes.FULL_BORDER,
 		text = "Credits",
@@ -132,25 +154,42 @@ NavigationMenu.Buttons = {
 
 NavigationMenu.OrderedMenuList = {
 	NavigationMenu.Buttons.SetupAndOptions,
+	NavigationMenu.Buttons.Extras,
 	NavigationMenu.Buttons.GameplaySettings,
+	NavigationMenu.Buttons.QuickloadSettings,
 	NavigationMenu.Buttons.ThemeCustomization,
 	NavigationMenu.Buttons.ManageTrackedData,
-	NavigationMenu.Buttons.CheckForUpdates,
 }
 
 function NavigationMenu.initialize()
-	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 15
-	local startY = Constants.SCREEN.MARGIN + 22
+	local btnWidth = 61
+	local btnHeight = 15
+	local spacer = 6
+	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + spacer
+	local startY = Constants.SCREEN.MARGIN + 16 + spacer
+	local leftCol = true
 	for _, button in ipairs(NavigationMenu.OrderedMenuList) do
 		button.type = Constants.ButtonTypes.FULL_BORDER
-		button.box = { startX, startY, 110, 16 }
-		startY = startY + 21
+		button.box = { startX, startY, btnWidth, btnHeight }
+
+		if leftCol then
+			startX = startX + btnWidth + spacer
+		else
+			startY = startY + btnHeight + spacer
+			startX = startX - btnWidth - spacer
+		end
+		leftCol = not leftCol
 	end
+
+	table.insert(NavigationMenu.OrderedMenuList, NavigationMenu.Buttons.MirageButton)
+	table.insert(NavigationMenu.OrderedMenuList, NavigationMenu.Buttons.CheckForUpdates)
 
 	for _, button in pairs(NavigationMenu.Buttons) do
 		button.textColor = NavigationMenu.textColor
 		button.boxColors = { NavigationMenu.borderColor, NavigationMenu.boxFillColor }
 	end
+
+	NavigationMenu.Buttons.QuickloadSettings:updateText()
 
 	if not Main.isOnLatestVersion() then
 		NavigationMenu.Buttons.CheckForUpdates.text = "New Update Available"
@@ -158,10 +197,10 @@ function NavigationMenu.initialize()
 	end
 
 	-- Yet another fun Easter Egg that shows up only once in a while
-	-- if math.random(256) == 1 or true then
-	-- 	NavigationMenu.Buttons.MirageButton.text = Utils.inlineIf(GameSettings.game == 3, "Reveal Mew by Truck", "Mirage Island Portal")
-	-- 	NavigationMenu.Buttons.MirageButton.canBeSeenToday = true
-	-- end
+	if math.random(256) == 1 then
+		NavigationMenu.Buttons.MirageButton.text = Utils.inlineIf(GameSettings.game == 3, "Reveal Mew by Truck", "Mirage Island Portal")
+		NavigationMenu.Buttons.MirageButton.canBeSeenToday = true
+	end
 end
 
 -- DRAWING FUNCTIONS
@@ -182,7 +221,7 @@ function NavigationMenu.drawScreen()
 
 	-- Draw header text
 	local headerShadow = Utils.calcShadowColor(Theme.COLORS["Main background"])
-	Drawing.drawText(topboxX + 32, Constants.SCREEN.MARGIN - 2, NavigationMenu.headerText:upper(), Theme.COLORS["Header text"], headerShadow)
+	Drawing.drawText(topboxX + 30, Constants.SCREEN.MARGIN - 2, NavigationMenu.headerText:upper(), Theme.COLORS["Header text"], headerShadow)
 
 	-- Draw top border box
 	gui.drawRectangle(topboxX, topboxY, topboxWidth, topboxHeight, Theme.COLORS[NavigationMenu.borderColor], Theme.COLORS[NavigationMenu.boxFillColor])
@@ -197,7 +236,7 @@ function NavigationMenu.drawScreen()
 			button.text = ""
 			Drawing.drawButton(button, shadowcolor)
 			button.text = holdText
-			Drawing.drawText(x + 17, y + 3, button.text, Theme.COLORS[button.textColor], shadowcolor)
+			Drawing.drawText(x + 16, y + 2, button.text, Theme.COLORS[button.textColor], shadowcolor)
 
 			-- TODO: Eventually make the Draw Button more flexible for centering its contents
 			if button.image == Constants.PixelImages.GEAR then
@@ -211,8 +250,12 @@ function NavigationMenu.drawScreen()
 			elseif button.image == Constants.PixelImages.INSTALL_BOX then
 				y = y + 2
 				x = x + 1
+			elseif button.image == Constants.PixelImages.POKEBALL then
+				x = x - 1
+			elseif button.image == Constants.PixelImages.CLOCK then
+				y = y + 1
 			end
-			Drawing.drawImageAsPixels(button.image, x + 4, y + 2, { Theme.COLORS[NavigationMenu.borderColor] }, shadowcolor)
+			Drawing.drawImageAsPixels(button.image, x + 4, y + 2, { Theme.COLORS[NavigationMenu.borderColor], Theme.COLORS[NavigationMenu.boxFillColor], Theme.COLORS[NavigationMenu.boxFillColor] }, shadowcolor)
 		end
 	end
 

--- a/ironmon_tracker/screens/NavigationMenu.lua
+++ b/ironmon_tracker/screens/NavigationMenu.lua
@@ -7,6 +7,13 @@ NavigationMenu = {
 }
 
 NavigationMenu.Buttons = {
+	VersionInfo = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		text = tostring(Main.TrackerVersion),
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 119, Constants.SCREEN.MARGIN - 2, 22, 10 },
+		isVisible = function() return not NavigationMenu.showCredits end,
+		onClick = function(self) UpdateScreen.openReleaseNotesWindow() end
+	},
 	SetupAndOptions = {
 		text = "Setup",
 		image = Constants.PixelImages.NOTEPAD,
@@ -55,32 +62,30 @@ NavigationMenu.Buttons = {
 		onClick = function() Program.changeScreenView(Program.Screens.MANAGE_DATA) end
 	},
 	CheckForUpdates = {
-		text = "Check for Updates", -- Can also be "New Update Available" or "No Updates Available"
+		text = "Update",
 		image = Constants.PixelImages.INSTALL_BOX,
-		type = Constants.ButtonTypes.FULL_BORDER,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 15, Constants.SCREEN.MARGIN + 112, 110, 15 },
 		isVisible = function(self) return not NavigationMenu.showCredits end,
-		onClick = function(self)
-			-- Don't check for updates if they've already been checked since in this NavigationMenu (resets after clicking Back)
-			if self.text == "Check for Updates" then
-				Main.CheckForVersionUpdate(true)
-			end
-
-			-- Regardless of the state of this button, always redirect to the UpdateScreen if an update is available
-			if not Main.isOnLatestVersion() then
-				Program.changeScreenView(Program.Screens.UPDATE)
-			else
-				self.text = "No Updates Available"
+		updateText = function(self)
+			if Main.isOnLatestVersion() then
 				self.textColor = NavigationMenu.textColor
-				Program.redraw(true)
+			else
+				self.textColor = "Positive text"
 			end
+		end,
+		onClick = function(self)
+			if Main.isOnLatestVersion() then
+				UpdateScreen.currentState = UpdateScreen.States.NEEDS_CHECK
+			else
+				UpdateScreen.currentState = UpdateScreen.States.NOT_UPDATED
+			end
+			Program.changeScreenView(Program.Screens.UPDATE)
 		end
 	},
 	MirageButton = {
 		text = "It's a secret...",
-		image = Constants.PixelImages.MAP_PINDROP,
+		image = Constants.PixelImages.POKEBALL,
 		type = Constants.ButtonTypes.FULL_BORDER,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 15, Constants.SCREEN.MARGIN + 91, 110, 15 },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 15, Constants.SCREEN.MARGIN + 110, 110, 15 },
 		timesClicked = 0,
 		canBeSeenToday = false,
 		isVisible = function(self) return self.canBeSeenToday and self.timesClicked <= 3 and not NavigationMenu.showCredits end,
@@ -101,25 +106,12 @@ NavigationMenu.Buttons = {
 			Program.redraw(true)
 		end
 	},
-	VersionInfo = {
-		type = Constants.ButtonTypes.NO_BORDER,
-		text = "Tracker v" .. Main.TrackerVersion,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 43, Constants.SCREEN.MARGIN + 135, 56, 10 },
-		timesClicked = 0,
+	Help = {
+		type = Constants.ButtonTypes.FULL_BORDER,
+		text = "Help",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 41, Constants.SCREEN.MARGIN + 135, 23, 11 },
 		isVisible = function() return not NavigationMenu.showCredits end,
-		onClick = function(self)
-			UpdateScreen.openReleaseNotesWindow()
-			-- TODO: Likely change this to highlight when hovered-over to show it can take you to the release notes
-			-- self.timesClicked = self.timesClicked + 1
-			-- if self.timesClicked % 2 == 0 then
-			-- 	self.textColor = NavigationMenu.textColor
-			-- elseif self.timesClicked % 21 == 0 then
-			-- 	self.textColor = "Positive text"
-			-- else
-			-- 	self.textColor = "Intermediate text"
-			-- end
-			-- Program.redraw(true)
-		end
+		onClick = function(self) NavigationMenu.openWikiBrowserWindow() end
 	},
 	Back = {
 		type = Constants.ButtonTypes.FULL_BORDER,
@@ -130,18 +122,6 @@ NavigationMenu.Buttons = {
 				NavigationMenu.showCredits = false
 				Program.redraw(true)
 			else
-				NavigationMenu.Buttons.VersionInfo.timesClicked = 0
-				NavigationMenu.Buttons.VersionInfo.textColor = NavigationMenu.textColor
-
-				-- Reset the CheckForUpdates button text/color
-				if Main.isOnLatestVersion() then
-					NavigationMenu.Buttons.CheckForUpdates.text = "Check for Updates"
-					NavigationMenu.Buttons.CheckForUpdates.textColor = NavigationMenu.textColor
-				else
-					NavigationMenu.Buttons.CheckForUpdates.text = "New Update Available"
-					NavigationMenu.Buttons.CheckForUpdates.textColor = "Positive text"
-				end
-
 				if Program.isValidMapLocation() then
 					Program.changeScreenView(Program.Screens.TRACKER)
 				else
@@ -159,13 +139,14 @@ NavigationMenu.OrderedMenuList = {
 	NavigationMenu.Buttons.QuickloadSettings,
 	NavigationMenu.Buttons.ThemeCustomization,
 	NavigationMenu.Buttons.ManageTrackedData,
+	NavigationMenu.Buttons.CheckForUpdates,
 }
 
 function NavigationMenu.initialize()
-	local btnWidth = 61
+	local btnWidth = 63
 	local btnHeight = 15
 	local spacer = 6
-	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + spacer
+	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4
 	local startY = Constants.SCREEN.MARGIN + 16 + spacer
 	local leftCol = true
 	for _, button in ipairs(NavigationMenu.OrderedMenuList) do
@@ -182,7 +163,6 @@ function NavigationMenu.initialize()
 	end
 
 	table.insert(NavigationMenu.OrderedMenuList, NavigationMenu.Buttons.MirageButton)
-	table.insert(NavigationMenu.OrderedMenuList, NavigationMenu.Buttons.CheckForUpdates)
 
 	for _, button in pairs(NavigationMenu.Buttons) do
 		button.textColor = NavigationMenu.textColor
@@ -190,16 +170,24 @@ function NavigationMenu.initialize()
 	end
 
 	NavigationMenu.Buttons.QuickloadSettings:updateText()
-
-	if not Main.isOnLatestVersion() then
-		NavigationMenu.Buttons.CheckForUpdates.text = "New Update Available"
-		NavigationMenu.Buttons.CheckForUpdates.textColor = "Positive text"
-	end
+	NavigationMenu.Buttons.CheckForUpdates:updateText()
 
 	-- Yet another fun Easter Egg that shows up only once in a while
 	if math.random(256) == 1 then
 		NavigationMenu.Buttons.MirageButton.text = Utils.inlineIf(GameSettings.game == 3, "Reveal Mew by Truck", "Mirage Island Portal")
 		NavigationMenu.Buttons.MirageButton.canBeSeenToday = true
+	end
+end
+
+function NavigationMenu.openWikiBrowserWindow()
+	-- The first parameter is the title of the window, the second is the url
+	if Main.OS == "Windows" then
+		os.execute(string.format('start "" "%s"', Constants.Release.WIKI_URL))
+	else
+		-- Currently doesn't work on Bizhawk on Linux, but unsure of any available working solution
+		os.execute(string.format('open "" "%s"', Constants.Release.WIKI_URL))
+		Main.DisplayError("Check the Lua Console for a link to the Tracker's Help Wiki.")
+		print(string.format("Help Wiki: %s", Constants.Release.WIKI_URL))
 	end
 end
 
@@ -227,41 +215,41 @@ function NavigationMenu.drawScreen()
 	gui.drawRectangle(topboxX, topboxY, topboxWidth, topboxHeight, Theme.COLORS[NavigationMenu.borderColor], Theme.COLORS[NavigationMenu.boxFillColor])
 
 	-- Draw all buttons, manually
-	for index, button in ipairs(NavigationMenu.OrderedMenuList) do
+	for _, button in pairs(NavigationMenu.Buttons) do
 		if button.isVisible == nil or button:isVisible() then
-			local x = button.box[1]
-			local y = button.box[2]
-			local holdText = button.text
+			if button.image ~= nil then
+				local x = button.box[1]
+				local y = button.box[2]
+				local holdText = button.text
 
-			button.text = ""
-			Drawing.drawButton(button, shadowcolor)
-			button.text = holdText
-			Drawing.drawText(x + 16, y + 2, button.text, Theme.COLORS[button.textColor], shadowcolor)
+				button.text = ""
+				Drawing.drawButton(button, shadowcolor)
+				button.text = holdText
+				Drawing.drawText(x + 16, y + 2, button.text, Theme.COLORS[button.textColor], shadowcolor)
 
-			-- TODO: Eventually make the Draw Button more flexible for centering its contents
-			if button.image == Constants.PixelImages.GEAR then
-				y = y + 2
-				x = x + 1
-			elseif button.image == Constants.PixelImages.PHYSICAL then
-				y = y + 3
-				x = x + 1
-			elseif button.image == Constants.PixelImages.MAGNIFYING_GLASS then
-				y = y + 1
-			elseif button.image == Constants.PixelImages.INSTALL_BOX then
-				y = y + 2
-				x = x + 1
-			elseif button.image == Constants.PixelImages.POKEBALL then
-				x = x - 1
-			elseif button.image == Constants.PixelImages.CLOCK then
-				y = y + 1
+				-- TODO: Eventually make the Draw Button more flexible for centering its contents
+				if button.image == Constants.PixelImages.GEAR then
+					y = y + 2
+					x = x + 1
+				elseif button.image == Constants.PixelImages.PHYSICAL then
+					y = y + 3
+					x = x + 1
+				elseif button.image == Constants.PixelImages.MAGNIFYING_GLASS then
+					y = y + 1
+				elseif button.image == Constants.PixelImages.INSTALL_BOX then
+					y = y + 2
+					x = x + 1
+				elseif button.image == Constants.PixelImages.POKEBALL then
+					x = x - 1
+				elseif button.image == Constants.PixelImages.CLOCK then
+					y = y + 1
+				end
+				Drawing.drawImageAsPixels(button.image, x + 4, y + 2, { Theme.COLORS[NavigationMenu.borderColor], Theme.COLORS[NavigationMenu.boxFillColor], Theme.COLORS[NavigationMenu.boxFillColor] }, shadowcolor)
+			else
+				Drawing.drawButton(button, shadowcolor)
 			end
-			Drawing.drawImageAsPixels(button.image, x + 4, y + 2, { Theme.COLORS[NavigationMenu.borderColor], Theme.COLORS[NavigationMenu.boxFillColor], Theme.COLORS[NavigationMenu.boxFillColor] }, shadowcolor)
 		end
 	end
-
-	Drawing.drawButton(NavigationMenu.Buttons.Credits, shadowcolor)
-	Drawing.drawButton(NavigationMenu.Buttons.VersionInfo, shadowcolor)
-	Drawing.drawButton(NavigationMenu.Buttons.Back, shadowcolor)
 end
 
 function NavigationMenu.drawCredits()

--- a/ironmon_tracker/screens/NavigationMenu.lua
+++ b/ironmon_tracker/screens/NavigationMenu.lua
@@ -9,8 +9,8 @@ NavigationMenu = {
 NavigationMenu.Buttons = {
 	VersionInfo = {
 		type = Constants.ButtonTypes.NO_BORDER,
-		text = tostring(Main.TrackerVersion),
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 119, Constants.SCREEN.MARGIN - 2, 22, 10 },
+		text = "v" .. tostring(Main.TrackerVersion),
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 115, Constants.SCREEN.MARGIN - 2, 22, 10 },
 		isVisible = function() return not NavigationMenu.showCredits end,
 		onClick = function(self) UpdateScreen.openReleaseNotesWindow() end
 	},
@@ -169,6 +169,7 @@ function NavigationMenu.initialize()
 		button.boxColors = { NavigationMenu.borderColor, NavigationMenu.boxFillColor }
 	end
 
+	NavigationMenu.Buttons.VersionInfo.textColor = "Header text"
 	NavigationMenu.Buttons.QuickloadSettings:updateText()
 	NavigationMenu.Buttons.CheckForUpdates:updateText()
 
@@ -209,7 +210,7 @@ function NavigationMenu.drawScreen()
 
 	-- Draw header text
 	local headerShadow = Utils.calcShadowColor(Theme.COLORS["Main background"])
-	Drawing.drawText(topboxX + 30, Constants.SCREEN.MARGIN - 2, NavigationMenu.headerText:upper(), Theme.COLORS["Header text"], headerShadow)
+	Drawing.drawText(topboxX, Constants.SCREEN.MARGIN - 2, NavigationMenu.headerText:upper(), Theme.COLORS["Header text"], headerShadow)
 
 	-- Draw top border box
 	gui.drawRectangle(topboxX, topboxY, topboxWidth, topboxHeight, Theme.COLORS[NavigationMenu.borderColor], Theme.COLORS[NavigationMenu.boxFillColor])

--- a/ironmon_tracker/screens/QuickloadScreen.lua
+++ b/ironmon_tracker/screens/QuickloadScreen.lua
@@ -1,8 +1,8 @@
 QuickloadScreen = {
 	headerText = "Quickload Setup",
 	textColor = "Default text",
-	borderColor = "Upper box border",
-	boxFillColor = "Upper box background",
+	borderColor = "Lower box border",
+	boxFillColor = "Lower box background",
 }
 
 QuickloadScreen.OptionKeys = {
@@ -47,6 +47,7 @@ QuickloadScreen.Buttons = {
 			-- Toggle the setting and store the change to be saved later in Settings.ini
 			self.toggleState = not self.toggleState
 			Options.updateSetting(self.text, self.toggleState)
+			NavigationMenu.Buttons.QuickloadSettings:updateText()
 
 			-- Only one of these options can be active at any given moment
 			if self.toggleState then
@@ -67,6 +68,7 @@ QuickloadScreen.Buttons = {
 			-- Toggle the setting and store the change to be saved later in Settings.ini
 			self.toggleState = not self.toggleState
 			Options.updateSetting(self.text, self.toggleState)
+			NavigationMenu.Buttons.QuickloadSettings:updateText()
 
 			-- Only one of these options can be active at any given moment
 			if self.toggleState then
@@ -83,7 +85,7 @@ QuickloadScreen.Buttons = {
 		onClick = function(self)
 			-- Save all of the Options to the Settings.ini file, and navigate back to the Tracker Setup screen
 			Main.SaveSettings()
-			Program.changeScreenView(Program.Screens.SETUP)
+			Program.changeScreenView(Program.Screens.NAVIGATION)
 		end
 	},
 }

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -11,8 +11,6 @@ SetupScreen.OptionKeys = {
 	"Disable mainscreen carousel",
 	"Track PC Heals",
 	"PC heals count downward", -- Text referenced in initialize()
-	"Display repel usage",
-	"Animated Pokemon popout", -- Text referenced in initialize()
 }
 
 SetupScreen.Buttons = {
@@ -73,16 +71,6 @@ SetupScreen.Buttons = {
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4, Constants.SCREEN.MARGIN + 135, 53, 11 },
 		onClick = function() SetupScreen.openEditControlsWindow() end
 	},
-	QuickLoad = {
-		type = Constants.ButtonTypes.FULL_BORDER,
-		text = "Quick- load",
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 60, Constants.SCREEN.MARGIN + 135, 49, 11 },
-		onClick = function()
-			-- Save all of the Options to the Settings.ini file, and navigate back to the main Tracker screen
-			Main.SaveSettings()
-			Program.changeScreenView(Program.Screens.QUICKLOAD)
-		end
-	},
 	Back = {
 		type = Constants.ButtonTypes.FULL_BORDER,
 		text = "Back",
@@ -97,7 +85,7 @@ SetupScreen.Buttons = {
 
 function SetupScreen.initialize()
 	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4
-	local startY = Constants.SCREEN.MARGIN + 63
+	local startY = Constants.SCREEN.MARGIN + 66
 	local linespacing = Constants.SCREEN.LINESPACING + 1
 
 	for _, optionKey in ipairs(SetupScreen.OptionKeys) do
@@ -140,11 +128,6 @@ function SetupScreen.initialize()
 	SetupScreen.Buttons.PortraitAuthor.text = "Added by:  " .. Options.IconSetMap[Options["Pokemon icon set"]].author
 	-- Randomize what Pokemon icon is shown
 	SetupScreen.Buttons.PokemonIcon.pokemonID = Utils.randomPokemonID()
-
-	-- If neither quickload option is enabled (somehow), then highlight it to draw user's attention
-	if not Options[QuickloadScreen.OptionKeys[1]] and not Options[QuickloadScreen.OptionKeys[2]] then
-		SetupScreen.Buttons.QuickLoad.textColor = "Intermediate text"
-	end
 
 	local animatedAddonInstalled = Main.FileExists(Utils.getWorkingDirectory() .. Main.DataFolder .. "/images/pokemonAnimated/abra.gif")
 	local animatedBtnOption = SetupScreen.Buttons["Animated Pokemon popout"]


### PR DESCRIPTION
This cleans up the old Navigation Menu, now known as "Tracker Settings" to allow room for faster access to some settings and options. Notably, this puts the Quickload settings at the top level and adds a new page for "Extras", which are a bunch of fun add-ons. Another goal of this restructure is allowing room for more features to get added later, such as "Stats" or "Analytics", or perhaps a way to "Look up" info and tracked Pokemon.

This menu layout also changes the location of some of the existing settings and relocates them to the Extras screen:
- Show random ball picker
- Display repel usage
- Display pedometer
- Animated Pokemon popout
- Estimate Pokemon IV Potential

I didn't get around to redoing the pixel icons for each of these buttons to help clean them up a bit. Will have to do that some time later.

![image](https://user-images.githubusercontent.com/4258818/201503621-312e6c68-a36a-4d01-8315-5477a3c6c210.png)
