### PR TITLE
Battle starting flag

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -1,5 +1,7 @@
 Battle = {
+	totalBattles = 0,
 	inBattle = false,
+	battleStarting = false,
 	isWildEncounter = false,
 	isGhost = false,
 	isViewingLeft = true, -- By default, out of battle should view the left combatant slot (index = 0)
@@ -79,6 +81,11 @@ function Battle.updateBattleStatus()
 	-- BattleStatus [0 = In battle, 1 = Won the match, 2 = Lost the match, 4 = Fled, 7 = Caught]
 	local lastBattleStatus = Memory.readbyte(GameSettings.gBattleOutcome)
 	local opposingPokemon = Tracker.getPokemon(1, false) -- get the lead pokemon on the enemy team
+	local totalBattles = Utils.getGameStat(Constants.GAME_STATS.TOTAL_BATTLES)
+	if (Battle.totalBattles < totalBattles) then
+		Battle.battleStarting = true
+	end
+	Battle.totalBattles = totalBattles
 	if not Battle.inBattle and lastBattleStatus == 0 and opposingPokemon ~= nil then
 		Battle.isWildEncounter = Tracker.Data.trainerID == opposingPokemon.trainerID -- testing this shorter version
 		-- Battle.isWildEncounter = Tracker.Data.trainerID ~= nil and Tracker.Data.trainerID ~= 0 and Tracker.Data.trainerID == opposingPokemon.trainerID
@@ -485,6 +492,7 @@ function Battle.beginNewBattle()
 
 	-- If this is a new battle, reset views and other pokemon tracker info
 	Battle.inBattle = true
+	Battle.battleStarting = false
 	Battle.turnCount = 0
 	Battle.prevDamageTotal = 0
 	Battle.damageReceived = 0
@@ -537,6 +545,7 @@ function Battle.endCurrentBattle()
 
 	Battle.numBattlers = 0
 	Battle.inBattle = false
+	Battle.battleStarting = false
 	Battle.turnCount = -1
 	Battle.lastEnemyMoveId = 0
 	Battle.Synchronize.turnCount = 0

--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -82,7 +82,7 @@ function Battle.updateBattleStatus()
 	local lastBattleStatus = Memory.readbyte(GameSettings.gBattleOutcome)
 	local opposingPokemon = Tracker.getPokemon(1, false) -- get the lead pokemon on the enemy team
 	local totalBattles = Utils.getGameStat(Constants.GAME_STATS.TOTAL_BATTLES)
-	if (Battle.totalBattles < totalBattles) then
+	if Battle.totalBattles ~= 0 and (Battle.totalBattles < totalBattles) then
 		Battle.battleStarting = true
 	end
 	Battle.totalBattles = totalBattles

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -225,7 +225,7 @@ function Drawing.drawScreen(screenFunc)
 		screenFunc()
 	end
 	-- Draw the repel icon here so that it's drawn regardless of what tracker screen is displayed
-	if Options["Display repel usage"] and Program.ActiveRepel.inUse and not Battle.inBattle and not Program.inStartMenu then
+	if Options["Display repel usage"] and Program.ActiveRepel.inUse and not (Battle.inBattle or Battle.battleStarting) and not Program.inStartMenu then
 		Drawing.drawRepelUsage()
 	end
 end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -149,7 +149,7 @@ function Program.update()
 				end
 			end
 
-			if Options["Display repel usage"] and not Battle.inBattle then
+			if Options["Display repel usage"] and not (Battle.inBattle or Battle.battleStarting) then
 				-- Check if the player is in the start menu (for hiding the repel usage icon)
 				Program.inStartMenu = Program.isInStartMenu()
 				-- Check for active repel and steps remaining
@@ -394,7 +394,7 @@ function Program.updatePCHeals()
 	-- Does not include whiteouts, as those don't increment either of these gamestats
 
 	-- Save blocks move and are re-encrypted right as the battle starts
-	if Battle.inBattle then
+	if Battle.inBattle or Battle.battleStarting then
 		return
 	end
 


### PR DESCRIPTION
- New Battle.battleStarting flag which is triggered by the GAME_STAT for total encounters incrementing.
- Using this to shut off reads for PC Heals and the repel tracker, since memory is shuffled around before the battle starts.