### PR TITLE
Battle abilities crash

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -400,6 +400,16 @@ function Battle.checkAbilitiesToTrack()
 	end
 	local combatantIndexesToTrack = {}
 
+	--Something is not right with the data; happens occasionally for emerald.
+	if Battle.attacker == nil or Battle.IndexMap[Battle.attacker] == nil or Battle.Combatants[Battle.IndexMap[Battle.attacker]] == nil
+	or Battle.BattleAbilities[Battle.attacker % 2] == nil or Battle.BattleAbilities[Battle.attacker % 2][Battle.Combatants[Battle.IndexMap[Battle.attacker]]] == nil
+	or Battle.battler == nil or Battle.IndexMap[Battle.battler] == nil or Battle.Combatants[Battle.IndexMap[Battle.battler]] == nil
+	or Battle.BattleAbilities[Battle.battler % 2] == nil or Battle.BattleAbilities[Battle.battler % 2][Battle.Combatants[Battle.IndexMap[Battle.battler]]] == nil
+	or Battle.battlerTarget == nil or Battle.IndexMap[Battle.battlerTarget] == nil or Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]] == nil
+	or Battle.BattleAbilities[Battle.battlerTarget % 2] == nil or Battle.BattleAbilities[Battle.battlerTarget % 2][Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]]] == nil then
+		return combatantIndexesToTrack
+	end
+
 	local attackerAbility = Battle.BattleAbilities[Battle.attacker % 2][Battle.Combatants[Battle.IndexMap[Battle.attacker]]].ability
 	local battlerAbility = Battle.BattleAbilities[Battle.battler % 2][Battle.Combatants[Battle.IndexMap[Battle.battler]]].ability
 	local battleTargetAbility = Battle.BattleAbilities[Battle.battlerTarget % 2][Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]]].ability

--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -506,8 +506,12 @@ function Battle.beginNewBattle()
 	Battle.Synchronize.turnCount = 0
 	Battle.Synchronize.attacker = -1
 	Battle.Synchronize.battlerTarget = -1
-	Battle.partySize = Memory.readbyte(0x020244e9);
-
+        -- RS allocated a dword for the party size
+        if GameSettings.game == 1 then
+	        Battle.partySize = Memory.readdword(GameSettings.gPlayerPartyCount)
+        else
+	        Battle.partySize = Memory.readbyte(GameSettings.gPlayerPartyCount)
+        end
 	Battle.isGhost = false
 
 	Tracker.Data.isViewingOwn = not Options["Auto swap to enemy"]

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -263,6 +263,8 @@ function GameSettings.setEwramAddresses()
 		pstats = { nil, 0x020244EC, 0x02024284 },
 		-- Enemy Stats, exists in IWRAM instead in RS
 		estats = { nil, 0x02024744, 0x0202402C },
+		-- Player Party Size, exists in IWRAM instead in RS
+		gPlayerPartyCount = { nil, 0x020244e9, 0x02024029 },
 
 		-- RS uses this directly (gSharedMem + 0x14800)
 		sEvoInfo = { 0x02014800, nil, nil },
@@ -338,6 +340,7 @@ function GameSettings.setIwramAddresses()
 		-- Addresses only in IWRAM for RS, but in EWRAM for Em/FRLG (so were already set by this point, omit to avoid overwrite)
 		pstats = { { 0x03004360 }, { nil, nil }, { nil, nil } },
 		estats = { { 0x030045C0 }, { nil, nil }, { nil, nil } },
+                gPlayerPartyCount = { { 0x03004350 }, { nil, nil }, { nil, nil },},
 		sBattleBuffersTransferData = { { 0x03004040 }, { nil, nil }, { nil, nil } },
 		gBattleTextBuff1 = { { 0x030041c0 }, { nil, nil }, { nil, nil } },
 		gBattleTerrain = { { 0x0300428c }, { nil, nil }, { nil, nil } },

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -38,6 +38,10 @@ function Input.checkJoypadInput(joypadButtons)
 			if Tracker.Data.isViewingOwn and Battle.numBattlers > 2 then
 				--swap sides on returning to allied side
 				Battle.isViewingLeft = not Battle.isViewingLeft
+				--undo changes for special double battles
+				if Battle.isViewingLeft == false and Battle.Combatants.RightOwn > Battle.partySize then
+					Tracker.Data.isViewingOwn = not Tracker.Data.isViewingOwn
+				end
 				-- Recalculate "Heals In Bag" HP percentages using a constant value (so player sees the update)
 				Program.Frames.three_sec_update = 30
 			end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -255,7 +255,7 @@ function Program.updatePokemonTeams()
 				end
 
 				-- Remove trainerID value from the pokemon data itself since it's now owned by the player, saves data space
-				newPokemonData.trainerID = nil
+				--newPokemonData.trainerID = nil
 
 				Tracker.addUpdatePokemon(newPokemonData, personality, true)
 			end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -232,9 +232,11 @@ function Program.updatePokemonTeams()
 	for i = 1, 6, 1 do
 		-- Lookup information on the player's Pokemon first
 		local personality = Memory.readdword(GameSettings.pstats + addressOffset)
+		local trainerID = Memory.readdword(GameSettings.pstats + addressOffset + 4)
+		--print (i .. "; personality: " .. personality .. ";trainerID: " .. trainerID)
 		Tracker.Data.ownTeam[i] = personality
 
-		if personality ~= 0 then
+		if personality ~= 0 or trainerID ~= 0 then
 			local newPokemonData = Program.readNewPokemon(GameSettings.pstats + addressOffset, personality)
 
 			if Program.validPokemonData(newPokemonData) then
@@ -254,7 +256,7 @@ function Program.updatePokemonTeams()
 				end
 
 				-- Remove trainerID value from the pokemon data itself since it's now owned by the player, saves data space
-				newPokemonData.trainerID = nil
+				--newPokemonData.trainerID = nil
 
 				Tracker.addUpdatePokemon(newPokemonData, personality, true)
 			end
@@ -262,9 +264,10 @@ function Program.updatePokemonTeams()
 
 		-- Then lookup information on the opposing Pokemon
 		personality = Memory.readdword(GameSettings.estats + addressOffset)
+		trainerID = Memory.readdword(GameSettings.estats + addressOffset + 4)
 		Tracker.Data.otherTeam[i] = personality
 
-		if personality ~= 0 then
+		if personality ~= 0 or trainerID ~= 0 then
 			local newPokemonData = Program.readNewPokemon(GameSettings.estats + addressOffset, personality)
 
 			if Program.validPokemonData(newPokemonData) then

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -256,7 +256,7 @@ function Program.updatePokemonTeams()
 				end
 
 				-- Remove trainerID value from the pokemon data itself since it's now owned by the player, saves data space
-				--newPokemonData.trainerID = nil
+				newPokemonData.trainerID = nil
 
 				Tracker.addUpdatePokemon(newPokemonData, personality, true)
 			end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -255,7 +255,8 @@ function Program.updatePokemonTeams()
 				end
 
 				-- Remove trainerID value from the pokemon data itself since it's now owned by the player, saves data space
-				--newPokemonData.trainerID = nil
+				-- No longer remove, as it's currently used to verify Trainer pokemon with personality values of 0
+				-- newPokemonData.trainerID = nil
 
 				Tracker.addUpdatePokemon(newPokemonData, personality, true)
 			end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -233,7 +233,6 @@ function Program.updatePokemonTeams()
 		-- Lookup information on the player's Pokemon first
 		local personality = Memory.readdword(GameSettings.pstats + addressOffset)
 		local trainerID = Memory.readdword(GameSettings.pstats + addressOffset + 4)
-		--print (i .. "; personality: " .. personality .. ";trainerID: " .. trainerID)
 		Tracker.Data.ownTeam[i] = personality
 
 		if personality ~= 0 or trainerID ~= 0 then

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -67,9 +67,10 @@ function Tracker.getPokemon(slotNumber, isOwn)
 	if isOwn == nil then isOwn = true end
 
 	local personality = Utils.inlineIf(isOwn, Tracker.Data.ownTeam[slotNumber], Tracker.Data.otherTeam[slotNumber])
-	if personality == nil then return nil
+	if personality == nil then return nil end
+	local pokemonInSlot = Utils.inlineIf(isOwn, Tracker.Data.ownPokemon[personality], Tracker.Data.otherPokemon[personality])
 	-- allow personality 0 only in Battle, and only if the trainer ID is not also 0
-	elseif personality == 0 and (Battle.inBattle and Tracker.Data.ownPokemon[personality].trainerID == nil or Tracker.Data.ownPokemon[personality].trainerID == 0) then return nil
+	if pokemonInSlot == nil or (personality == 0 and (pokemonInSlot.trainerID == nil or pokemonInSlot.trainerID == 0)) then return nil
 	end
 
 	if isOwn then

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -67,7 +67,10 @@ function Tracker.getPokemon(slotNumber, isOwn)
 	if isOwn == nil then isOwn = true end
 
 	local personality = Utils.inlineIf(isOwn, Tracker.Data.ownTeam[slotNumber], Tracker.Data.otherTeam[slotNumber])
-	if personality == nil or personality == 0 then return nil end
+	if personality == nil then return nil
+	-- allow personality 0 only in Battle, and only if the trainer ID is not also 0
+	elseif personality == 0 and (Battle.inBattle and Tracker.Data.ownPokemon[personality].trainerID == nil or Tracker.Data.ownPokemon[personality].trainerID == 0) then return nil
+	end
 
 	if isOwn then
 		local isEggPokemon = Tracker.Data.ownPokemon[personality].isEgg == 1

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -67,10 +67,14 @@ function Tracker.getPokemon(slotNumber, isOwn)
 	if isOwn == nil then isOwn = true end
 
 	local personality = Utils.inlineIf(isOwn, Tracker.Data.ownTeam[slotNumber], Tracker.Data.otherTeam[slotNumber])
-	if personality == nil then return nil end
+	if personality == nil then
+		return nil
+	end
+
+	-- Personality of 0 is okay for some real trainers, usually occurs in Battle
 	local pokemonInSlot = Utils.inlineIf(isOwn, Tracker.Data.ownPokemon[personality], Tracker.Data.otherPokemon[personality])
-	-- allow personality 0 only in Battle, and only if the trainer ID is not also 0
-	if pokemonInSlot == nil or (personality == 0 and (pokemonInSlot.trainerID == nil or pokemonInSlot.trainerID == 0)) then return nil
+	if pokemonInSlot == nil or (personality == 0 and (pokemonInSlot.trainerID == nil or pokemonInSlot.trainerID == 0)) then
+		return nil
 	end
 
 	if isOwn then


### PR DESCRIPTION
- Fixing an issue where in Emerald, Steven's NPC 3 + 3 tag team double battle hard-coded personality values, including one with "0", which resulted in the pokemon not being read into memory since the tracker ignores 0 as an invalid ID
- Now trainer ID is also checked to determine whether a pokemon block is valid
- Toggling will skip over the NPC pokemon. Eventually I would like to display the NPC pokemon still as a third enemy pokemon, but that requires some refactoring which would delay the fix.
- Moves and abilities for NPC pokemon are now tracked on the same basis as enemy pokemon, instead of always like normal allied pokemon. 

Known TODOs:
- gPlayerPartyCount is hardcoded for Emerald, need to get the addresses for other games as well
- want to test in regular double battles and in FRLG before shipping it