### PR TITLE
Patch 7.0.3 - Hotfix for doubles battle crash in RSE

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -6,6 +6,7 @@ Battle = {
 	isGhost = false,
 	isViewingLeft = true, -- By default, out of battle should view the left combatant slot (index = 0)
 	numBattlers = 0,
+	partySize = 6,
 	isNewTurn = true,
 
 	-- "Low accuracy" values
@@ -261,8 +262,8 @@ function Battle.updateTrackedInfo()
 								end
 							end
 						else
-							--Only track moves for enemies; our moves could be TM moves, or moves we didn't forget from earlier levels
-							if not transformData.isOwn then
+							-- Only track moves for enemies or NPC allies; our moves could be TM moves, or moves we didn't forget from earlier levels
+							if not transformData.isOwn or transformData.slot > Battle.partySize then
 								local attackingMon = Tracker.getPokemon(transformData.slot,transformData.isOwn)
 								if attackingMon ~= nil then
 									Tracker.TrackMove(attackingMon.pokemonID, lastMoveByAttacker, attackingMon.level)
@@ -282,9 +283,9 @@ function Battle.updateTrackedInfo()
 		end
 	end
 
-	-- Always track your own Pokemons' abilities
+	-- Always track your own Pokemons' abilities, unless you are in a half-double battle alongside an NPC (3 + 3 vs 3 + 3)
 	local ownLeftPokemon = Tracker.getPokemon(Battle.Combatants.LeftOwn,true)
-	if ownLeftPokemon ~= nil then
+	if ownLeftPokemon ~= nil and Battle.Combatants.LeftOwn <= Battle.partySize then
 		local ownLeftAbilityId = PokemonData.getAbilityId(ownLeftPokemon.pokemonID, ownLeftPokemon.abilityNum)
 		Tracker.TrackAbility(ownLeftPokemon.pokemonID, ownLeftAbilityId)
 		Battle.updateStatStages(ownLeftPokemon, true)
@@ -292,7 +293,7 @@ function Battle.updateTrackedInfo()
 
 	if Battle.numBattlers == 4 then
 		local ownRightPokemon = Tracker.getPokemon(Battle.Combatants.RightOwn,true)
-		if ownRightPokemon ~= nil then
+		if ownRightPokemon ~= nil and Battle.Combatants.RightOwn <= Battle.partySize then
 			local ownRightAbilityId = PokemonData.getAbilityId(ownRightPokemon.pokemonID, ownRightPokemon.abilityNum)
 			Tracker.TrackAbility(ownRightPokemon.pokemonID, ownRightAbilityId)
 			Battle.updateStatStages(ownRightPokemon, true)
@@ -407,6 +408,16 @@ function Battle.checkAbilitiesToTrack()
 	end
 	local combatantIndexesToTrack = {}
 
+	--Something is not right with the data; happens occasionally for emerald.
+	if Battle.attacker == nil or Battle.IndexMap[Battle.attacker] == nil or Battle.Combatants[Battle.IndexMap[Battle.attacker]] == nil
+	or Battle.BattleAbilities[Battle.attacker % 2] == nil or Battle.BattleAbilities[Battle.attacker % 2][Battle.Combatants[Battle.IndexMap[Battle.attacker]]] == nil
+	or Battle.battler == nil or Battle.IndexMap[Battle.battler] == nil or Battle.Combatants[Battle.IndexMap[Battle.battler]] == nil
+	or Battle.BattleAbilities[Battle.battler % 2] == nil or Battle.BattleAbilities[Battle.battler % 2][Battle.Combatants[Battle.IndexMap[Battle.battler]]] == nil
+	or Battle.battlerTarget == nil or Battle.IndexMap[Battle.battlerTarget] == nil or Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]] == nil
+	or Battle.BattleAbilities[Battle.battlerTarget % 2] == nil or Battle.BattleAbilities[Battle.battlerTarget % 2][Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]]] == nil then
+		return combatantIndexesToTrack
+	end
+
 	local attackerAbility = Battle.BattleAbilities[Battle.attacker % 2][Battle.Combatants[Battle.IndexMap[Battle.attacker]]].ability
 	local battlerAbility = Battle.BattleAbilities[Battle.battler % 2][Battle.Combatants[Battle.IndexMap[Battle.battler]]].ability
 	local battleTargetAbility = Battle.BattleAbilities[Battle.battlerTarget % 2][Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]]].ability
@@ -503,7 +514,12 @@ function Battle.beginNewBattle()
 	Battle.Synchronize.turnCount = 0
 	Battle.Synchronize.attacker = -1
 	Battle.Synchronize.battlerTarget = -1
-
+        -- RS allocated a dword for the party size
+        if GameSettings.game == 1 then
+	        Battle.partySize = Memory.readdword(GameSettings.gPlayerPartyCount)
+        else
+	        Battle.partySize = Memory.readbyte(GameSettings.gPlayerPartyCount)
+        end
 	Battle.isGhost = false
 
 	Tracker.Data.isViewingOwn = not Options["Auto swap to enemy"]
@@ -544,6 +560,7 @@ function Battle.endCurrentBattle()
 	end
 
 	Battle.numBattlers = 0
+	Battle.partySize = 6
 	Battle.inBattle = false
 	Battle.battleStarting = false
 	Battle.turnCount = -1
@@ -751,13 +768,11 @@ function Battle.trackTransformedMoves()
 
 	-- Track all moves, if we are copying an enemy mon
 	local transformData = Battle.BattleAbilities[0][Battle.Combatants[Battle.IndexMap[currentSelectingMon]]].transformData
-	if not transformData.isOwn then
+	if not transformData.isOwn or transformData.slot > Battle.partySize then
 		local copiedMon = Tracker.getPokemon(transformData.slot, false)
 		if copiedMon ~= nil then
 			for _, move in pairs(copiedMon.moves) do
-				if MoveData.isValid(move.id) then
-					Tracker.TrackMove(copiedMon.pokemonID, move.id, copiedMon.level)
-				end
+				Tracker.TrackMove(copiedMon.pokemonID, move.id, copiedMon.level)
 			end
 		end
 	end

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -263,6 +263,8 @@ function GameSettings.setEwramAddresses()
 		pstats = { nil, 0x020244EC, 0x02024284 },
 		-- Enemy Stats, exists in IWRAM instead in RS
 		estats = { nil, 0x02024744, 0x0202402C },
+		-- Player Party Size, exists in IWRAM instead in RS
+		gPlayerPartyCount = { nil, 0x020244e9, 0x02024029 },
 
 		-- RS uses this directly (gSharedMem + 0x14800)
 		sEvoInfo = { 0x02014800, nil, nil },
@@ -338,6 +340,7 @@ function GameSettings.setIwramAddresses()
 		-- Addresses only in IWRAM for RS, but in EWRAM for Em/FRLG (so were already set by this point, omit to avoid overwrite)
 		pstats = { { 0x03004360 }, { nil, nil }, { nil, nil } },
 		estats = { { 0x030045C0 }, { nil, nil }, { nil, nil } },
+                gPlayerPartyCount = { { 0x03004350 }, { nil, nil }, { nil, nil },},
 		sBattleBuffersTransferData = { { 0x03004040 }, { nil, nil }, { nil, nil } },
 		gBattleTextBuff1 = { { 0x030041c0 }, { nil, nil }, { nil, nil } },
 		gBattleTerrain = { { 0x0300428c }, { nil, nil }, { nil, nil } },

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -38,6 +38,10 @@ function Input.checkJoypadInput(joypadButtons)
 			if Tracker.Data.isViewingOwn and Battle.numBattlers > 2 then
 				--swap sides on returning to allied side
 				Battle.isViewingLeft = not Battle.isViewingLeft
+				--undo changes for special double battles
+				if Battle.isViewingLeft == false and Battle.Combatants.RightOwn > Battle.partySize then
+					Tracker.Data.isViewingOwn = not Tracker.Data.isViewingOwn
+				end
 				-- Recalculate "Heals In Bag" HP percentages using a constant value (so player sees the update)
 				Program.Frames.three_sec_update = 30
 			end

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "7", minor = "0", patch = "2" }
+Main.Version = { major = "7", minor = "0", patch = "3" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -52,7 +52,7 @@ Program.Pedometer = {
 	lastResetCount = 0, -- num steps since last "reset", for counting new steps
 	goalSteps = 0, -- num steps that is set by the user as a milestone goal to reach, 0 to disable
 	getCurrentStepcount = function(self) return math.max(self.totalSteps - self.lastResetCount, 0) end,
-	isInUse = function(self) return Options["Display pedometer"] and not Battle.inBattle and not Program.inStartMenu end,
+	isInUse = function(self) return Options["Display pedometer"] and not Battle.inBattle and not Battle.battleStarting and not Program.inStartMenu end,
 }
 
 function Program.initialize()
@@ -232,9 +232,10 @@ function Program.updatePokemonTeams()
 	for i = 1, 6, 1 do
 		-- Lookup information on the player's Pokemon first
 		local personality = Memory.readdword(GameSettings.pstats + addressOffset)
+		local trainerID = Memory.readdword(GameSettings.pstats + addressOffset + 4)
 		Tracker.Data.ownTeam[i] = personality
 
-		if personality ~= 0 then
+		if personality ~= 0 or trainerID ~= 0 then
 			local newPokemonData = Program.readNewPokemon(GameSettings.pstats + addressOffset, personality)
 
 			if Program.validPokemonData(newPokemonData) then
@@ -254,7 +255,8 @@ function Program.updatePokemonTeams()
 				end
 
 				-- Remove trainerID value from the pokemon data itself since it's now owned by the player, saves data space
-				newPokemonData.trainerID = nil
+				-- No longer remove, as it's currently used to verify Trainer pokemon with personality values of 0
+				-- newPokemonData.trainerID = nil
 
 				Tracker.addUpdatePokemon(newPokemonData, personality, true)
 			end
@@ -262,9 +264,10 @@ function Program.updatePokemonTeams()
 
 		-- Then lookup information on the opposing Pokemon
 		personality = Memory.readdword(GameSettings.estats + addressOffset)
+		trainerID = Memory.readdword(GameSettings.estats + addressOffset + 4)
 		Tracker.Data.otherTeam[i] = personality
 
-		if personality ~= 0 then
+		if personality ~= 0 or trainerID ~= 0 then
 			local newPokemonData = Program.readNewPokemon(GameSettings.estats + addressOffset, personality)
 
 			if Program.validPokemonData(newPokemonData) then

--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -3310,16 +3310,16 @@ function RouteData.setupRouteInfoAsRSE()
 	RouteData.Info[54] = { name = "Mom's House", }
 	RouteData.Info[61] = { name = Constants.Words.POKEMON .. " Center", }
 	RouteData.Info[65] = { name = "Dewford Gym", }
-	RouteData.Info[69] = { name = "Lavaridge Gym1", }
-	RouteData.Info[70] = { name = "Lavaridge Gym2", }
+	RouteData.Info[69] = { name = "Lavaridge Gym 1F", }
+	RouteData.Info[70] = { name = "Lavaridge Gym B1F", }
 	RouteData.Info[71] = { name = "Lavaridge Town PC", }
 	RouteData.Info[79] = { name = "Petalburg Gym", }
 	RouteData.Info[89] = { name = "Mauville Gym", }
 	RouteData.Info[94] = { name = "Rustboro Gym", }
 	RouteData.Info[100] = { name = "Fortree Gym", }
 	RouteData.Info[108] = { name = "Mossdeep Gym", }
-	RouteData.Info[109] = { name = "Sootopolis Gym1", }
-	RouteData.Info[110] = { name = "Sootopolis Gym2", }
+	RouteData.Info[109] = { name = "Sootopolis Gym 1F", }
+	RouteData.Info[110] = { name = "Sootopolis Gym B1F", }
 	RouteData.Info[111] = { name = "Sidney's Room", }
 	RouteData.Info[112] = { name = "Phoebe's Room", }
 	RouteData.Info[113] = { name = "Glacia's Room", }
@@ -3822,6 +3822,8 @@ function RouteData.setupRouteInfoAsRSE()
 	RouteData.Info[270 + offset] = { name = Constants.Words.POKEMON .. " League PC", }
 	RouteData.Info[271 + offset] = { name = "Weather Institute 1F", }
 	RouteData.Info[272 + offset] = { name = "Weather Institute 2F", }
+	RouteData.Info[275 + offset] = { name = "City Space Center 1F", }
+	RouteData.Info[276 + offset] = { name = "City Space Center 2F", }
 	RouteData.Info[285 + offset] = { name = "Victory Road B1F",
 		[RouteData.EncounterArea.LAND] = {
 			{ pokemonID = 42, rate = 0.35, },

--- a/ironmon_tracker/screens/StartupScreen.lua
+++ b/ironmon_tracker/screens/StartupScreen.lua
@@ -17,12 +17,11 @@ StartupScreen.Buttons = {
 		image = Constants.PixelImages.GEAR,
 		textColor = "Default text",
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 130, 8, 7, 7 },
-		onClick = function(self)
-			Program.changeScreenView(Program.Screens.NAVIGATION)
-		end
+		onClick = function(self) Program.changeScreenView(Program.Screens.NAVIGATION) end
 	},
 	PokemonIcon = {
 		type = Constants.ButtonTypes.POKEMON_ICON,
+		clickableArea = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 100, Constants.SCREEN.MARGIN + 14, 31, 28 },
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 100, Constants.SCREEN.MARGIN + 10, 32, 32 },
 		pokemonID = 0,
 		getIconPath = function(self)
@@ -30,9 +29,7 @@ StartupScreen.Buttons = {
 			local imagepath = Main.DataFolder .. "/images/" .. iconset.folder .. "/" .. self.pokemonID .. iconset.extension
 			return imagepath
 		end,
-		onClick = function(self)
-			StartupScreen.openChoosePokemonWindow()
-		end
+		onClick = function(self) StartupScreen.openChoosePokemonWindow() end
 	},
 	AttemptsCount = {
 		type = Constants.ButtonTypes.NO_BORDER,
@@ -41,11 +38,32 @@ StartupScreen.Buttons = {
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 54, Constants.SCREEN.MARGIN + 37, 33, 11 },
 		boxColors = { "Upper box border", "Upper box background" },
 		isVisible = function() return Main.currentSeed > 1 end,
-		onClick = function(self)
-			StartupScreen.openEditAttemptsWindow()
-		end
+		updateSelf = function(self)
+			self.text = tostring(Main.currentSeed) or Constants.BLANKLINE
+		end,
+		onClick = function(self) StartupScreen.openEditAttemptsWindow() end
 	},
-	EraseGame = {
+	AttemptsEdit = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = Constants.PixelImages.NOTEPAD,
+		textColor = "Default text",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 54, Constants.SCREEN.MARGIN + 37, 10, 10 },
+		isVisible = function() return Main.currentSeed > 1 end,
+		updateSelf = function(self)
+			local txtLength = string.len(StartupScreen.Buttons.AttemptsCount.text or "") + 1
+			self.box[1] = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 54 + (txtLength * 5) -- 5 pixels per digit
+		end,
+		onClick = function(self) StartupScreen.openEditAttemptsWindow() end
+	},
+	NotesAreaEdit = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = Constants.PixelImages.NOTEPAD,
+		textColor = "Lower box text",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 128, Constants.SCREEN.MARGIN + 137, 10, 10 },
+		isVisible = function() return false end,
+		onClick = function(self) StartupScreen.openEditNotesAreaWindow() end
+	},
+	EraseGame = { -- Currently unused
 		type = Constants.ButtonTypes.FULL_BORDER,
 		text = "< Press",
 		textColor = "Lower box text",
@@ -68,7 +86,9 @@ StartupScreen.Buttons = {
 function StartupScreen.initialize()
 	StartupScreen.setPokemonIcon(Options["Startup Pokemon displayed"])
 
-	StartupScreen.Buttons.AttemptsCount.text = tostring(Main.currentSeed)
+	-- Update the attempts count to the current seed number
+	StartupScreen.Buttons.AttemptsCount:updateSelf()
+	StartupScreen.Buttons.AttemptsEdit:updateSelf()
 end
 
 function StartupScreen.setPokemonIcon(displayOption)
@@ -165,7 +185,8 @@ function StartupScreen.openEditAttemptsWindow()
 			local newAttemptsCount = tonumber(formInput)
 			if newAttemptsCount ~= nil then
 				Main.currentSeed = newAttemptsCount
-				StartupScreen.Buttons.AttemptsCount.text = newAttemptsCount
+				StartupScreen.Buttons.AttemptsCount:updateSelf()
+				StartupScreen.Buttons.AttemptsEdit:updateSelf()
 
 				local filename = Main.GetAttemptsFile()
 				if filename ~= nil then
@@ -182,6 +203,10 @@ function StartupScreen.openEditAttemptsWindow()
 		client.unpause()
 		forms.destroy(form)
 	end, 157, 60)
+end
+
+function StartupScreen.openEditNotesAreaWindow()
+	-- To be implemented later. Allows users to define text shown on startup screen, replacing controls
 end
 
 -- DRAWING FUNCTIONS
@@ -229,6 +254,7 @@ function StartupScreen.drawScreen()
 
 	if StartupScreen.Buttons.AttemptsCount.isVisible() then
 		Drawing.drawText(topBox.x + 2, textLineY, StartupScreen.Labels.attempts, topBox.text, topBox.shadow)
+		Drawing.drawButton(StartupScreen.Buttons.AttemptsEdit, topBox.shadow)
 		Drawing.drawButton(StartupScreen.Buttons.AttemptsCount, topBox.shadow)
 	end
 	textLineY = textLineY + linespacing
@@ -281,4 +307,5 @@ function StartupScreen.drawScreen()
 	Drawing.drawButton(StartupScreen.Buttons.SettingsGear, topBox.shadow)
 	Drawing.drawButton(StartupScreen.Buttons.PokemonIcon, topBox.shadow)
 	Drawing.drawButton(StartupScreen.Buttons.EraseGame, botBox.shadow)
+	Drawing.drawButton(StartupScreen.Buttons.NotesAreaEdit, botBox.shadow)
 end


### PR DESCRIPTION
Summary of fixes:
- Updated some Route Data locations and names (Ruby/Sapphire/Emerald)
- Fixed a bug where the move "Struggle" was tracked in some cases
- Fixed a bug where tracker would freeze on some story-related double battles (Emerald)
- Updated Startup Screen to show an edit-icon for the attempts counter

Doing another patch release because of the Tracker freezes in RSE, likely due to double battles