### PR TITLE
Neutral stat marking

### DIFF
--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -34,6 +34,7 @@ Constants.STAT_STATES = {
 	[0] = { text = " ", textColor = "Default text" },
 	[1] = { text = "+", textColor = "Positive text" },
 	[2] = { text = "--", textColor = "Negative text" },
+	[3] = { text = "=", textColor = "Default text" },
 }
 
 Constants.MoveTypeColors = {

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -223,8 +223,8 @@ function Drawing.drawButton(button, shadowcolor)
 		end
 	elseif button.type == Constants.ButtonTypes.STAT_STAGE then
 		if button.text ~= nil and button.text ~= "" then
-			if button.text == Constants.STAT_STATES[2].text then
-				y = y - 1 -- Move up the negative stat mark 1px
+			if button.text == Constants.STAT_STATES[2].text or button.text == Constants.STAT_STATES[3].text then
+				y = y - 1 -- Move up the negative/neutral stat mark 1px
 			end
 			Drawing.drawText(x, y - 1, button.text, Theme.COLORS[button.textColor], shadowcolor)
 		end

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -312,7 +312,7 @@ function TrackerScreen.initialize()
 			onClick = function(self)
 				if not self:isVisible() then return end
 
-				self.statState = ((self.statState + 1) % 3)
+				self.statState = ((self.statState + 1) % 4) -- 4 total possible markings for a stat state
 				self.text = Constants.STAT_STATES[self.statState].text
 				self.textColor = Constants.STAT_STATES[self.statState].textColor
 


### PR DESCRIPTION
Closes #309 

This adds a 4th option for marking a stat on the Tracker: neutral or equal. This is helpful for cases where you test a Pokémon's defensive stat and determine its neither low or high, but still want to mark it instead of leaving it as blank or "untested"

The original order of stat markings is unchanged with the 4th option at the end. So if you cycle through the markings for a stat in goes in order:

1. "blank"
2. Positive, indicated by a "+"
3. Negative, indicated by a "-"
4. Neutral, indicated by a "="
5. (Back to 1. "blank")

![image](https://user-images.githubusercontent.com/4258818/208824310-296e398e-ed4d-4bc3-804f-fe99e6f02b1c.png)
