### PR TITLE
Allowing the Tracker to autoflush saveRAM

### DIFF
--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -60,7 +60,7 @@ Program.AutoSaver = {
 	framesUntilNextSave = -1,
 	updateSaveCount = function(self) -- returns true if the savecount has been updated
 		local currentSaveCount = Utils.getGameStat(Constants.GAME_STATS.SAVED_GAME) or 0
-		if currentSaveCount > self.knownSaveCount and currentSaveCount < 9999 then -- mem read sometimes huge number
+		if currentSaveCount > self.knownSaveCount and currentSaveCount < 99999 then -- mem read sometimes huge number
 			self.knownSaveCount = currentSaveCount
 			return true
 		end
@@ -70,7 +70,7 @@ Program.AutoSaver = {
 		if not Main.IsOnBizhawk() then return end -- flush saveRAM only for Bizhawk
 		if self.framesUntilNextSave == 0 then
 			client.saveram()
-			self.framesUntilNextSave = - 1 -- prevent step frame ticks and additional saves
+			self.framesUntilNextSave = -1 -- prevent step frame ticks and additional saves
 		end
 		if self:updateSaveCount() then
 			self.framesUntilNextSave = 10 * 60

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -55,6 +55,34 @@ Program.Pedometer = {
 	isInUse = function(self) return Options["Display pedometer"] and not Battle.inBattle and not Battle.battleStarting end,
 }
 
+Program.AutoSaver = {
+	knownSaveCount = 0,
+	framesUntilNextSave = -1,
+	updateSaveCount = function(self) -- returns true if the savecount has been updated
+		local currentSaveCount = Utils.getGameStat(Constants.GAME_STATS.SAVED_GAME) or 0
+		if currentSaveCount > self.knownSaveCount and currentSaveCount < 9999 then -- mem read sometimes huge number
+			self.knownSaveCount = currentSaveCount
+			return true
+		end
+		return false
+	end,
+	checkForNextSave = function(self)
+		if not Main.IsOnBizhawk() then return end -- flush saveRAM only for Bizhawk
+		if self.framesUntilNextSave == 0 then
+			client.saveram()
+			self.framesUntilNextSave = - 1 -- prevent step frame ticks and additional saves
+		end
+		if self:updateSaveCount() then
+			self.framesUntilNextSave = 10 * 60
+		end
+	end,
+	stepFrame = function(self)
+		if self.framesUntilNextSave > 0 then
+			self.framesUntilNextSave = self.framesUntilNextSave - 1
+		end
+	end
+}
+
 function Program.initialize()
 	-- If an update is available, offer that up first before going to the Tracker StartupScreen
 	if Main.Version.showUpdate then
@@ -68,6 +96,8 @@ function Program.initialize()
 	if friendshipRequired > 1 and friendshipRequired <= 220 then
 		Program.friendshipRequired = friendshipRequired
 	end
+
+	Program.AutoSaver:updateSaveCount()
 
 	-- Update data asap
 	Program.Frames.highAccuracyUpdate = 0
@@ -168,6 +198,8 @@ function Program.update()
 			if Program.Pedometer:isInUse() then
 				Program.Pedometer.totalSteps = Utils.getGameStat(Constants.GAME_STATS.STEPS)
 			end
+
+			Program.AutoSaver:checkForNextSave()
 		end
 	end
 
@@ -193,6 +225,7 @@ function Program.stepFrames()
 	Program.Frames.three_sec_update = (Program.Frames.three_sec_update - 1) % 180
 	Program.Frames.saveData = (Program.Frames.saveData - 1) % 3600
 	Program.Frames.carouselActive = Program.Frames.carouselActive + 1
+	Program.AutoSaver:stepFrame()
 end
 
 function Program.updateRepelSteps()


### PR DESCRIPTION
Since Bizhawk doesn't always flush the saveRAM, this is an attempt to make that happen more reliably.

This solution uses a simple hack of checking the `GAME_STATS` for a change in quantity on the stat "game saves". This change occurs the moment the user presses the "Save the game" button, and NOT when the save actually completes. As a result, I added a short **10 second delay** before telling Bizhawk to flush the save. It's not perfect, but its a simple addition that likely helps save some runs (pun intended).

Let me know if you can think of a slightly better way to do this.