### PR TITLE
Patch 7.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ We'd ideally like to support all non-English versions if we can, progress update
 1. **Get a Supported Emulator**:
    - We recommend using the Bizhawk emulator (Windows/Linux only).
 	   - [Download Bizhawk](https://tasvideos.org/BizHawk/ReleaseHistory) (v2.8 or higher)
-		- If you are on windows, make sure to also download and run the [prereq installer](https://github.com/TASEmulators/BizHawk-Prereqs/releases) first.
+		- If you are on Windows, make sure to also download and run the [prereq installer](https://github.com/TASEmulators/BizHawk-Prereqs/releases) first
+		- If you are on Linux, we recommend using Bizhawk 2.9 or higher
 	- Alternatively, you can use the MGBA emulator (Windows/Mac/Linux).
 	   - [Download MGBA](https://mgba.io/downloads.html) (v0.10.0 or higher)
 2. **Download the Tracker**: You can get the latest project release from the [releases](https://github.com/besteon/Ironmon-Tracker/releases/latest) section.
@@ -58,7 +59,7 @@ We'd ideally like to support all non-English versions if we can, progress update
 
 - **_NEW!!_ Full Tracked Move History**
 
-![image](https://user-images.githubusercontent.com/4258818/208857705-f4414043-7f19-40da-bbaa-2a75cc759d5a.png)
+![image](https://user-images.githubusercontent.com/4258818/209043481-ad71a433-92ca-47f1-9e24-94790dab70dc.png)
 
 See the project's Wiki for a full [version changelog](https://github.com/besteon/Ironmon-Tracker/wiki/Version-Changelog).
 

--- a/ironmon_tracker/Debug/Symbols.lua
+++ b/ironmon_tracker/Debug/Symbols.lua
@@ -57,11 +57,7 @@ Symbols = {
 		},
 	},
 	symbolSearch = {
-		{"BattleIntroDrawPartySummaryScreens",0x1},
-		{"BattleIntroOpponentSendsOutMonAnimation",0x1},
-		{"HandleEndTurn_FinishBattle",0x1},
-		{"gBattleMainFunc",0x1},
-		{"HandleEndTurn_FinishBattle",0x1}
+		{"sSaveDialogDelay",0x0},
 	},
 	FRToOtherGameNameMap = {
 		["sBattleBuffersTransferData"] = {
@@ -76,6 +72,14 @@ Symbols = {
 			[0] = "SendOutMonAnimation",
 			[1] = "SendOutMonAnimation",
 			[2] = "BattleIntroOpponent2SendsOutMonAnimation",
+		},
+		["sSaveDialogDelay"] = {
+			[0]="saveDialogTimer",
+			[1]="saveDialogTimer",
+			[2]="sSaveDialogTimer",
+		},
+		["SaveDialogCB_ReturnSuccess"] = {
+			[2]="SaveSuccessCallback",
 		}
 	},
 	outputFile = "addresses.txt",
@@ -88,6 +92,7 @@ function Symbols.populateSymbolsMap()
 		local gameValues = Symbols.symbolSources[i]
 		gameValues.symbols = {}
 		for j = 1, #Symbols.symbolSearch, 1 do
+			print (FileManager.prependDir(gameValues.fileName))
 			local symbolFile = io.open(FileManager.prependDir(gameValues.fileName),"r") or ""
 			local found = false
 			local variableName = Symbols.symbolSearch[j][1]

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -342,6 +342,7 @@ function GameSettings.setEwramAddresses()
 		gBattleTerrain = { nil, 0x02022ff0, 0x02022b50 },
 		-- This address doesn't exist at all in RS
 		sStartMenuWindowId = { nil, 0x0203cd8c, 0x0203abe0 },
+		sSaveDialogDelay = { nil, 0x2037620, nil},
 	}
 
 	for key, address in pairs(addresses) do
@@ -374,6 +375,7 @@ function GameSettings.setIwramAddresses()
 		-- IWRAM addresses present in all games
 		gBattleResults = { { 0x030042e0 }, { 0x03005d10 }, { 0x03004f90, 0x03004ee0 } },
 		gTasks = { { 0x03004b20 }, { 0x03005e00 }, { 0x03005090, 0x03004fe0 } },
+		sSaveDialogDelay = {{ 0x30006ac}, {nil, nil}, {0x3000fa8, 0x3000fa8,}},
 	}
 
 	local languageIndex = Utils.inlineIf(GameSettings.language == "English", 1, 2)

--- a/ironmon_tracker/MGBA.lua
+++ b/ironmon_tracker/MGBA.lua
@@ -1019,6 +1019,16 @@ MGBA.CommandMap = {
 			end
 		end,
 	},
+	["RANDOMBALL"] = {
+		description = "Chooses a random " .. Constants.Words.POKEMON .. " starter " .. Constants.Words.POKE .. "ball from among: Left, Middle, Right",
+		usageSyntax = 'RANDOMBALL()',
+		usageExample = 'RANDOMBALL()',
+		execute = function(self, params)
+			local ballChoice = TrackerScreen.randomlyChooseBall() -- 1, 2, or 3
+			local chosenBallText = TrackerScreen.PokeBalls.Labels[ballChoice] or Constants.BLANKLINE
+			print(string.format(" Randomly chosen starter %sball: %s", Constants.Words.POKE, chosenBallText))
+		end,
+	},
 }
 
 -- Global functions required by mGBA input prompts
@@ -1103,3 +1113,7 @@ function helpwiki(...) HELPWIKI(...) end
 function ATTEMPTS(...) MGBA.CommandMap["ATTEMPTS"]:execute(...) end
 function Attempts(...) ATTEMPTS(...) end
 function attempts(...) ATTEMPTS(...) end
+
+function RANDOMBALL(...) MGBA.CommandMap["RANDOMBALL"]:execute(...) end
+function RandomBall(...) RANDOMBALL(...) end
+function randomball(...) RANDOMBALL(...) end

--- a/ironmon_tracker/MGBADisplay.lua
+++ b/ironmon_tracker/MGBADisplay.lua
@@ -416,6 +416,7 @@ MGBADisplay.LineBuilder = {
 			MGBA.CommandMap["PCHEALS"],
 			MGBA.CommandMap["HIDDENPOWER"],
 			MGBA.CommandMap["ATTEMPTS"],
+			MGBA.CommandMap["RANDOMBALL"],
 			MGBA.CommandMap["HELPWIKI"],
 			MGBA.CommandMap["CREDITS"],
 			MGBA.CommandMap["ALLCOMMANDS"],

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "7", minor = "1", patch = "0" }
+Main.Version = { major = "7", minor = "1", patch = "4" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -62,7 +62,9 @@ Program.AutoSaver = {
 	framesUntilNextSave = -1,
 	updateSaveCount = function(self) -- returns true if the savecount has been updated
 		local currentSaveCount = Utils.getGameStat(Constants.GAME_STATS.SAVED_GAME) or 0
-		if currentSaveCount > self.knownSaveCount and currentSaveCount < 99999 then -- mem read sometimes huge number
+		local saveSuccessCountdown = Memory.readbyte(GameSettings.sSaveDialogDelay) or 0
+		-- Starts at 60 on success, then immediately decrements to 59 before checking if the save menu should close
+		if saveSuccessCountdown == 60 and currentSaveCount > self.knownSaveCount and currentSaveCount < 99999 then
 			self.knownSaveCount = currentSaveCount
 			return true
 		end
@@ -70,17 +72,8 @@ Program.AutoSaver = {
 	end,
 	checkForNextSave = function(self)
 		if not Main.IsOnBizhawk() then return end -- flush saveRAM only for Bizhawk
-		if self.framesUntilNextSave == 0 then
-			client.saveram()
-			self.framesUntilNextSave = -1 -- prevent step frame ticks and additional saves
-		end
 		if self:updateSaveCount() then
-			self.framesUntilNextSave = 10 * 60
-		end
-	end,
-	stepFrame = function(self)
-		if self.framesUntilNextSave > 0 then
-			self.framesUntilNextSave = self.framesUntilNextSave - 1
+			client.saveram()
 		end
 	end
 }
@@ -245,7 +238,6 @@ function Program.stepFrames()
 	Program.Frames.three_sec_update = (Program.Frames.three_sec_update - 1) % 180
 	Program.Frames.saveData = (Program.Frames.saveData - 1) % 3600
 	Program.Frames.carouselActive = Program.Frames.carouselActive + 1
-	Program.AutoSaver:stepFrame()
 end
 
 function Program.updateRepelSteps()

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -282,7 +282,7 @@ function Program.updatePokemonTeams()
 		-- Lookup information on the player's Pokemon first
 		local personality = Memory.readdword(GameSettings.pstats + addressOffset)
 		local trainerID = Memory.readdword(GameSettings.pstats + addressOffset + 4)
-		local previousPersonality = Tracker.Data.ownTeam[i]
+		-- local previousPersonality = Tracker.Data.ownTeam[i] -- See below
 		Tracker.Data.ownTeam[i] = personality
 
 		if personality ~= 0 or trainerID ~= 0 then
@@ -310,12 +310,13 @@ function Program.updatePokemonTeams()
 
 				Tracker.addUpdatePokemon(newPokemonData, personality, true)
 
+				-- TODO: Removing for now until some better option is available, not sure there is one
 				-- If this is a newly caught Pokémon, track all of its moves. Can't do this later cause TMs/HMs
-				if previousPersonality == 0 then
-					for _, move in ipairs(newPokemonData.moves) do
-						Tracker.TrackMove(newPokemonData.pokemonID, move.id, newPokemonData.level)
-					end
-				end
+				-- if previousPersonality == 0 then
+				-- 	for _, move in ipairs(newPokemonData.moves) do
+				-- 		Tracker.TrackMove(newPokemonData.pokemonID, move.id, newPokemonData.level)
+				-- 	end
+				-- end
 			end
 		end
 

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -270,11 +270,7 @@ function Tracker.TrackNote(pokemonID, note)
 end
 
 function Tracker.TrackHiddenPowerType(personality, moveType)
-	if personality == nil or moveType == nil then return end
-
-	if personality == 0 or PokemonData.Types[moveType] == nil then
-		return
-	end
+	if personality == nil or moveType == nil or personality == 0 then return end
 
 	Tracker.Data.hiddenPowers[personality] = moveType
 end

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -173,7 +173,7 @@ InfoScreen.Buttons = {
 		textColor = "Default text",
 		box = { Constants.SCREEN.WIDTH + 116, Constants.SCREEN.MARGIN + 31, 10, 10 },
 		isVisible = function()
-			if InfoScreen.viewScreen ~= InfoScreen.Screens.MOVE_INFO then return false end
+			if InfoScreen.viewScreen ~= InfoScreen.Screens.MOVE_INFO or InfoScreen.infoLookup ~= 237 then return false end
 			-- Only reveal the HP set arrows if the player's active Pokemon has the move
 			local pokemon = Battle.getViewedPokemon(true) or Tracker.getDefaultPokemon()
 			return PokemonData.isValid(pokemon.pokemonID) and Utils.pokemonHasMove(pokemon, 237) -- 237 = Hidden Power
@@ -205,12 +205,7 @@ InfoScreen.Buttons = {
 		image = Constants.PixelImages.NEXT_BUTTON,
 		textColor = "Default text",
 		box = { Constants.SCREEN.WIDTH + 129, Constants.SCREEN.MARGIN + 31, 10, 10 },
-		isVisible = function()
-			if InfoScreen.viewScreen ~= InfoScreen.Screens.MOVE_INFO then return false end
-			-- Only reveal the HP set arrows if the player's active Pokemon has the move
-			local pokemon = Battle.getViewedPokemon(true) or Tracker.getDefaultPokemon()
-			return PokemonData.isValid(pokemon.pokemonID) and Utils.pokemonHasMove(pokemon, 237) -- 237 = Hidden Power
-		end,
+		isVisible = function() return InfoScreen.Buttons.HiddenPowerPrev:isVisible() end,
 		onClick = function(self)
 			-- If the player's lead pokemon has Hidden Power, lookup that tracked typing
 			local pokemon = Battle.getViewedPokemon(true) or Tracker.getDefaultPokemon()

--- a/ironmon_tracker/screens/MoveHistoryScreen.lua
+++ b/ironmon_tracker/screens/MoveHistoryScreen.lua
@@ -1,6 +1,6 @@
 MoveHistoryScreen = {
 	Labels = {
-		headerMoves = "Move used at level:",
+		headerMoves = "Move seen at level:",
 		headerMin = "Min",
 		headerMax = "Max",
 		noTrackedMoves = "(No tracked move data yet)",

--- a/ironmon_tracker/screens/NavigationMenu.lua
+++ b/ironmon_tracker/screens/NavigationMenu.lua
@@ -73,10 +73,11 @@ NavigationMenu.Buttons = {
 			end
 		end,
 		onClick = function(self)
-			if Main.isOnLatestVersion() then
-				UpdateScreen.currentState = UpdateScreen.States.NEEDS_CHECK
-			else
+			-- Always show the update menu if using a dev build, to allow updating from dev branch
+			if UpdateOrInstall.Dev.enabled or not Main.isOnLatestVersion() then
 				UpdateScreen.currentState = UpdateScreen.States.NOT_UPDATED
+			else
+				UpdateScreen.currentState = UpdateScreen.States.NEEDS_CHECK
 			end
 			Program.changeScreenView(Program.Screens.UPDATE)
 		end

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -928,6 +928,11 @@ function TrackerScreen.drawMovesArea(data)
 	Drawing.drawText(Constants.SCREEN.WIDTH + moveAccOffset, moveOffsetY - moveTableHeaderHeightDiff, "Acc", Theme.COLORS["Header text"], bgHeaderShadow)
 
 	-- Redraw next move level in the header with a different color if close to learning new move
+	if #Tracker.getMoves(data.p.id) > 4 then
+		Drawing.drawText(Constants.SCREEN.WIDTH + 30, moveOffsetY - moveTableHeaderHeightDiff, "*", TrackerScreen.nextMoveLevelHighlight, bgHeaderShadow)
+	end
+
+	-- Redraw next move level in the header with a different color if close to learning new move
 	if data.m.nextmovelevel ~= nil and data.m.nextmovespacing ~= nil and Tracker.Data.isViewingOwn and data.p.level + 1 >= data.m.nextmovelevel then
 		Drawing.drawText(Constants.SCREEN.WIDTH + data.m.nextmovespacing, moveOffsetY - moveTableHeaderHeightDiff, data.m.nextmovelevel, TrackerScreen.nextMoveLevelHighlight, bgHeaderShadow)
 	end

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -672,6 +672,7 @@ end
 
 function TrackerScreen.randomlyChooseBall()
 	TrackerScreen.PokeBalls.chosenBall = math.random(3)
+	return TrackerScreen.PokeBalls.chosenBall
 end
 
 function TrackerScreen.canShowBallPicker()


### PR DESCRIPTION
Closes #141 

This patch release fixes the following issues:
- [MGBA] Added a RANDOMBALL() command for picking a random starter Pokéball
- Setting your Pokémon's Hidden Power type can now be cycled forwards or backwards
- Autoflush SaveRAM is now more accurate
- Fixed an issue where legacy Tracker versions (7.0.3 and lower) weren't being notified of new update
   - This is why this patch version ends in 4 instead of anything else. (x.x.4 is greater than x.x.3)
- Fixed an issue where the asterisk on "Moves *" wasn't highlighting properly
- Fixed an issue where a player wasn't able to set their own Hidden Power
- Fixed an issue where some moves were spoiled if a player caught and released Pokémon too frequently
