### PR TITLE
Hotfix 7.1.5 Fixing all io.popen errors

### DIFF
--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -538,7 +538,7 @@ function Main.GenerateNextRom()
 	)
 
 	local success, file
-	if Main.emulator == Main.EMU.MGBA or (Main.IsOnBizhawk() and Main.OS == "Linux") then
+	if Main.emulator == Main.EMU.MGBA or (Main.emulator == Main.EMU.BIZHAWK28 and Main.OS == "Linux") then
 		local result = os.execute(javacommand)
 		success = (result == true or result == 0)
 	else

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -538,7 +538,7 @@ function Main.GenerateNextRom()
 	)
 
 	local success, file
-	if Main.emulator == Main.EMU.MGBA or (Main.emulator == Main.EMU.BIZHAWK28 and Main.OS == "Linux") then
+	if Main.OS ~= "Windows" and (Main.emulator == Main.EMU.MGBA or Main.emulator == Main.EMU.BIZHAWK28) then
 		local result = os.execute(javacommand)
 		success = (result == true or result == 0)
 	else

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "7", minor = "1", patch = "4" }
+Main.Version = { major = "7", minor = "1", patch = "5" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",


### PR DESCRIPTION
This changes all uses of popen to use a tryExecute function instead, to prevent unexpected Tracker crashes.

Unfortunately, this means the convenient method to setup Quickload for mGBA on Mac is unavailable. Won't have a solution for a while.

In short, this means mGBA users without access to Bizhawk to setup their Settings.ini file simply cannot use Quickload.