### PR TITLE
Hotfix 7.1.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ quickload/*.gba
 quickload/*.sav
 quickload/*.jar
 quickload/*.rnqs
+ironmon_tracker/osexecute-output.txt
 ironmon_tracker/images/pokemonAnimated/*.gif
 AnimatedPokemon.gif
 RandomizerErrorLog.txt

--- a/UpdateOrInstall.lua
+++ b/UpdateOrInstall.lua
@@ -1,7 +1,7 @@
 -- This file is NOT automatically loaded on Tracker startup; only loads *after* new update files are downloaded
 -- In this way, this file will always be the latest version possible and allow for properly updating files
 
--- Lots of redundancy here as this file is meant to work as a standalong or as part of the full Tracker script
+-- Lots of redundancy here as this file is meant to work as a standalone or as part of the full Tracker script
 UpdateOrInstall = {
 	thisFileName = "UpdateOrInstall.lua",
 	trackerFileName = "Ironmon-Tracker.lua",
@@ -287,7 +287,9 @@ function UpdateOrInstall.buildDownloadExtractCommand(tarUrl, archive, extractedF
 			table.insert(batchCommands, string.format('tar -xzf "%s" --overwrite', archive))
 		else
 			table.insert(batchCommands, string.format('mkdir -p "%s"', extractedFolder))
-			table.insert(batchCommands, string.format('tar -xzf "%s" --overwrite -C "%s"', archive, IronmonTracker.workingDir))
+			local linuxExtract = string.format('tar -xzf "%s" --overwrite -C "%s"', archive, IronmonTracker.workingDir)
+			local macExtract = string.format('tar -xzf "%s" -C "%s"', archive, IronmonTracker.workingDir)
+			table.insert(batchCommands, string.format("(%s || %s)", linuxExtract, macExtract))
 		end
 		table.insert(batchCommands, string.format('rm -rf "%s"', archive))
 

--- a/UpdateOrInstall.lua
+++ b/UpdateOrInstall.lua
@@ -155,7 +155,7 @@ function UpdateOrInstall.performParallelUpdate()
 	end
 
 	-- Attempt to replace the local UpdateOrInstall.lua with the newly downloaded one
-	FileManager.loadLuaFile(archiveFolderPath .. FileManager.slash .. FileManager.Files.UpdateOrInstall, true)
+	FileManager.loadLuaFile(archiveFolderPath .. FileManager.slash .. FileManager.Files.UPDATE_OR_INSTALL, true)
 
 	local success = UpdateOrInstall.updateFiles(archiveFolderPath)
 	if success then

--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -48,7 +48,7 @@ Battle = {
 		RightOwn = 2,
 		RightOther = 2,
 	},
-	BattleAbilities = {
+	BattleParties = {
 		[0] = {},
 		[1] = {},
 	},
@@ -162,16 +162,16 @@ function Battle.updateViewSlots()
 	end
 
 	--Track if ally pokemon changes, to reset transform and ability changes
-	if prevOwnPokemonLeft ~= nil and prevOwnPokemonLeft ~= Battle.Combatants.LeftOwn and Battle.BattleAbilities[0][prevOwnPokemonLeft] ~= nil then
+	if prevOwnPokemonLeft ~= nil and prevOwnPokemonLeft ~= Battle.Combatants.LeftOwn and Battle.BattleParties[0][prevOwnPokemonLeft] ~= nil then
 		Battle.resetAbilityMapPokemon(prevOwnPokemonLeft,true)
-	elseif Battle.numBattlers == 4 and prevOwnPokemonRight ~= nil and prevOwnPokemonRight ~= Battle.Combatants.RightOwn and Battle.BattleAbilities[0][prevOwnPokemonRight] ~= nil then
+	elseif Battle.numBattlers == 4 and prevOwnPokemonRight ~= nil and prevOwnPokemonRight ~= Battle.Combatants.RightOwn and Battle.BattleParties[0][prevOwnPokemonRight] ~= nil then
 		Battle.resetAbilityMapPokemon(prevOwnPokemonRight,true)
 	end
 	-- Pokemon on the left is not the one that was there previously
-	if prevEnemyPokemonLeft ~= nil and prevEnemyPokemonLeft ~= Battle.Combatants.LeftOther and Battle.BattleAbilities[1][prevEnemyPokemonLeft]  then
+	if prevEnemyPokemonLeft ~= nil and prevEnemyPokemonLeft ~= Battle.Combatants.LeftOther and Battle.BattleParties[1][prevEnemyPokemonLeft]  then
 		Battle.resetAbilityMapPokemon(prevEnemyPokemonLeft,false)
 		Battle.changeOpposingPokemonView(true)
-	elseif Battle.numBattlers == 4 and prevEnemyPokemonRight ~= nil and prevEnemyPokemonRight ~= Battle.Combatants.RightOther and Battle.BattleAbilities[1][prevEnemyPokemonRight]  then
+	elseif Battle.numBattlers == 4 and prevEnemyPokemonRight ~= nil and prevEnemyPokemonRight ~= Battle.Combatants.RightOther and Battle.BattleParties[1][prevEnemyPokemonRight]  then
 		Battle.resetAbilityMapPokemon(prevEnemyPokemonRight,false)
 		Battle.changeOpposingPokemonView(false)
 	end
@@ -250,52 +250,78 @@ function Battle.updateTrackedInfo()
 	if actionCount <= 1 and (lastMoveByAttacker ~= 0 or currentAction ~= 0) then Battle.firstActionTaken = true end
 	--ignore focus punch setup, only priority move that isn't actually a used move yet. Also don't bother tracking abilities/moves for ghosts
 	if not Battle.moveDelayed() and not Battle.isGhost then
+
+		-- Handle Focus punch separately
+		if not Battle.battleMsg == GameSettings.BattleScript_FocusPunchSetUp then
 		-- Check if we are on a new action cycle (Range 0 to numBattlers - 1)
 		-- firstActionTaken fixes leftover data issue going from Single to Double battle
 		-- If the same attacker was just logged, stop logging
 
-		if actionCount < Battle.numBattlers and Battle.firstActionTaken and confirmedCount == 0 and currentAction == 0 then
-			-- 0 = MOVE_USED
-			if lastMoveByAttacker > 0 and lastMoveByAttacker < #MoveData.Moves + 1 then
-				if Battle.AbilityChangeData.prevAction ~= actionCount then
-					Battle.AbilityChangeData.recordNextMove = true
-					Battle.AbilityChangeData.prevAction = actionCount
-				elseif Battle.AbilityChangeData.recordNextMove then
-					local hitFlags = Memory.readdword(GameSettings.gHitMarker)
-					local moveFlags = Memory.readbyte(GameSettings.gMoveResultFlags)
-					--Do nothing if attacker was unable to use move (Fully paralyzed, Truant, etc.; HITMARKER_UNABLE_TO_USE_MOVE)
-					if Utils.bit_and(hitFlags,0x80000) == 0 then
-						-- Track move so long as the mon was able to use it
-						local attackerSlot = Battle.Combatants[Battle.IndexMap[Battle.attacker]]
-						local transformData = Battle.BattleAbilities[Battle.attacker % 2][attackerSlot].transformData
-						--Handle snatch
-						if Battle.battleMsg == GameSettings.BattleScript_SnatchedMove then
-							local battlerSlot = Battle.Combatants[Battle.IndexMap[Battle.battler]]
-							local battlerTransformData = Battle.BattleAbilities[Battle.battler % 2][battlerSlot].transformData
-							if not battlerTransformData.isOwn then
-								local lastMoveByBattler = Memory.readword(GameSettings.gBattleResults + 0x22 + ((Battle.battler % 2) * 0x2))
-								local battlerMon = Tracker.getPokemon(battlerTransformData.slot,battlerTransformData.isOwn)
-								if battlerMon ~= nil then
-									Tracker.TrackMove(battlerMon.pokemonID, lastMoveByBattler, battlerMon.level)
-								end
-							end
-						else
-							-- Only track moves for enemies or NPC allies; our moves could be TM moves, or moves we didn't forget from earlier levels
-							if not transformData.isOwn or transformData.slot > Battle.partySize then
-								local attackingMon = Tracker.getPokemon(transformData.slot,transformData.isOwn)
-								if attackingMon ~= nil then
-									Tracker.TrackMove(attackingMon.pokemonID, lastMoveByAttacker, attackingMon.level)
-								end
-							end
+			if actionCount < Battle.numBattlers and Battle.firstActionTaken and confirmedCount == 0 and currentAction == 0 then
+				-- 0 = MOVE_USED
+				if lastMoveByAttacker > 0 and lastMoveByAttacker < #MoveData.Moves + 1 then
+					if Battle.AbilityChangeData.prevAction ~= actionCount then
+						Battle.AbilityChangeData.recordNextMove = true
+						Battle.AbilityChangeData.prevAction = actionCount
+					elseif Battle.AbilityChangeData.recordNextMove then
+						local hitFlags = Memory.readdword(GameSettings.gHitMarker)
+						local moveFlags = Memory.readbyte(GameSettings.gMoveResultFlags)
+						--Do nothing if attacker was unable to use move (Fully paralyzed, Truant, etc.; HITMARKER_UNABLE_TO_USE_MOVE)
+						if Utils.bit_and(hitFlags,0x80000) == 0 then
+							-- Track move so long as the mon was able to use it
 
-							--Only track ability-changing moves if they also did not fail/miss
-							if Utils.bit_and(moveFlags,0x29) == 0 then -- MOVE_RESULT_MISSED | MOVE_RESULT_DOESNT_AFFECT_FOE | MOVE_RESULT_FAILED
-								Battle.trackAbilityChanges(lastMoveByAttacker,nil)
+							--Handle snatch
+							if Battle.battleMsg == GameSettings.BattleScript_SnatchedMove then
+								local battlerSlot = Battle.Combatants[Battle.IndexMap[Battle.battler]]
+								local battler = Battle.BattleParties[Battle.battler % 2][battlerSlot]
+								local battlerTransformData = battler.transformData
+								if not battlerTransformData.isOwn then
+									local lastMoveByBattler = Memory.readword(GameSettings.gBattleResults + 0x22 + ((Battle.battler % 2) * 0x2))
+									if lastMoveByBattler == battler.moves[1] or lastMoveByBattler == battler.moves[2] or lastMoveByBattler == battler.moves[3] or lastMoveByBattler == battler.moves[4] then
+										local battlerMon = Tracker.getPokemon(battlerTransformData.slot,battlerTransformData.isOwn)
+										if battlerMon ~= nil then
+											Tracker.TrackMove(battlerMon.pokemonID, lastMoveByBattler, battlerMon.level)
+										end
+									end
+								end
+							else
+								-- Only track moves for enemies or NPC allies; our moves could be TM moves, or moves we didn't forget from earlier levels
+								local attackerSlot = Battle.Combatants[Battle.IndexMap[Battle.attacker]]
+								local attacker = Battle.BattleParties[Battle.attacker % 2][attackerSlot]
+								local transformData = attacker.transformData
+								if not transformData.isOwn then
+									-- Only track moves which the pokemon knew at the start of battle (in case of Sketch/Mimic)
+									if lastMoveByAttacker == attacker.moves[1] or lastMoveByAttacker == attacker.moves[2] or lastMoveByAttacker == attacker.moves[3] or lastMoveByAttacker == attacker.moves[4] then
+										local attackingMon = Tracker.getPokemon(transformData.slot,transformData.isOwn)
+										if attackingMon ~= nil then
+											Tracker.TrackMove(attackingMon.pokemonID, lastMoveByAttacker, attackingMon.level)
+										end
+									end
+								end
+
+								--Only track ability-changing moves if they also did not fail/miss
+								if Utils.bit_and(moveFlags,0x29) == 0 then -- MOVE_RESULT_MISSED | MOVE_RESULT_DOESNT_AFFECT_FOE | MOVE_RESULT_FAILED
+									Battle.trackAbilityChanges(lastMoveByAttacker,nil)
+								end
 							end
 						end
+						--only get one chance to record
+						Battle.AbilityChangeData.recordNextMove = false
 					end
-					--only get one chance to record
-					Battle.AbilityChangeData.recordNextMove = false
+				end
+			end
+		else
+			--Focus Punch
+			local attackerSlot = Battle.Combatants[Battle.IndexMap[Battle.attacker]]
+			local attacker = Battle.BattleParties[Battle.attacker % 2][attackerSlot]
+			local transformData = attacker.transformData
+			if not transformData.isOwn then
+				-- Only track moves which the pokemon knew at the start of battle (in case of Sketch/Mimic). Focus Punch needs to hard-coded, focus punch doesn't become the last-used move until the second part
+				if 264 == attacker.moves[1] or 264 == attacker.moves[2] or 264 == attacker.moves[3] or 264 == attacker.moves[4] then
+					local attackingMon = Tracker.getPokemon(transformData.slot,transformData.isOwn)
+					if attackingMon ~= nil then
+						Tracker.TrackMove(attackingMon.pokemonID, 264, attackingMon.level)
+					end
 				end
 			end
 		end
@@ -322,7 +348,7 @@ function Battle.updateTrackedInfo()
 		local combatantIndexesToTrack = Battle.checkAbilitiesToTrack()
 		for _, indexToTrack in pairs(combatantIndexesToTrack) do
 			if indexToTrack >= 0 and indexToTrack < Battle.numBattlers then
-				local battleMon = Battle.BattleAbilities[indexToTrack % 2][Battle.Combatants[Battle.IndexMap[indexToTrack]]]
+				local battleMon = Battle.BattleParties[indexToTrack % 2][Battle.Combatants[Battle.IndexMap[indexToTrack]]]
 				local abilityOwner = Tracker.getPokemon(battleMon.abilityOwner.slot,battleMon.abilityOwner.isOwn)
 				if abilityOwner ~= nil then
 					Tracker.TrackAbility(abilityOwner.pokemonID, battleMon.ability)
@@ -431,17 +457,17 @@ function Battle.checkAbilitiesToTrack()
 
 	--Something is not right with the data; happens occasionally for emerald.
 	if Battle.attacker == nil or Battle.IndexMap[Battle.attacker] == nil or Battle.Combatants[Battle.IndexMap[Battle.attacker]] == nil
-	or Battle.BattleAbilities[Battle.attacker % 2] == nil or Battle.BattleAbilities[Battle.attacker % 2][Battle.Combatants[Battle.IndexMap[Battle.attacker]]] == nil
+	or Battle.BattleParties[Battle.attacker % 2] == nil or Battle.BattleParties[Battle.attacker % 2][Battle.Combatants[Battle.IndexMap[Battle.attacker]]] == nil
 	or Battle.battler == nil or Battle.IndexMap[Battle.battler] == nil or Battle.Combatants[Battle.IndexMap[Battle.battler]] == nil
-	or Battle.BattleAbilities[Battle.battler % 2] == nil or Battle.BattleAbilities[Battle.battler % 2][Battle.Combatants[Battle.IndexMap[Battle.battler]]] == nil
+	or Battle.BattleParties[Battle.battler % 2] == nil or Battle.BattleParties[Battle.battler % 2][Battle.Combatants[Battle.IndexMap[Battle.battler]]] == nil
 	or Battle.battlerTarget == nil or Battle.IndexMap[Battle.battlerTarget] == nil or Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]] == nil
-	or Battle.BattleAbilities[Battle.battlerTarget % 2] == nil or Battle.BattleAbilities[Battle.battlerTarget % 2][Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]]] == nil then
+	or Battle.BattleParties[Battle.battlerTarget % 2] == nil or Battle.BattleParties[Battle.battlerTarget % 2][Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]]] == nil then
 		return combatantIndexesToTrack
 	end
 
-	local attackerAbility = Battle.BattleAbilities[Battle.attacker % 2][Battle.Combatants[Battle.IndexMap[Battle.attacker]]].ability
-	local battlerAbility = Battle.BattleAbilities[Battle.battler % 2][Battle.Combatants[Battle.IndexMap[Battle.battler]]].ability
-	local battleTargetAbility = Battle.BattleAbilities[Battle.battlerTarget % 2][Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]]].ability
+	local attackerAbility = Battle.BattleParties[Battle.attacker % 2][Battle.Combatants[Battle.IndexMap[Battle.attacker]]].ability
+	local battlerAbility = Battle.BattleParties[Battle.battler % 2][Battle.Combatants[Battle.IndexMap[Battle.battler]]].ability
+	local battleTargetAbility = Battle.BattleParties[Battle.battlerTarget % 2][Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]]].ability
 
 	-- BATTLER: 'battler' had their ability triggered
 	local abilityMsg = GameSettings.ABILITIES.BATTLER[Battle.battleMsg]
@@ -507,7 +533,7 @@ function Battle.checkAbilitiesToTrack()
 			combatantIndexesToTrack[Battle.battlerTarget] = Battle.battlerTarget
 		--check for first Damp mon
 		elseif abilityMsg ~= nil and abilityMsg.scope == "both" then
-			local monAbility = Battle.BattleAbilities[i%2][Battle.Combatants[Battle.IndexMap[i]]].ability
+			local monAbility = Battle.BattleParties[i%2][Battle.Combatants[Battle.IndexMap[i]]].ability
 			if abilityMsg[monAbility] then
 				combatantIndexesToTrack[i] = i
 			end
@@ -561,7 +587,7 @@ function Battle.beginNewBattle()
 		RightOwn = 2,
 		RightOther = 2,
 	}
-	Battle.populateBattleAbilityObject()
+	Battle.populateBattlePartyObject()
 	Input.StatHighlighter:resetSelectedStat()
 
 	-- Handles a common case of looking up a move, then entering combat. As a battle begins, the move info screen should go away.
@@ -589,7 +615,7 @@ function Battle.endCurrentBattle()
 	--Most of the time, Run Away message is present only after the battle ends
 	Battle.battleMsg = Memory.readdword(GameSettings.gBattlescriptCurrInstr)
 	if Battle.battleMsg == GameSettings.BattleScript_RanAwayUsingMonAbility then
-		local battleMon = Battle.BattleAbilities[0][Battle.Combatants[Battle.IndexMap[0]]]
+		local battleMon = Battle.BattleParties[0][Battle.Combatants[Battle.IndexMap[0]]]
 		local abilityOwner = Tracker.getPokemon(battleMon.abilityOwner.slot,battleMon.abilityOwner.isOwn)
 		if abilityOwner ~= nil then
 			Tracker.TrackAbility(abilityOwner.pokemonID, battleMon.ability)
@@ -619,7 +645,7 @@ function Battle.endCurrentBattle()
 		RightOwn = 2,
 		RightOther = 2,
 	}
-	Battle.BattleAbilities = {
+	Battle.BattleParties = {
 		[0] = {},
 		[1] = {},
 	}
@@ -670,15 +696,22 @@ function Battle.changeOpposingPokemonView(isLeft)
 	Program.Frames.waitToDraw = 0
 end
 
-function Battle.populateBattleAbilityObject()
-	--populate BattleAbilities for all Pokemon with their starting Abilities and pokemonIDs
-	Battle.BattleAbilities[0] = {}
-	Battle.BattleAbilities[1] = {}
+function Battle.populateBattlePartyObject()
+	--populate BattleParties for all Pokemon with their starting Abilities and pokemonIDs
+	Battle.BattleParties[0] = {}
+	Battle.BattleParties[1] = {}
 	for i=1, 6, 1 do
 		local ownPokemon = Tracker.getPokemon(i, true)
 		if ownPokemon ~= nil then
+			local ownMoves = {
+				ownPokemon.moves[1].id,
+				ownPokemon.moves[2].id,
+				ownPokemon.moves[3].id,
+				ownPokemon.moves[4].id
+
+			}
 			local ability = PokemonData.getAbilityId(ownPokemon.pokemonID, ownPokemon.abilityNum)
-			Battle.BattleAbilities[0][i] = {
+			Battle.BattleParties[0][i] = {
 				abilityOwner = {
 					isOwn = true,
 					slot = i
@@ -689,12 +722,20 @@ function Battle.populateBattleAbilityObject()
 					isOwn = true,
 					slot = i,
 				},
+				moves = ownMoves
 			}
 		end
 		local enemyPokemon = Tracker.getPokemon(i, false)
 		if enemyPokemon ~= nil then
+			local enemyMoves = {
+				enemyPokemon.moves[1].id,
+				enemyPokemon.moves[2].id,
+				enemyPokemon.moves[3].id,
+				enemyPokemon.moves[4].id
+
+			}
 			local ability = PokemonData.getAbilityId(enemyPokemon.pokemonID, enemyPokemon.abilityNum)
-			Battle.BattleAbilities[1][i] = {
+			Battle.BattleParties[1][i] = {
 				abilityOwner = {
 					isOwn = false,
 					slot = i
@@ -705,6 +746,7 @@ function Battle.populateBattleAbilityObject()
 					isOwn = false,
 					slot = i,
 				},
+				moves = enemyMoves
 			}
 		end
 	end
@@ -721,16 +763,16 @@ function Battle.trackAbilityChanges(moveUsed, ability)
 			local targetTeamIndex =  Battle.battlerTarget % 2
 			local targetSlot = Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]]
 
-			local tempOwnerIsOwn = Battle.BattleAbilities[attackerTeamIndex][attackerSlot].abilityOwner.isOwn
-			local tempOwnerSlot = Battle.BattleAbilities[attackerTeamIndex][attackerSlot].abilityOwner.slot
-			local tempAbility = Battle.BattleAbilities[attackerTeamIndex][attackerSlot].ability
+			local tempOwnerIsOwn = Battle.BattleParties[attackerTeamIndex][attackerSlot].abilityOwner.isOwn
+			local tempOwnerSlot = Battle.BattleParties[attackerTeamIndex][attackerSlot].abilityOwner.slot
+			local tempAbility = Battle.BattleParties[attackerTeamIndex][attackerSlot].ability
 
-			Battle.BattleAbilities[attackerTeamIndex][attackerSlot].abilityOwner.isOwn = Battle.BattleAbilities[targetTeamIndex][targetSlot].abilityOwner.isOwn
-			Battle.BattleAbilities[attackerTeamIndex][attackerSlot].abilityOwner.slot = Battle.BattleAbilities[targetTeamIndex][targetSlot].abilityOwner.slot
-			Battle.BattleAbilities[attackerTeamIndex][attackerSlot].ability = Battle.BattleAbilities[targetTeamIndex][targetSlot].ability
-			Battle.BattleAbilities[targetTeamIndex][targetSlot].abilityOwner.isOwn = tempOwnerIsOwn
-			Battle.BattleAbilities[targetTeamIndex][targetSlot].abilityOwner.slot = tempOwnerSlot
-			Battle.BattleAbilities[targetTeamIndex][targetSlot].ability = tempAbility
+			Battle.BattleParties[attackerTeamIndex][attackerSlot].abilityOwner.isOwn = Battle.BattleParties[targetTeamIndex][targetSlot].abilityOwner.isOwn
+			Battle.BattleParties[attackerTeamIndex][attackerSlot].abilityOwner.slot = Battle.BattleParties[targetTeamIndex][targetSlot].abilityOwner.slot
+			Battle.BattleParties[attackerTeamIndex][attackerSlot].ability = Battle.BattleParties[targetTeamIndex][targetSlot].ability
+			Battle.BattleParties[targetTeamIndex][targetSlot].abilityOwner.isOwn = tempOwnerIsOwn
+			Battle.BattleParties[targetTeamIndex][targetSlot].abilityOwner.slot = tempOwnerSlot
+			Battle.BattleParties[targetTeamIndex][targetSlot].ability = tempAbility
 		elseif moveUsed == 272 or moveUsed == 144 then
 			--Role Play/Transform; copy abilities and sources of target and attacker, and turn on/off transform tracking
 			local attackerTeamIndex =  Battle.attacker % 2
@@ -739,20 +781,20 @@ function Battle.trackAbilityChanges(moveUsed, ability)
 			local targetSlot = Battle.Combatants[Battle.IndexMap[Battle.battlerTarget]]
 
 			if moveUsed == 272 then
-				local abilityOwner = Tracker.getPokemon(Battle.BattleAbilities[targetTeamIndex][targetSlot].abilityOwner.slot,Battle.BattleAbilities[targetTeamIndex][targetSlot].abilityOwner.isOwn)
+				local abilityOwner = Tracker.getPokemon(Battle.BattleParties[targetTeamIndex][targetSlot].abilityOwner.slot,Battle.BattleParties[targetTeamIndex][targetSlot].abilityOwner.isOwn)
 				if abilityOwner ~= nil then
-					Tracker.TrackAbility(abilityOwner.pokemonID, Battle.BattleAbilities[targetTeamIndex][targetSlot].ability)
+					Tracker.TrackAbility(abilityOwner.pokemonID, Battle.BattleParties[targetTeamIndex][targetSlot].ability)
 				end
 			end
 
-			Battle.BattleAbilities[attackerTeamIndex][attackerSlot].abilityOwner.isOwn = Battle.BattleAbilities[targetTeamIndex][targetSlot].abilityOwner.isOwn
-			Battle.BattleAbilities[attackerTeamIndex][attackerSlot].abilityOwner.slot = Battle.BattleAbilities[targetTeamIndex][targetSlot].abilityOwner.slot
-			Battle.BattleAbilities[attackerTeamIndex][attackerSlot].ability = Battle.BattleAbilities[targetTeamIndex][targetSlot].ability
+			Battle.BattleParties[attackerTeamIndex][attackerSlot].abilityOwner.isOwn = Battle.BattleParties[targetTeamIndex][targetSlot].abilityOwner.isOwn
+			Battle.BattleParties[attackerTeamIndex][attackerSlot].abilityOwner.slot = Battle.BattleParties[targetTeamIndex][targetSlot].abilityOwner.slot
+			Battle.BattleParties[attackerTeamIndex][attackerSlot].ability = Battle.BattleParties[targetTeamIndex][targetSlot].ability
 
 			--Track Transform changes
 			if moveUsed == 144 then
-				Battle.BattleAbilities[attackerTeamIndex][attackerSlot].transformData.isOwn = Battle.BattleAbilities[targetTeamIndex][targetSlot].transformData.isOwn
-				Battle.BattleAbilities[attackerTeamIndex][attackerSlot].transformData.slot = Battle.BattleAbilities[targetTeamIndex][targetSlot].transformData.slot
+				Battle.BattleParties[attackerTeamIndex][attackerSlot].transformData.isOwn = Battle.BattleParties[targetTeamIndex][targetSlot].transformData.isOwn
+				Battle.BattleParties[attackerTeamIndex][attackerSlot].transformData.slot = Battle.BattleParties[targetTeamIndex][targetSlot].transformData.slot
 			end
 
 		end
@@ -766,26 +808,26 @@ function Battle.trackAbilityChanges(moveUsed, ability)
 			local targetTeamSlot = Battle.Combatants[Battle.IndexMap[target]]
 
 			--Track Trace here, otherwise when we try to track normally, the pokemon's battle ability and owner will have already updated to what was traced.
-			local abilityOwner = Tracker.getPokemon(Battle.BattleAbilities[tracerTeamIndex][tracerTeamSlot].abilityOwner.slot,Battle.BattleAbilities[tracerTeamIndex][tracerTeamSlot].abilityOwner.isOwn)
+			local abilityOwner = Tracker.getPokemon(Battle.BattleParties[tracerTeamIndex][tracerTeamSlot].abilityOwner.slot,Battle.BattleParties[tracerTeamIndex][tracerTeamSlot].abilityOwner.isOwn)
 			if abilityOwner ~= nil then
 				Tracker.TrackAbility(abilityOwner.pokemonID, ability)
 			end
 
-			Battle.BattleAbilities[tracerTeamIndex][tracerTeamSlot].abilityOwner.isOwn = Battle.BattleAbilities[targetTeamIndex][targetTeamSlot].abilityOwner.isOwn
-			Battle.BattleAbilities[tracerTeamIndex][tracerTeamSlot].abilityOwner.slot = Battle.BattleAbilities[targetTeamIndex][targetTeamSlot].abilityOwner.slot
-			Battle.BattleAbilities[tracerTeamIndex][tracerTeamSlot].ability = Battle.BattleAbilities[targetTeamIndex][targetTeamSlot].ability
+			Battle.BattleParties[tracerTeamIndex][tracerTeamSlot].abilityOwner.isOwn = Battle.BattleParties[targetTeamIndex][targetTeamSlot].abilityOwner.isOwn
+			Battle.BattleParties[tracerTeamIndex][tracerTeamSlot].abilityOwner.slot = Battle.BattleParties[targetTeamIndex][targetTeamSlot].abilityOwner.slot
+			Battle.BattleParties[tracerTeamIndex][tracerTeamSlot].ability = Battle.BattleParties[targetTeamIndex][targetTeamSlot].ability
 		end
 	end
 end
 
 function Battle.resetAbilityMapPokemon(slot, isOwn)
 	local teamIndex = Utils.inlineIf(isOwn,0,1)
-	Battle.BattleAbilities[teamIndex][slot].abilityOwner.isOwn = isOwn
-	Battle.BattleAbilities[teamIndex][slot].abilityOwner.slot = slot
-	Battle.BattleAbilities[teamIndex][slot].ability = Battle.BattleAbilities[teamIndex][slot].originalAbility
+	Battle.BattleParties[teamIndex][slot].abilityOwner.isOwn = isOwn
+	Battle.BattleParties[teamIndex][slot].abilityOwner.slot = slot
+	Battle.BattleParties[teamIndex][slot].ability = Battle.BattleParties[teamIndex][slot].originalAbility
 
-	Battle.BattleAbilities[teamIndex][slot].transformData.isOwn = isOwn
-	Battle.BattleAbilities[teamIndex][slot].transformData.slot = slot
+	Battle.BattleParties[teamIndex][slot].transformData.isOwn = isOwn
+	Battle.BattleParties[teamIndex][slot].transformData.slot = slot
 end
 
 function Battle.trackTransformedMoves()
@@ -810,7 +852,7 @@ function Battle.trackTransformedMoves()
 	if currentSelectingMon % 2 ~= 0 then return end
 
 	-- Track all moves, if we are copying an enemy mon
-	local transformData = Battle.BattleAbilities[0][Battle.Combatants[Battle.IndexMap[currentSelectingMon]]].transformData
+	local transformData = Battle.BattleParties[0][Battle.Combatants[Battle.IndexMap[currentSelectingMon]]].transformData
 	if not transformData.isOwn or transformData.slot > Battle.partySize then
 		local copiedMon = Tracker.getPokemon(transformData.slot, false)
 		if copiedMon ~= nil then

--- a/ironmon_tracker/FileManager.lua
+++ b/ironmon_tracker/FileManager.lua
@@ -161,9 +161,11 @@ end
 
 -- Attempts to execute the command, returning two results: success, outputTable
 function FileManager.tryOsExecute(command, errorFile)
-	errorFile = errorFile or "&1"
 	local tempOutputFile = FileManager.prependDir(FileManager.Files.OSEXECUTE_OUTPUT)
-	local commandWithOutput = string.format('%s >"%s" 2>"%s"', command, tempOutputFile, errorFile)
+	local commandWithOutput = string.format('%s >"%s"', command, tempOutputFile)
+	if errorFile ~= nil then
+		commandWithOutput = string.format('%s 2>"%s"', commandWithOutput, errorFile)
+	end
 	local result = os.execute(commandWithOutput)
 	local success = (result == true or result == 0) -- 0 = success in some cases
 	if not success then

--- a/ironmon_tracker/MGBA.lua
+++ b/ironmon_tracker/MGBA.lua
@@ -27,6 +27,11 @@ function MGBA.clearConsole()
 end
 
 function MGBA.printStartupInstructions()
+	-- Lazy solution to spot it from doubling instructions if you load script before game ROM
+	if MGBA.hasPrintedInstructions then
+		return
+	end
+
 	print("")
 	print("- Click on the menus on the left sidebar to see different information screens.")
 	print("- To use commands, type the command into the box below.")
@@ -35,6 +40,7 @@ function MGBA.printStartupInstructions()
 	print("")
 	print('- If you\'re unsure of what a command does, you can use: HELP "command"')
 	print("- More information can be found on the Tracker's wiki by typing: HELPWIKI()")
+	MGBA.hasPrintedInstructions = true
 end
 
 function MGBA.setupActiveRunCallbacks()

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -538,7 +538,7 @@ function Main.GenerateNextRom()
 	)
 
 	local success, file
-	if Main.emulator == Main.EMU.MGBA or (Main.IsOnBizhawk() and Main.OS == "Linux") then
+	if Main.emulator == Main.EMU.MGBA or (Main.emulator == Main.EMU.BIZHAWK28 and Main.OS == "Linux") then
 		local result = os.execute(javacommand)
 		success = (result == true or result == 0)
 	else

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -61,6 +61,8 @@ function Main.Initialize()
 		return false
 	end
 
+	Main.LoadSettings()
+
 	print(string.format("Ironmon Tracker v%s successfully loaded", Main.TrackerVersion))
 
 	-- Get the quickload files just once to be used in several places during start-up, removed later
@@ -280,6 +282,9 @@ function Main.CheckForVersionUpdate(forcedCheck)
 
 	-- Only notify about updates once per day
 	if forcedCheck or todaysDate ~= Main.Version.dateChecked then
+		-- Track that an update was checked today, so no additional api calls are performed today
+		Main.Version.dateChecked = todaysDate
+
 		local wasSoundOn
 		if Main.IsOnBizhawk() then
 			-- Disable Bizhawk sound while the update check is in process
@@ -311,8 +316,6 @@ function Main.CheckForVersionUpdate(forcedCheck)
 				Main.Version.showUpdate = true
 			end
 
-			-- Track that an update was checked today, so no additional api calls are performed today
-			Main.Version.dateChecked = todaysDate
 			-- Track the latest available version
 			Main.Version.latestAvailable = latestReleasedVersion
 		end

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "7", minor = "1", patch = "5" }
+Main.Version = { major = "7", minor = "1", patch = "6" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -538,7 +538,7 @@ function Main.GenerateNextRom()
 	)
 
 	local success, file
-	if Main.emulator == Main.EMU.MGBA or (Main.emulator == Main.EMU.BIZHAWK28 and Main.OS == "Linux") then
+	if Main.OS ~= "Windows" and (Main.emulator == Main.EMU.MGBA or Main.emulator == Main.EMU.BIZHAWK28) then
 		local result = os.execute(javacommand)
 		success = (result == true or result == 0)
 	else

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "7", minor = "1", patch = "4" }
+Main.Version = { major = "7", minor = "1", patch = "5" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/screens/StartupScreen.lua
+++ b/ironmon_tracker/screens/StartupScreen.lua
@@ -31,6 +31,26 @@ StartupScreen.Buttons = {
 		end,
 		onClick = function(self) StartupScreen.openChoosePokemonWindow() end
 	},
+	UpdateAvailable = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		text = "",
+		textColor = "Positive text",
+		clickableArea = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 54, Constants.SCREEN.MARGIN + 12, 30, 10 },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 74, Constants.SCREEN.MARGIN + 12, 10, 10 },
+		boxColors = { "Upper box border", "Upper box background" },
+		isVisible = function(self) return self.text == "*" end, -- check on text instead of Main.isOnLatestVersion() again
+		updateSelf = function(self)
+			if not Main.isOnLatestVersion() then
+				self.text = "*"
+				if string.len(Main.TrackerVersion or "") > 5 then
+					self.box[1] = self.box[1] + 4
+				end
+			else
+				self.text = ""
+			end
+		end,
+		onClick = function(self) Program.changeScreenView(Program.Screens.UPDATE) end
+	},
 	AttemptsCount = {
 		type = Constants.ButtonTypes.NO_BORDER,
 		text = Constants.BLANKLINE,
@@ -88,7 +108,7 @@ StartupScreen.Buttons = {
 function StartupScreen.initialize()
 	StartupScreen.setPokemonIcon(Options["Startup Pokemon displayed"])
 
-	-- Update the attempts count to the current seed number
+	StartupScreen.Buttons.UpdateAvailable:updateSelf()
 	StartupScreen.Buttons.AttemptsCount:updateSelf()
 	StartupScreen.Buttons.AttemptsEdit:updateSelf()
 
@@ -248,6 +268,7 @@ function StartupScreen.drawScreen()
 
 	Drawing.drawText(topBox.x + 2, textLineY, StartupScreen.Labels.version, topBox.text, topBox.shadow)
 	Drawing.drawText(topcolX, textLineY, Main.TrackerVersion, topBox.text, topBox.shadow)
+	Drawing.drawButton(StartupScreen.Buttons.UpdateAvailable, topBox.shadow)
 	textLineY = textLineY + linespacing
 
 	Drawing.drawText(topBox.x + 2, textLineY, StartupScreen.Labels.game, topBox.text, topBox.shadow)


### PR DESCRIPTION
This fixes a **CRITICAL bug** that prevents users on **7.1.0** - **7.1.5** from being able to update while the tracker is active; they instead have to close it down and load just the `UpdateOrInstall.lua` file.

This also actually fixes `io.popen` to instead use an alternative method involving `os.execute`. Tested and it works on Windows and MacOS at least. After this, users should be able to use the simple, alternative Quickload method I worked on.

Also snuck in a nice little update-asterisk to show on the tracker startup screen if an update is available.
![image](https://user-images.githubusercontent.com/4258818/209286109-6e7cdf9d-24a9-46fb-82f4-530c5f8cd2f3.png)

Note: After this this fix goes live, we can delete the 7.1.5 release as that one is short-lived and buggy, and im using it as a placeholder for this 7.1.6 release.

https://github.com/besteon/Ironmon-Tracker/releases/tag/v7.1.5