### PR TITLE
Hotfix 7.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,15 @@ Emu-specific Lua documentation:
 
 The primary branches of the Ironmon-Tracker repository are as follows:
 
-- **Main**: This is kept in a state of the latest release. We merge into this branch from staging when we are ready to do the final checks and make a new release.
-- **Staging**: This is essentially the "beta" build of the next release, where the majority of contributions merge into.
-- **Bugfixes**: This branch is for any quick/minor bugfixes. It regularly gets updated to match and pull fixes into the staging branch.
+- **Main**: This is kept in a state of the latest release. We merge into this branch from dev when we are ready to do the final checks and make a new release.
+- **Dev**: This is essentially the "staging" build of the next release, where the majority of contributions merge into.
+- **Beta-Test**: This branch is for test builds that Tracker users can opt-in to trying out. It regularly gets updated with new features from the dev branch.
 
-**Make your PRs to either Staging or Bugfixes, whichever is more fitting for the contribution.**
+**Make your PRs to the Dev branch.**
 
 The workflow we'd recommend for contributing:
 
 1. Create a fork of the repository.
 2. Create a branch on your local fork for your new feature/contribution. Make your commits to this branch.
-3. When you are ready to send it to us for review, open a Pull Request back to this repository. Request to merge into either **Staging** or **Bugfixes** depending on what the contribution is (see above).
+3. When you are ready to send it to us for review, open a Pull Request back to this repository. Request to merge into the **Dev** branch.
 4. We'll review the Pull Request and decide whether it needs some changes / more work or if we're happy to merge it in.

--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -592,7 +592,6 @@ function Battle.beginNewBattle()
 
 	Tracker.Data.isViewingOwn = not Options["Auto swap to enemy"]
 	-- If the player hasn't fought the Rival yet, use this to determine their pokemon team based on starter ball selection
-	-- TODO: Is this FRLG only?
 	if Tracker.Data.whichRival == nil then
 		local opposingTrainerId = Memory.readword(GameSettings.gTrainerBattleOpponent_A)
 		Tracker.tryTrackWhichRival(opposingTrainerId)

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -263,8 +263,8 @@ function Drawing.drawButton(button, shadowcolor)
 			for _, pixelColor in ipairs(button.iconColors or {}) do
 				table.insert(iconColors, Theme.COLORS[pixelColor])
 			end
-			if #iconColors == 0 then -- default to using the border color
-				table.insert(iconColors, bordercolor)
+			if #iconColors == 0 then -- default to using the same text color
+				table.insert(iconColors, Theme.COLORS[button.textColor])
 			end
 			Drawing.drawImageAsPixels(button.image, x + offsetX, y + offsetY, iconColors, shadowcolor)
 		end

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "7", minor = "2", patch = "0" }
+Main.Version = { major = "7", minor = "2", patch = "1" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -98,12 +98,6 @@ Options.StartupIcon = {
 Options["Startup Pokemon displayed"] = Options.StartupIcon.attempts
 
 function Options.initialize()
-	-- Check if the Toggle View controller button is not default, and update the tip message if so.
-	local toggleViewValue = Options.CONTROLS["Toggle view"]
-	if toggleViewValue ~= "Start" then
-		Constants.OrderedLists.TIPS[3] = Constants.OrderedLists.TIPS[3]:gsub("Start", toggleViewValue)
-	end
-
 	Drawing.AnimatedPokemon:create()
 end
 

--- a/ironmon_tracker/data/RandomizerLog.lua
+++ b/ironmon_tracker/data/RandomizerLog.lua
@@ -2,7 +2,7 @@
 RandomizerLog = {}
 
 RandomizerLog.Patterns = {
-	RandomizerVersion = "Randomizer Version:%s*([%d%.]+)%s*$", -- Note, log file line 1 does NOT start with this
+	RandomizerVersion = "Randomizer Version:%s*([%d%.]+)%s*$", -- Note: log file line 1 does NOT start with "Rando..."
 	RandomizerSeed = "^Random Seed:%s*(%d+)%s*$",
 	RandomizerSettings = "^Settings String:%s*(.+)%s*$",
 	RandomizerGame = "^Randomization of%s*(.+)%s+completed",
@@ -14,40 +14,42 @@ RandomizerLog.Patterns = {
 	end,
 }
 
+-- Each Sector has Pattern(s) to match on, and the Sector Start Header LineNumber
 RandomizerLog.Sectors = {
 	-- First three lines: Randomizer Version, Random Seed, Settings String
+
 	Evolutions = {
-		Header = "Randomized Evolutions",
+		HeaderPattern = RandomizerLog.Patterns.getSectorHeaderPattern("Randomized Evolutions"),
 		-- Matches: pokemon, evos
 		PokemonEvosPattern = "^" .. RandomizerLog.Patterns.PokemonName .. "%s*%->%s*(.*)",
 	},
-	BaseStatsItems = { -- Currently unused, Get Base Stats from Movesets instead
-		Header = "Pokemon Base Stats & Types",
+	BaseStatsItems = {
+		HeaderPattern = RandomizerLog.Patterns.getSectorHeaderPattern("Pokemon Base Stats & Types"),
 		-- Matches: pokemon, hp, atk, def, spatk, spdef, spd, helditems
 		PokemonBSTPattern = "^.*|" .. RandomizerLog.Patterns.PokemonName .. "%s*|.*|%s*(%d*)|%s*(%d*)|%s*(%d*)|%s*(%d*)|%s*(%d*)|%s*(%d*)|.*|.*|(.*)",
 	},
 	MoveSets = {
-		Header = "Pokemon Movesets",
+		HeaderPattern = RandomizerLog.Patterns.getSectorHeaderPattern("Pokemon Movesets"),
 		-- Matches: pokemon
 		NextMonPattern = "^%d+%s" .. RandomizerLog.Patterns.PokemonName .. "%s*%->",
 		-- Matches: level, movename
 		MovePattern = "^Level%s(%d+)%s?%s?:%s(.*)",
 	},
 	TMMoves = {
-		Header = "TM Moves",
+		HeaderPattern = RandomizerLog.Patterns.getSectorHeaderPattern("TM Moves"),
 		-- Matches: tmNumber, movename
 		TMPattern = "^TM(%d+)%s(.*)",
 	},
+	-- TODO: If TMs aren't randomized, then we don't store the original TM data, we probably need to do that
 	TMCompatibility = {
-		-- TODO: If TMs aren't randomized, then we don't store the original TM data, we probably need to do that
-		Header = "TM Compatibility",
+		HeaderPattern = RandomizerLog.Patterns.getSectorHeaderPattern("TM Compatibility"),
 		-- Matches: pokemon
 		NextMonPattern = "^[%s%d]+%s" .. RandomizerLog.Patterns.PokemonName .. "%s*|(.*)",
 		-- Matches: tmNumber
 		TMPattern = "TM(%d+)",
 	},
 	Trainers = {
-		Header = "Trainers Pokemon",
+		HeaderPattern = RandomizerLog.Patterns.getSectorHeaderPattern("Trainers Pokemon"),
 		-- Matches: trainer_num, trainername, party
 		NextTrainerPattern = "^#(%d+)%s%((.+)%s*=>.*%s%-%s(.*)",
 		-- Matches: partypokemon (pokemon name with held item and level info)
@@ -57,13 +59,14 @@ RandomizerLog.Sectors = {
 	},
 	-- Currently unused
 	PickupItems = {
-		Header = "Pickup Items",
+		HeaderPattern = RandomizerLog.Patterns.getSectorHeaderPattern("Pickup Items"),
 		LevelPattern = "",
 		PercentPattern = "",
 		ItemsPattern = "",
 	},
 	GameInfo = {
-		Header = "%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-", -- :(
+		-- :(
+		HeaderPattern = RandomizerLog.Patterns.getSectorHeaderPattern("%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-%-"),
 	},
 }
 
@@ -111,8 +114,8 @@ function RandomizerLog.parseLog(filepath)
 	end
 
 	RandomizerLog.resetData()
+	RandomizerLog.locateSectorLineStarts(logLines)
 
-	-- Trying with an inefficient approach first, parsing the lines in order
 	RandomizerLog.setupMappings()
 	RandomizerLog.parseRandomizerSettings(logLines)
 	RandomizerLog.parseEvolutions(logLines)
@@ -157,27 +160,28 @@ function RandomizerLog.resetData()
 	end
 end
 
--- Locates the start of the sector, returning the index
-function RandomizerLog.seekSectorStart(logLines, sectorHead)
+-- Locates the starting line number of each sector
+function RandomizerLog.locateSectorLineStarts(logLines)
 	if logLines == nil or #logLines == 0 then
-		return false
+		return
 	end
 
-	local line = table.remove(logLines, 1)
-	while line ~= nil do
-		if string.find(line, sectorHead) ~= nil then
-			return true
+	for i, line in ipairs(logLines) do
+		-- If the sector hasn't been found yet, and its this line
+		for _, sector in pairs(RandomizerLog.Sectors) do
+			if sector.LineNumber == nil and string.find(line, sector.HeaderPattern) ~= nil then
+				sector.LineNumber = i + 1 -- +1 to skip the header itself
+				break -- and continue looking for other sectors
+			end
 		end
-		line = table.remove(logLines, 1)
 	end
-	return false
 end
 
 function RandomizerLog.parseRandomizerSettings(logLines)
 	if #logLines < 3 then return end
-	local version = string.match(table.remove(logLines, 1), RandomizerLog.Patterns.RandomizerVersion)
-	local randomSeed = string.match(table.remove(logLines, 1), RandomizerLog.Patterns.RandomizerSeed)
-	local settingsString = string.match(table.remove(logLines, 1), RandomizerLog.Patterns.RandomizerSettings)
+	local version = string.match(logLines[1], RandomizerLog.Patterns.RandomizerVersion)
+	local randomSeed = string.match(logLines[2], RandomizerLog.Patterns.RandomizerSeed)
+	local settingsString = string.match(logLines[3], RandomizerLog.Patterns.RandomizerSettings)
 	RandomizerLog.Data.Settings.Version = version
 	RandomizerLog.Data.Settings.RandomSeed = randomSeed
 	RandomizerLog.Data.Settings.SettingsString = settingsString
@@ -185,30 +189,27 @@ end
 
 -- This sector is near the end of the file
 function RandomizerLog.parseRandomizerGame(logLines)
-	local sectorHeader = RandomizerLog.Patterns.getSectorHeaderPattern(RandomizerLog.Sectors.GameInfo.Header)
-	if not RandomizerLog.seekSectorStart(logLines, sectorHeader) then
+	if RandomizerLog.Sectors.GameInfo.LineNumber == nil then
 		return
 	end
 
-	local game = string.match(table.remove(logLines, 1), RandomizerLog.Patterns.RandomizerGame)
+	local game = string.match(logLines[RandomizerLog.Sectors.GameInfo.LineNumber] or "", RandomizerLog.Patterns.RandomizerGame)
 	RandomizerLog.Data.Settings.Game = game
 end
 
 function RandomizerLog.parseEvolutions(logLines)
-	local sectorHeader = RandomizerLog.Patterns.getSectorHeaderPattern(RandomizerLog.Sectors.Evolutions.Header)
-	if not RandomizerLog.seekSectorStart(logLines, sectorHeader) then
+	if RandomizerLog.Sectors.Evolutions.LineNumber == nil then
 		return
 	end
 
 	-- Parse the sector
-	local line = table.remove(logLines, 1)
-	while line ~= nil do
-		local pokemon, evos = string.match(line, RandomizerLog.Sectors.Evolutions.PokemonEvosPattern)
+	local index = RandomizerLog.Sectors.Evolutions.LineNumber
+	while index <= #logLines do
+		local pokemon, evos = string.match(logLines[index] or "", RandomizerLog.Sectors.Evolutions.PokemonEvosPattern)
 		pokemon = RandomizerLog.formatInput(pokemon)
 
 		-- If nothing matches, end of sector
 		if pokemon == nil or evos == nil or RandomizerLog.PokemonNameToIdMap[pokemon] == nil then
-			table.insert(logLines, 1, line)
 			return
 		end
 
@@ -221,71 +222,65 @@ function RandomizerLog.parseEvolutions(logLines)
 				table.insert(RandomizerLog.Data.Pokemon[pokemonId].Evolutions, RandomizerLog.PokemonNameToIdMap[evo])
 			end
 		end
-		line = table.remove(logLines, 1)
+
+		index = index + 1
 	end
 end
 
 function RandomizerLog.parseBaseStatsItems(logLines)
-	local sectorHeader = RandomizerLog.Patterns.getSectorHeaderPattern(RandomizerLog.Sectors.BaseStatsItems.Header)
-	if not RandomizerLog.seekSectorStart(logLines, sectorHeader) then
+	if RandomizerLog.Sectors.BaseStatsItems.LineNumber == nil then
 		return
 	end
 
-	table.remove(logLines, 1) -- remove the first line to skip the table header
-
 	-- Parse the sector
-	local line = table.remove(logLines, 1)
-	while line ~= nil do
-		local pokemon, hp, atk, def, spa, spd, spe, helditems = string.match(line, RandomizerLog.Sectors.BaseStatsItems.PokemonBSTPattern)
+	local index = RandomizerLog.Sectors.BaseStatsItems.LineNumber + 1 -- remove the first line to skip the table header
+	while index <= #logLines do
+		local pokemon, hp, atk, def, spa, spd, spe, helditems = string.match(logLines[index] or "", RandomizerLog.Sectors.BaseStatsItems.PokemonBSTPattern)
 		pokemon = RandomizerLog.formatInput(pokemon)
 
 		-- If nothing matches, end of sector
 		if pokemon == nil or spe == nil or RandomizerLog.PokemonNameToIdMap[pokemon] == nil then
-			table.insert(logLines, 1, line)
 			return
 		end
 
 		local pokemonId = RandomizerLog.PokemonNameToIdMap[pokemon]
 		local pokemonData = RandomizerLog.Data.Pokemon[pokemonId]
 		if pokemonData ~= nil then
-			pokemonData.BaseStats = {}
-			pokemonData.BaseStats.hp = tonumber(hp) or 0
-			pokemonData.BaseStats.atk = tonumber(atk) or 0
-			pokemonData.BaseStats.def = tonumber(def) or 0
-			pokemonData.BaseStats.spa = tonumber(spa) or 0
-			pokemonData.BaseStats.spd = tonumber(spd) or 0
-			pokemonData.BaseStats.spe = tonumber(spe) or 0
+			pokemonData.BaseStats = {
+				hp = tonumber(hp) or 0,
+				atk = tonumber(atk) or 0,
+				def = tonumber(def) or 0,
+				spa = tonumber(spa) or 0,
+				spd = tonumber(spd) or 0,
+				spe = tonumber(spe) or 0,
+			}
 			if helditems ~= nil and helditems ~= "" then
 				pokemonData.BaseStats.helditems = RandomizerLog.formatInput(helditems)
 			end
 		end
-		line = table.remove(logLines, 1)
+		index = index + 1
 	end
 end
 
 function RandomizerLog.parseMoveSets(logLines)
-	local sectorHeader = RandomizerLog.Patterns.getSectorHeaderPattern(RandomizerLog.Sectors.MoveSets.Header)
-	if not RandomizerLog.seekSectorStart(logLines, sectorHeader) then
+	if RandomizerLog.Sectors.MoveSets.LineNumber == nil then
 		return
 	end
 
 	-- Parse the sector
-	local line = table.remove(logLines, 1)
-	while line ~= nil do
-		local pokemon = string.match(line, RandomizerLog.Sectors.MoveSets.NextMonPattern)
+	local index = RandomizerLog.Sectors.MoveSets.LineNumber
+	while index <= #logLines do
+		local pokemon = string.match(logLines[index] or "", RandomizerLog.Sectors.MoveSets.NextMonPattern)
 		pokemon = RandomizerLog.formatInput(pokemon)
 
 		-- Search for the next Pokémon's name, or the end of sector
+		-- I might fix this whole mess later when I'm awake
 		while pokemon == nil or RandomizerLog.PokemonNameToIdMap[pokemon] == nil do
-			if string.find(line, "TM Moves", 1, true) ~= nil then
-				table.insert(logLines, 1, line or "")
+			if string.find(logLines[index] or "", "^%-%-") ~= nil or index + 1 > #logLines then
 				return
 			end
-			line = table.remove(logLines, 1)
-			if line == nil then
-				return
-			end
-			pokemon = string.match(line, RandomizerLog.Sectors.MoveSets.NextMonPattern)
+			index = index + 1
+			pokemon = string.match(logLines[index] or "", RandomizerLog.Sectors.MoveSets.NextMonPattern)
 			pokemon = RandomizerLog.formatInput(pokemon)
 		end
 
@@ -293,17 +288,11 @@ function RandomizerLog.parseMoveSets(logLines)
 		local pokemonData = RandomizerLog.Data.Pokemon[pokemonId]
 		if pokemonData ~= nil then
 			pokemonData.MoveSet = {}
-			 -- First six lines are redundant Base Sets (also don't trust these will exist)
-			 table.remove(logLines, 1)
-			 table.remove(logLines, 1)
-			 table.remove(logLines, 1)
-			 table.remove(logLines, 1)
-			 table.remove(logLines, 1)
-			 table.remove(logLines, 1)
+			 -- First six lines are redundant Base Sets (also don't trust these will exist), and skip current line
+			 index = index + 7
 
 			-- Search for each listed level-up move
-			line = table.remove(logLines, 1)
-			local level, movename = string.match(line, RandomizerLog.Sectors.MoveSets.MovePattern)
+			local level, movename = string.match(logLines[index] or "", RandomizerLog.Sectors.MoveSets.MovePattern)
 			while level ~= nil and movename ~= nil do
 				local nextMove = {
 					level = tonumber(RandomizerLog.formatInput(level)) or 0,
@@ -311,59 +300,55 @@ function RandomizerLog.parseMoveSets(logLines)
 				}
 				table.insert(RandomizerLog.Data.Pokemon[pokemonId].MoveSet, nextMove)
 
-				line = table.remove(logLines, 1)
-				if line == nil then
+				index = index + 1
+				if index > #logLines then
 					return
 				end
-				level, movename = string.match(line, RandomizerLog.Sectors.MoveSets.MovePattern)
+				level, movename = string.match(logLines[index] or "", RandomizerLog.Sectors.MoveSets.MovePattern)
 			end
 		else
-			line = table.remove(logLines, 1)
+			index = index + 1
 		end
 	end
 end
 
 function RandomizerLog.parseTMMoves(logLines)
-	local sectorHeader = RandomizerLog.Patterns.getSectorHeaderPattern(RandomizerLog.Sectors.TMMoves.Header)
-	if not RandomizerLog.seekSectorStart(logLines, sectorHeader) then
+	if RandomizerLog.Sectors.TMMoves.LineNumber == nil then
 		return
 	end
 
 	-- Parse the sector
-	local line = table.remove(logLines, 1)
-	while line ~= nil do
-		local tmNumber, movename = string.match(line, RandomizerLog.Sectors.TMMoves.TMPattern)
+	local index = RandomizerLog.Sectors.TMMoves.LineNumber
+	while index <= #logLines do
+		local tmNumber, movename = string.match(logLines[index] or "", RandomizerLog.Sectors.TMMoves.TMPattern)
 		tmNumber = tonumber(RandomizerLog.formatInput(tmNumber) or "") -- nil if not a number
 		movename = RandomizerLog.formatInput(movename)
 
 		-- If nothing matches, end of sector
 		if tmNumber == nil or movename == nil or RandomizerLog.MoveNameToIdMap[movename] == nil then
-			table.insert(logLines, 1, line)
 			return
 		end
 
 		local moveId = RandomizerLog.MoveNameToIdMap[movename]
 		RandomizerLog.Data.TMs[tmNumber] = moveId
 
-		line = table.remove(logLines, 1)
+		index = index + 1
 	end
 end
 
 function RandomizerLog.parseTMCompatibility(logLines)
-	local sectorHeader = RandomizerLog.Patterns.getSectorHeaderPattern(RandomizerLog.Sectors.TMCompatibility.Header)
-	if not RandomizerLog.seekSectorStart(logLines, sectorHeader) then
+	if RandomizerLog.Sectors.TMCompatibility.LineNumber == nil then
 		return
 	end
 
 	-- Parse the sector
-	local line = table.remove(logLines, 1)
-	while line ~= nil do
-		local pokemon, tms = string.match(line, RandomizerLog.Sectors.TMCompatibility.NextMonPattern)
+	local index = RandomizerLog.Sectors.TMCompatibility.LineNumber
+	while index <= #logLines do
+		local pokemon, tms = string.match(logLines[index] or "", RandomizerLog.Sectors.TMCompatibility.NextMonPattern)
 		pokemon = RandomizerLog.formatInput(pokemon)
 
 		-- If nothing matches, end of sector
 		if pokemon == nil or tms == nil or RandomizerLog.PokemonNameToIdMap[pokemon] == nil then
-			table.insert(logLines, 1, line)
 			return
 		end
 
@@ -376,26 +361,24 @@ function RandomizerLog.parseTMCompatibility(logLines)
 				table.insert(RandomizerLog.Data.Pokemon[pokemonId].TMMoves, tmNumber)
 			end
 		end
-		line = table.remove(logLines, 1)
+		index = index + 1
 	end
 end
 
 function RandomizerLog.parseTrainers(logLines)
-	local sectorHeader = RandomizerLog.Patterns.getSectorHeaderPattern(RandomizerLog.Sectors.Trainers.Header)
-	if not RandomizerLog.seekSectorStart(logLines, sectorHeader) then
+	if RandomizerLog.Sectors.Trainers.LineNumber == nil then
 		return
 	end
 
 	-- Parse the sector
-	local line = table.remove(logLines, 1)
-	while line ~= nil do
-		local trainer_num, trainername, party = string.match(line, RandomizerLog.Sectors.Trainers.NextTrainerPattern)
+	local index = RandomizerLog.Sectors.Trainers.LineNumber
+	while index <= #logLines do
+		local trainer_num, trainername, party = string.match(logLines[index] or "", RandomizerLog.Sectors.Trainers.NextTrainerPattern)
 		trainer_num = tonumber(RandomizerLog.formatInput(trainer_num) or "") -- nil if not a number
 		trainername = RandomizerLog.formatInput(trainername)
 
 		-- If nothing matches, end of sector
 		if trainer_num == nil or trainername == nil or party == nil then
-			table.insert(logLines, 1, line)
 			return
 		end
 
@@ -422,17 +405,16 @@ function RandomizerLog.parseTrainers(logLines)
 				table.insert(RandomizerLog.Data.Trainers[trainer_num].party, partyPokemon)
 			end
 		end
-		line = table.remove(logLines, 1)
+		index = index + 1
 	end
 end
--- Utils.printDebug("#%s: %s >%s< %s", trainer_num, pokemon or "N/A", helditem or "N/A", level or 0)
 
 -- Currently unused
 function RandomizerLog.parsePickupItems(logLines)
-
+	-- Utils.printDebug("#%s: %s >%s< %s", trainer_num, pokemon or "N/A", helditem or "N/A", level or 0)
 end
 
--- DEBUG HELPER
+-- DEBUG HELPER, will use later for foreign games
 function RandomizerLog.printPokemonIds()
 	local count = 0
 	local mons = {}
@@ -454,7 +436,7 @@ function RandomizerLog.printPokemonIds()
 	end
 end
 
--- DEBUG HELPER
+-- DEBUG HELPER, will use later for foreign games
 function RandomizerLog.printMoveIds()
 	local count = 0
 	local moves = {}

--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -3839,6 +3839,15 @@ function RouteData.setupRouteInfoAsRSE()
 		},
 	}
 
+	RouteData.Info[243 + offset] = { name = "Seashore House", }
+	RouteData.Info[247 + offset] = { name = "Trick House 1", }
+	RouteData.Info[248 + offset] = { name = "Trick House 2", }
+	RouteData.Info[249 + offset] = { name = "Trick House 3", }
+	RouteData.Info[250 + offset] = { name = "Trick House 4", }
+	RouteData.Info[251 + offset] = { name = "Trick House 5", }
+	RouteData.Info[252 + offset] = { name = "Trick House 6", }
+	RouteData.Info[253 + offset] = { name = "Trick House 7", }
+	RouteData.Info[254 + offset] = { name = "Trick House 8", }
 	RouteData.Info[270 + offset] = { name = Constants.Words.POKEMON .. " League PC", }
 	RouteData.Info[271 + offset] = { name = "Weather Institute 1F", }
 	RouteData.Info[272 + offset] = { name = "Weather Institute 2F", }

--- a/ironmon_tracker/screens/NavigationMenu.lua
+++ b/ironmon_tracker/screens/NavigationMenu.lua
@@ -23,7 +23,7 @@ NavigationMenu.Buttons = {
 	Extras = {
 		text = "Extras",
 		image = Constants.PixelImages.POKEBALL,
-		iconColors = { NavigationMenu.borderColor, NavigationMenu.boxFillColor, NavigationMenu.boxFillColor, },
+		iconColors = { NavigationMenu.textColor, NavigationMenu.boxFillColor, NavigationMenu.boxFillColor, },
 		isVisible = function() return not NavigationMenu.showCredits end,
 		onClick = function() Program.changeScreenView(Program.Screens.EXTRAS) end
 	},

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -399,11 +399,6 @@ function TrackerScreen.buildCarousel()
 		isVisible = function() return not Tracker.Data.isViewingOwn end,
 		framesToShow = 180,
 		getContentList = function(pokemonID)
-			-- If the player doesn't have a Pokemon, display something else useful instead
-			-- if pokemonID == 0 then
-			-- 	return { Constants.OrderedLists.TIPS[TrackerScreen.tipMessageIndex] }
-			-- end
-
 			local noteText = Tracker.getNote(pokemonID)
 			if Main.IsOnBizhawk() then
 				if noteText ~= nil and noteText ~= "" then
@@ -513,16 +508,6 @@ function TrackerScreen.getCurrentCarouselItem()
 		local nextCarousel = TrackerScreen.getNextVisibleCarouselItem(TrackerScreen.carouselIndex)
 		TrackerScreen.carouselIndex = nextCarousel.type
 		Program.Frames.carouselActive = 0
-
-		-- When carousel switches to the Notes display, prepare the next tip message to display
-		if false and nextCarousel ~= carousel and TrackerScreen.carouselIndex == TrackerScreen.CarouselTypes.NOTES then -- currently disabled, will use later
-			local numTips = #Constants.OrderedLists.TIPS
-			if TrackerScreen.tipMessageIndex == numTips then
-				TrackerScreen.tipMessageIndex = 2 -- Skip "helpful tip" message if that's next up
-			else
-				TrackerScreen.tipMessageIndex = (TrackerScreen.tipMessageIndex % numTips) + 1
-			end
-		end
 
 		return nextCarousel
 	end


### PR DESCRIPTION
This adds some protective checks (not actual fixes) during the automatic update that is executed while the Tracker is open and running. As of 7.2.0 release, I have seen at least two people attempt to update shortly after starting up Bizhawk, only for it to fail. Not only does the update not complete, it also breaks halfway through the process of overwriting and removing files.

### Goal of this PR
To be extra cautious during the parallel update process (while Tracker is running already). I don't want people corrupting their Tracker and stumbling to have to manually redownload the Tracker and lose files or settings.

So far I've witnessed **two potential causes** for this, both of which are included in this hotfix patch. As a note, this hotfix will be applied immediately to anyone attempting to use the Updater (v7.1.6+), as new code gets loaded after it's downloaded but before the update scripts run.

1. The Tracker files are kept inside a folder structure that includse `OneDrive`
   - This check identifies the folder path contains "OneDrive" and aborts the update process before any files are removed or replaced.
2. The Tracker files are kept on a separate harddrive that isn't the primary harddrive `C:\`
   - This is a simple check on the folder path.

To add to this, I was **not** able to reproduce either of this issues on my local machine.

While it's definitely possible that some users with Tracker files on OneDrive or a non-primary harddrive could still update without issue, there doesn't seem to be a good rhyme or reason for when it decides to break. This is really hard to pinpoint or even reproduce.

### After Review
Please feel free to merge this in as soon as you want and create a new release. You can copy the release notes exactly from the old one (v7.2.0), as I want to keep showing that the major update includes the new Log Viewer.