### PR TITLE
Custom Extension UI

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -85,9 +85,7 @@ function Battle.update()
 	end
 	if Program.Frames.lowAccuracyUpdate == 0 then
 		Battle.updateLowAccuracy()
-		if CustomCode.enabled and CustomCode.afterBattleDataUpdate ~= nil then
-			CustomCode.afterBattleDataUpdate()
-		end
+		CustomCode.afterBattleDataUpdate()
 	end
 end
 
@@ -628,9 +626,7 @@ function Battle.beginNewBattle()
 		MGBA.Screens.LookupPokemon.manuallySet = false
 	end
 
-	if CustomCode.enabled and CustomCode.afterBattleBegins ~= nil then
-		CustomCode.afterBattleBegins()
-	end
+	CustomCode.afterBattleBegins()
 end
 
 function Battle.endCurrentBattle()
@@ -708,9 +704,7 @@ function Battle.endCurrentBattle()
 	Program.Frames.waitToDraw = Utils.inlineIf(Battle.isWildEncounter, 70, 150)
 	Program.Frames.saveData = Utils.inlineIf(Battle.isWildEncounter, 70, 150) -- Save data after every battle
 
-	if CustomCode.enabled and CustomCode.afterBattleEnds ~= nil then
-		CustomCode.afterBattleEnds()
-	end
+	CustomCode.afterBattleEnds()
 end
 
 function Battle.resetBattle()

--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -130,6 +130,7 @@ Constants.OrderedLists = {
 		"Startup favorites",
 		"Show on new game screen",
 		"Enable restore points",
+		"Enable custom extensions",
 	},
 	CONTROLS = {
 		"Load next seed",

--- a/ironmon_tracker/FileManager.lua
+++ b/ironmon_tracker/FileManager.lua
@@ -25,7 +25,6 @@ FileManager.Files = {
 	RANDOMIZER_ERROR_LOG = "RandomizerErrorLog.txt",
 	UPDATE_OR_INSTALL = "UpdateOrInstall.lua",
 	OSEXECUTE_OUTPUT = FileManager.Folders.TrackerCode .. FileManager.slash .. "osexecute-output.txt",
-	CUSTOM_CODE_SETTINGS = "CustomCodeSettings.lua",
 
 	-- All of the files required by the tracker
 	LuaCode = {
@@ -61,6 +60,7 @@ FileManager.Files = {
 		FileManager.Folders.ScreensCode .. FileManager.slash .. "GameOverScreen.lua",
 		FileManager.Folders.ScreensCode .. FileManager.slash .. "StreamerScreen.lua",
 		FileManager.Folders.ScreensCode .. FileManager.slash .. "TimeMachineScreen.lua",
+		FileManager.Folders.ScreensCode .. FileManager.slash .. "CustomExtensionsScreen.lua",
 		FileManager.Folders.ScreensCode .. FileManager.slash .. "LogOverlay.lua",
 		"Input.lua",
 		"Drawing.lua",
@@ -100,6 +100,7 @@ FileManager.Extensions = {
 	TRAINER = ".png",
 	BADGE = ".png",
 	SAVESTATE = ".State", -- Bizhawk save-state
+	LUA_CODE = ".lua",
 }
 
 FileManager.Urls = {

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -253,7 +253,7 @@ function Input.checkButtonsClicked(xmouse, ymouse, buttons)
 			end
 
 			if isAreaClicked and button.onClick ~= nil then
-				CustomCode.beforeButtonClicked(button)
+				CustomCode.onButtonClicked(button)
 				button:onClick()
 			end
 		end

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -76,9 +76,7 @@ function Input.checkForInput()
 
 		Input.checkJoypadInput()
 
-		if CustomCode.enabled and CustomCode.inputCheckBizhawk ~= nil then
-			CustomCode.inputCheckBizhawk()
-		end
+		CustomCode.inputCheckBizhawk()
 	end
 end
 
@@ -108,9 +106,7 @@ end
 function Input.checkJoypadInput()
 	local joypadButtons = Input.getJoypadInputFormatted()
 
-	if CustomCode.enabled and CustomCode.inputCheckMGBA ~= nil and not Main.IsOnBizhawk() then
-		CustomCode.inputCheckMGBA()
-	end
+	CustomCode.inputCheckMGBA()
 
 	-- "Options.CONTROLS["Toggle view"]" pressed
 	if joypadButtons[Options.CONTROLS["Toggle view"]] and Input.prevJoypadInput[Options.CONTROLS["Toggle view"]] ~= joypadButtons[Options.CONTROLS["Toggle view"]] then
@@ -209,6 +205,9 @@ function Input.checkMouseInput(xmouse, ymouse)
 	elseif Program.currentScreen == Program.Screens.TIME_MACHINE then
 		Input.checkButtonsClicked(xmouse, ymouse, TimeMachineScreen.Buttons)
 		Input.checkButtonsClicked(xmouse, ymouse, TimeMachineScreen.Pager.Buttons)
+	elseif Program.currentScreen == Program.Screens.EXTENSIONS then
+		Input.checkButtonsClicked(xmouse, ymouse, CustomExtensionsScreen.Buttons)
+		Input.checkButtonsClicked(xmouse, ymouse, CustomExtensionsScreen.Pager.Buttons)
 	end
 
 	-- Check if mouse clicked on the game screen itself
@@ -254,9 +253,7 @@ function Input.checkButtonsClicked(xmouse, ymouse, buttons)
 			end
 
 			if isAreaClicked and button.onClick ~= nil then
-				if CustomCode.enabled and CustomCode.beforeButtonClicked ~= nil then
-					CustomCode.beforeButtonClicked(button)
-				end
+				CustomCode.beforeButtonClicked(button)
 				button:onClick()
 			end
 		end

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "7", minor = "2", patch = "7" }
+Main.Version = { major = "7", minor = "2", patch = "8" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -936,12 +936,18 @@ function Main.SaveSettings(forced)
 	settings.theme["DRAW_TEXT_SHADOWS"] = Theme.DRAW_TEXT_SHADOWS
 
 	-- [EXTENSIONS]
-	for extKey, extension in ipairs(CustomCode.ExtensionLibrary) do
-		-- local encodedKey = string.gsub(extKey, " ", "_")
+	for extKey, extension in pairs(CustomCode.ExtensionLibrary) do
 		settings.extensions[extKey] = extension.isEnabled or false
 	end
 
 	Inifile.save(FileManager.prependDir(FileManager.Files.SETTINGS), settings)
 	Options.settingsUpdated = false
 	Theme.settingsUpdated = false
+end
+
+function Main.RemoveMetaSetting(section, key)
+	if section == nil or key == nil or section == "" or key == "" then return end
+	if Main.MetaSettings[section] ~= nil then
+		Main.MetaSettings[section][key] = nil
+	end
 end

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -270,12 +270,11 @@ function Main.InitializeAllTrackerFiles()
 	GameOverScreen.initialize()
 	StreamerScreen.initialize()
 	TimeMachineScreen.initialize()
+	CustomExtensionsScreen.initialize()
 	LogOverlay.initialize()
 
 	CustomCode.initialize()
-	if CustomCode.enabled and CustomCode.startup ~= nil then
-		CustomCode.startup()
-	end
+	CustomCode.startup()
 end
 
 -- Determines if there is an update to the current Tracker version
@@ -870,6 +869,22 @@ function Main.LoadSettings()
 		end
 	end
 
+	-- [EXTENSIONS]
+	if settings.extensions ~= nil then
+		for extKey, extValue in pairs(settings.extensions) do
+			if extValue ~= nil then
+				if CustomCode.ExtensionLibrary[extKey] == nil then
+					CustomCode.ExtensionLibrary[extKey] = {
+						isEnabled = extValue,
+						isLoaded = false,
+					}
+				else
+					CustomCode.ExtensionLibrary[extKey].isEnabled = extValue
+				end
+			end
+		end
+	end
+
 	return true
 end
 
@@ -887,6 +902,7 @@ function Main.SaveSettings(forced)
 	if settings.tracker == nil then settings.tracker = {} end
 	if settings.controls == nil then settings.controls = {} end
 	if settings.theme == nil then settings.theme = {} end
+	if settings.extensions == nil then settings.extensions = {} end
 
 	-- [CONFIG]
 	settings.config.RemindMeLater = Main.Version.remindMe
@@ -918,6 +934,12 @@ function Main.SaveSettings(forced)
 	end
 	settings.theme["MOVE_TYPES_ENABLED"] = Theme.MOVE_TYPES_ENABLED
 	settings.theme["DRAW_TEXT_SHADOWS"] = Theme.DRAW_TEXT_SHADOWS
+
+	-- [EXTENSIONS]
+	for extKey, extension in ipairs(CustomCode.ExtensionLibrary) do
+		-- local encodedKey = string.gsub(extKey, " ", "_")
+		settings.extensions[extKey] = extension.isEnabled or false
+	end
 
 	Inifile.save(FileManager.prependDir(FileManager.Files.SETTINGS), settings)
 	Options.settingsUpdated = false

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -37,6 +37,7 @@ Options = {
 	["Startup favorites"] = "1,4,7",
 	["Show on new game screen"] = false,
 	["Enable restore points"] = true,
+	["Enable custom extensions"] = false,
 
 	CONTROLS = {
 		["Load next seed"] = "A, B, Start",

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -35,6 +35,7 @@ Program.Screens = {
 	GAMEOVER = GameOverScreen.drawScreen,
 	STREAMER = StreamerScreen.drawScreen,
 	TIME_MACHINE = TimeMachineScreen.drawScreen,
+	EXTENSIONS = CustomExtensionsScreen.drawScreen,
 }
 
 Program.GameData = {
@@ -123,9 +124,7 @@ function Program.mainLoop()
 	Input.checkForInput()
 	Program.update()
 	Battle.update()
-	if CustomCode.enabled and CustomCode.afterEachFrame ~= nil then
-		CustomCode.afterEachFrame()
-	end
+	CustomCode.afterEachFrame()
 	Program.redraw(false)
 	Program.stepFrames() -- TODO: Really want a better way to handle this
 end
@@ -144,9 +143,7 @@ function Program.redraw(forced)
 		LogOverlay.drawScreen()
 	end
 
-	if CustomCode.enabled and CustomCode.afterRedraw ~= nil then
-		CustomCode.afterRedraw()
-	end
+	CustomCode.afterRedraw()
 end
 
 function Program.changeScreenView(screen)
@@ -257,7 +254,7 @@ function Program.update()
 		end
 	end
 
-	if CustomCode.enabled and CustomCode.afterProgramDataUpdate ~= nil and Program.Frames.lowAccuracyUpdate == 0 then
+	if Program.Frames.lowAccuracyUpdate == 0 then
 		CustomCode.afterProgramDataUpdate()
 	end
 end

--- a/ironmon_tracker/screens/CustomExtensionsScreen.lua
+++ b/ironmon_tracker/screens/CustomExtensionsScreen.lua
@@ -1,0 +1,236 @@
+CustomExtensionsScreen = {
+	Labels = {
+		header = "Custom Extensions",
+		pageFormat = "Page %s/%s", -- e.g. Page 1/3
+		noExtensions = "No Extensions Found",
+	},
+	Colors = {
+		text = "Default text",
+		border = "Upper box border",
+		boxFill = "Upper box background",
+	},
+}
+
+CustomExtensionsScreen.Pager = {
+	Buttons = {},
+	currentPage = 0,
+	totalPages = 0,
+	defaultSort = function(a, b) return a.name > b.name end,
+	realignButtonsToGrid = function(self, x, y, colSpacer, rowSpacer)
+		table.sort(self.Buttons, self.defaultSort)
+		local cutoffX = Constants.SCREEN.WIDTH + Constants.SCREEN.RIGHT_GAP - Constants.SCREEN.MARGIN
+		local cutoffY = Constants.SCREEN.HEIGHT - 20
+		local totalPages = Utils.gridAlign(self.Buttons, x, y, colSpacer, rowSpacer, true, cutoffX, cutoffY)
+		self.currentPage = 1
+		self.totalPages = totalPages or 1
+		CustomExtensionsScreen.Buttons.CurrentPage:updateText()
+	end,
+	getPageText = function(self)
+		if self.totalPages <= 1 then return "Page" end
+		return string.format(CustomExtensionsScreen.Labels.pageFormat, self.currentPage, self.totalPages)
+	end,
+	prevPage = function(self)
+		if self.totalPages <= 1 then return end
+		self.currentPage = ((self.currentPage - 2 + self.totalPages) % self.totalPages) + 1
+	end,
+	nextPage = function(self)
+		if self.totalPages <= 1 then return end
+		self.currentPage = (self.currentPage % self.totalPages) + 1
+	end,
+}
+
+CustomExtensionsScreen.Buttons = {
+	EnableCustomExtensions = {
+		type = Constants.ButtonTypes.CHECKBOX,
+		text = " Enable custom extensions", -- offset with a space for appearance
+		clickableArea = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4, Constants.SCREEN.MARGIN + 14, Constants.SCREEN.RIGHT_GAP - 12, 8 },
+		box = {	Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4, Constants.SCREEN.MARGIN + 14, 8, 8 },
+		toggleState = true, -- update later in initialize
+		toggleColor = "Positive text",
+		onClick = function(self)
+			-- Toggle the setting and store the change to be saved later in Settings.ini
+			self.toggleState = not self.toggleState
+			Options.updateSetting("Enable custom extensions", self.toggleState)
+			Options.forceSave()
+		end
+	},
+	CurrentPage = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		text = "", -- Set later via updateText()
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 53, Constants.SCREEN.MARGIN + 135, 50, 10, },
+		isVisible = function() return CustomExtensionsScreen.Pager.totalPages > 1 end,
+		updateText = function(self)
+			self.text = CustomExtensionsScreen.Pager:getPageText()
+		end,
+	},
+	PrevPage = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = Constants.PixelImages.LEFT_ARROW,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 39, Constants.SCREEN.MARGIN + 136, 10, 10, },
+		isVisible = function() return CustomExtensionsScreen.Pager.totalPages > 1 end,
+		onClick = function(self)
+			CustomExtensionsScreen.Pager:prevPage()
+			CustomExtensionsScreen.Buttons.CurrentPage:updateText()
+			Program.redraw(true)
+		end
+	},
+	NextPage = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = Constants.PixelImages.RIGHT_ARROW,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 98, Constants.SCREEN.MARGIN + 136, 10, 10, },
+		isVisible = function() return CustomExtensionsScreen.Pager.totalPages > 1 end,
+		onClick = function(self)
+			CustomExtensionsScreen.Pager:nextPage()
+			CustomExtensionsScreen.Buttons.CurrentPage:updateText()
+			Program.redraw(true)
+		end
+	},
+	RefreshExtensionList = {
+		type = Constants.ButtonTypes.FULL_BORDER,
+		text = "Refresh",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4, Constants.SCREEN.MARGIN + 135, 31, 11 },
+		onClick = function(self)
+			CustomExtensionsScreen.refreshExtensionList()
+			CustomExtensionsScreen.buildOutPagedButtons()
+			Program.redraw(true)
+		end
+	},
+	Back = {
+		type = Constants.ButtonTypes.FULL_BORDER,
+		text = "Back",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 112, Constants.SCREEN.MARGIN + 135, 24, 11 },
+		onClick = function(self)
+			CustomExtensionsScreen.resetButtons()
+			Program.changeScreenView(Program.Screens.SETUP)
+		end
+	},
+}
+
+function CustomExtensionsScreen.initialize()
+	for _, button in pairs(CustomExtensionsScreen.Buttons) do
+		if button.textColor == nil then
+			button.textColor = CustomExtensionsScreen.Colors.text
+		end
+		if button.boxColors == nil then
+			button.boxColors = { CustomExtensionsScreen.Colors.border, CustomExtensionsScreen.Colors.boxFill }
+		end
+	end
+	CustomExtensionsScreen.Buttons.EnableCustomExtensions.toggleState = Options["Enable custom extensions"]
+	CustomExtensionsScreen.Buttons.CurrentPage:updateText()
+end
+
+function CustomExtensionsScreen.refreshExtensionList()
+	local customFolderPath = FileManager.getCustomFolderPath()
+	local customFiles = FileManager.getFilesFromDirectory(customFolderPath)
+	for _, filename in pairs(customFiles) do
+		local name = FileManager.extractFileNameFromPath(filename) or ""
+		local ext = FileManager.extractFileExtensionFromPath(filename) or ""
+		Utils.printDebug("name: %s, ext: %s", name, ext)
+	end
+end
+
+function CustomExtensionsScreen.buildOutPagedButtons()
+	CustomExtensionsScreen.Pager.Buttons = {}
+
+	for _, extension in pairs(CustomCode.ExtensionLibrary) do
+		local button = {
+			type = Constants.ButtonTypes.ICON_BORDER,
+			image = Constants.PixelImages.CHECKMARK,
+			text = extension.name or Constants.BLANKLINE,
+			textColor = CustomExtensionsScreen.Colors.text,
+			iconColors = Utils.inlineIf(extension.isEnabled, { "Positive text", }, { "Negative text", }),
+			extension = extension,
+			dimensions = { width = 124, height = 16, },
+			isVisible = function(self) return CustomExtensionsScreen.Pager.currentPage == self.pageVisible end,
+			updateText = function(self)
+				if self.extension.isEnabled then
+					self.iconColors = { "Positive text", }
+				else
+					self.iconColors = { "Negative text", }
+				end
+			end,
+			-- draw = function(self, shadowcolor)
+			-- 	local minutesAgo = math.ceil((os.time() - restorePoint.timestamp) / 60)
+			-- 	local includeS = Utils.inlineIf(minutesAgo ~= 1, "s", "")
+			-- 	local timestampText = string.format(CustomExtensionsScreen.Labels.restoreTimeFormat, minutesAgo, includeS)
+			-- 	local rightAlignOffset = self.box[3] - Utils.calcWordPixelLength(timestampText) - 2
+			-- 	Drawing.drawText(self.box[1] + rightAlignOffset, self.box[2] + self.box[4] + 1, timestampText, Theme.COLORS[CustomExtensionsScreen.Colors.text], shadowcolor)
+			-- end,
+			onClick = function(self)
+				-- TODO: Navigate to single screen to show enable/disable options; for now, toggle it
+				self.extension.isEnabled = not self.extension.isEnabled
+				self:updateText()
+			end,
+		}
+		table.insert(CustomExtensionsScreen.Pager.Buttons, button)
+	end
+
+	local x = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 8
+	local y = Constants.SCREEN.MARGIN + 48
+	local colSpacer = 1
+	local rowSpacer = Constants.SCREEN.LINESPACING + 7
+	CustomExtensionsScreen.Pager:realignButtonsToGrid(x, y, colSpacer, rowSpacer)
+
+	return true
+end
+
+function CustomExtensionsScreen.resetButtons()
+	for _, button in pairs(CustomExtensionsScreen.Buttons) do
+		if button.updateText ~= nil then
+			button:updateText()
+		end
+	end
+	for _, button in pairs(CustomExtensionsScreen.Pager.Buttons) do
+		if button.updateText ~= nil then
+			button:updateText()
+		end
+	end
+end
+
+-- DRAWING FUNCTIONS
+function CustomExtensionsScreen.drawScreen()
+	Drawing.drawBackgroundAndMargins()
+	gui.defaultTextBackground(Theme.COLORS[CustomExtensionsScreen.Colors.boxFill])
+
+	local topBox = {
+		x = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN,
+		y = Constants.SCREEN.MARGIN + 10,
+		width = Constants.SCREEN.RIGHT_GAP - (Constants.SCREEN.MARGIN * 2),
+		height = Constants.SCREEN.HEIGHT - (Constants.SCREEN.MARGIN * 2) - 10,
+		text = Theme.COLORS[CustomExtensionsScreen.Colors.text],
+		border = Theme.COLORS[CustomExtensionsScreen.Colors.border],
+		fill = Theme.COLORS[CustomExtensionsScreen.Colors.boxFill],
+		shadow = Utils.calcShadowColor(Theme.COLORS[CustomExtensionsScreen.Colors.boxFill]),
+	}
+	local headerText = CustomExtensionsScreen.Labels.header:upper()
+	local headerShadow = Utils.calcShadowColor(Theme.COLORS["Main background"])
+	local offsetX = Utils.getCenteredTextX(headerText, topBox.width)
+	Drawing.drawText(topBox.x + offsetX, Constants.SCREEN.MARGIN - 2, headerText, Theme.COLORS["Header text"], headerShadow)
+
+	-- Draw top border box
+	gui.drawRectangle(topBox.x, topBox.y, topBox.width, topBox.height, topBox.border, topBox.fill)
+	local textLineY = topBox.y + Constants.SCREEN.LINESPACING + 3 -- make room for first checkbox
+
+	-- local wrappedDesc = Utils.getWordWrapLines(CustomExtensionsScreen.Labels.description, 32)
+	-- for _, line in pairs(wrappedDesc) do
+	-- 	Drawing.drawText(topBox.x + 3, textLineY, line, topBox.text, topBox.shadow)
+	-- 	textLineY = textLineY + Constants.SCREEN.LINESPACING - 1
+	-- end
+
+	if #CustomExtensionsScreen.Pager.Buttons == 0 then
+		local wrappedDesc = Utils.getWordWrapLines(CustomExtensionsScreen.Labels.noExtensions, 32)
+		textLineY = textLineY + Constants.SCREEN.LINESPACING - 1
+		for _, line in pairs(wrappedDesc) do
+			Drawing.drawText(topBox.x + 3, textLineY, line, Theme.COLORS["Negative text"], topBox.shadow)
+			textLineY = textLineY + Constants.SCREEN.LINESPACING - 1
+		end
+	end
+
+	-- Draw all buttons
+	for _, button in pairs(CustomExtensionsScreen.Buttons) do
+		Drawing.drawButton(button, topBox.shadow)
+	end
+	for _, button in pairs(CustomExtensionsScreen.Pager.Buttons) do
+		Drawing.drawButton(button, topBox.shadow)
+	end
+end

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -76,6 +76,7 @@ SetupScreen.Buttons = {
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 61, Constants.SCREEN.MARGIN + 135, 47, 11 },
 		onClick = function()
 			Main.SaveSettings()
+			CustomExtensionsScreen.buildOutPagedButtons()
 			Program.changeScreenView(Program.Screens.EXTENSIONS)
 		end
 	},

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -70,6 +70,15 @@ SetupScreen.Buttons = {
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4, Constants.SCREEN.MARGIN + 135, 53, 11 },
 		onClick = function() SetupScreen.openEditControlsWindow() end
 	},
+	Extensions = {
+		type = Constants.ButtonTypes.FULL_BORDER,
+		text = "Extensions",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 61, Constants.SCREEN.MARGIN + 135, 47, 11 },
+		onClick = function()
+			Main.SaveSettings()
+			Program.changeScreenView(Program.Screens.EXTENSIONS)
+		end
+	},
 	Back = {
 		type = Constants.ButtonTypes.FULL_BORDER,
 		text = "Back",


### PR DESCRIPTION
This PR adds a new screen to the Tracker settings under Setup to allow uses to easily see what extensions they've installed. From here, they can enable or disable an extension simply by clicking on it.

After this change, I'll need to update the wiki to explain this new method. There won't be much of an "add-on" to install anymore, it just all kind of works now. However, no custom extensions will be shipped with the tracker (unless we want to include just one?). I don't want to change the wiki right now as I have a few people using the old method for testing.

![image](https://user-images.githubusercontent.com/4258818/217514669-e7e00135-c4db-496b-9558-e007252a1dbd.png)