### PR TITLE
Adding option to show an EXP bar

### DIFF
--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -119,6 +119,7 @@ Constants.OrderedLists = {
 		"Pokemon icon set",
 		"Show last damage calcs",
 		"Reveal info if randomized",
+		"Show experience points bar",
 		"Animated Pokemon popout",
 		"Use premade ROMs",
 		"Generate ROM each time",

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -314,8 +314,11 @@ function Drawing.drawExpBar(x, y, width, height, percentFill, barColors, rightTo
 	local remainingWidth = math.floor(width * percentFill + 0.5)
 	local rightAlignedOffset = Utils.inlineIf(rightToLeft == true, width - remainingWidth, 0)
 
-	-- Draw outer border bar
-	gui.drawRectangle(x, y, width, height, barColors[2], barColors[3])
+	-- Draw outer border bar, a rounded rectangle
+	gui.drawLine(x + 1, y, x + width - 1, y, barColors[2])
+	gui.drawLine(x + 1, y + height, x + width - 1, y + height, barColors[2])
+	gui.drawLine(x, y + 1, x, y + height - 1, barColors[2])
+	gui.drawLine(x + width, y + 1, x + width, y + height - 1, barColors[2])
 	-- Draw inner colored bar for the percentage filled
 	gui.drawRectangle(x + rightAlignedOffset, y, remainingWidth, height, 0x00000000, barColors[1])
 end

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -301,6 +301,25 @@ function Drawing.drawImageAsPixels(imageMatrix, x, y, colorList, shadowcolor)
 	end
 end
 
+-- Draws an experience bar (partially filled based on exp needed to level); width/height is just the size of the bar fill, does not include border
+function Drawing.drawExpBar(x, y, width, height, percentFill, barColors, rightToLeft)
+	if not Main.IsOnBizhawk() then return end
+
+	-- Define default colors, to be safe
+	if barColors == nil then barColors = {} end
+	if barColors[1] == nil then barColors[1] = Theme.COLORS["Default text"] end
+	if barColors[2] == nil then barColors[2] = Theme.COLORS["Upper box border"] end
+	if barColors[3] == nil then barColors[3] = Theme.COLORS["Upper box background"] end
+
+	local remainingWidth = math.floor(width * percentFill + 0.5)
+	local rightAlignedOffset = Utils.inlineIf(rightToLeft == true, width - remainingWidth, 0)
+
+	-- Draw outer border bar
+	gui.drawRectangle(x, y, width, height, barColors[2], barColors[3])
+	-- Draw inner colored bar for the percentage filled
+	gui.drawRectangle(x + rightAlignedOffset, y, remainingWidth, height, 0x00000000, barColors[1])
+end
+
 -- Draws a tiny Tracker (50x50) on screen for purposes of previewing a Theme
 function Drawing.drawTrackerThemePreview(x, y, themeColors, displayColorBars)
 	local width = 50

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -427,7 +427,7 @@ function GameSettings.setRomAddresses(gameIndex, versionIndex)
 			{ 0x081fdf78, 0x081fdf90, 0x081fdf90 },
 			{ 0x081fdf08, 0x081fdf20, 0x081fdf20 },
 			{ 0x0831f72c },
-			{ 0x08253ae4, 0x08253b54, nil, nil, nil, nil }, -- TODO: Find foreign addresses for these
+			{ 0x08253ae4, 0x08253b54, 0x0824f2ac, 0x0824cbc4, 0x0824df34, 0x08253a08 },
 			{ 0x08253ac0, 0x08253b30 },
 		},
 		-- GetEvolutionTargetSpecies + 0x13E

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -423,6 +423,13 @@ function GameSettings.setRomAddresses(gameIndex, versionIndex)
 			{ 0x08254784, 0x082547f4, 0x0824ff4c, 0x0824d864, 0x0824ebd4, 0x082546a8 },
 			{ 0x08254760, 0x082547d0 },
 		},
+		gExperienceTables = {
+			{ 0x081fdf78, 0x081fdf90, 0x081fdf90 },
+			{ 0x081fdf08, 0x081fdf20, 0x081fdf20 },
+			{ 0x0831f72c },
+			{ 0x08253ae4, 0x08253b54, nil, nil, nil, nil }, -- TODO: Find foreign addresses for these
+			{ 0x08253ac0, 0x08253b30 },
+		},
 		-- GetEvolutionTargetSpecies + 0x13E
 		FriendshipRequiredToEvo = {
 			{ 0x0803F5CA, 0x0803F5CA, 0x0803F5CA },

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -27,6 +27,7 @@ Options = {
 	["Pokemon icon set"] = "1", -- Original icon set
 	["Show last damage calcs"] = true,
 	["Reveal info if randomized"] = true,
+	["Show experience points bar"] = false,
 	["Animated Pokemon popout"] = false,
 	["Use premade ROMs"] = false,
 	["Generate ROM each time"] = false,

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -329,6 +329,11 @@ function Program.updatePokemonTeams()
 				-- No longer remove, as it's currently used to verify Trainer pokemon with personality values of 0
 				-- newPokemonData.trainerID = nil
 
+				-- Include experience information for each Pokemon in the player's team
+				local curExp, totalExp = Program.getNextLevelExp(newPokemonData.pokemonID, newPokemonData.level, newPokemonData.experience)
+				newPokemonData.currentExp = curExp
+				newPokemonData.totalExp = totalExp
+
 				Tracker.addUpdatePokemon(newPokemonData, personality, true)
 
 				-- TODO: Removing for now until some better option is available, not sure there is one
@@ -380,7 +385,7 @@ function Program.readNewPokemon(startAddress, personality)
 
 	-- Pokemon Data structure: https://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_data_substructures_(Generation_III)
 	local growth1 = Utils.bit_xor(Memory.readdword(startAddress + 32 + growthoffset), magicword)
-	-- local growth2 = Utils.bit_xor(Memory.readdword(startAddress + 32 + growthoffset + 4), magicword) -- Currently unused
+	local growth2 = Utils.bit_xor(Memory.readdword(startAddress + 32 + growthoffset + 4), magicword) -- Experience
 	local growth3 = Utils.bit_xor(Memory.readdword(startAddress + 32 + growthoffset + 8), magicword)
 	local attack1 = Utils.bit_xor(Memory.readdword(startAddress + 32 + attackoffset), magicword)
 	local attack2 = Utils.bit_xor(Memory.readdword(startAddress + 32 + attackoffset + 4), magicword)
@@ -436,6 +441,7 @@ function Program.readNewPokemon(startAddress, personality)
 		trainerID = Utils.getbits(otid, 0, 16),
 		pokemonID = species,
 		heldItem = Utils.getbits(growth1, 16, 16),
+		experience = growth2,
 		friendship = Utils.getbits(growth3, 8, 8),
 		level = Utils.getbits(level_and_currenthp, 0, 8),
 		nature = personality % 25,
@@ -462,12 +468,30 @@ function Program.readNewPokemon(startAddress, personality)
 
 		-- Unused data that can be added back in later
 		-- secretID = Utils.getbits(otid, 16, 16), -- Unused
-		-- experience = Utils.getbits(growth2, 32, 31), -- Unused
 		-- pokerus = Utils.getbits(misc1, 0, 8), -- Unused
 		-- iv = misc2,
 		-- ev1 = effort1,
 		-- ev2 = effort2,
 	}
+end
+
+-- Returns two exp values that describe the amount of experience points needed to reach the next level.
+-- currentExp: A value between 0 and 'totalExp'
+-- totalExp: The amount of exp needed to reach the next level
+function Program.getNextLevelExp(pokemonID, level, experience)
+	if not PokemonData.isValid(pokemonID) or level == nil or level >= 100 or experience == nil or GameSettings.gExperienceTables == nil then
+		return 0, 100 -- arbitrary returned values to indicate this information isn't found and it's 0% of the way to next level
+	end
+
+	local growthRateIndex = Memory.readbyte(GameSettings.gBaseStats + (pokemonID * 0x1C) + 0x13)
+	local expTableOffset = GameSettings.gExperienceTables + (growthRateIndex * 0x194) + (level * 0x4)
+	local expAtLv = Memory.readdword(expTableOffset)
+	local expAtNextLv = Memory.readdword(expTableOffset + 0x4)
+
+	local currentExp = experience - expAtLv
+	local totalExp = expAtNextLv - expAtLv
+
+	return currentExp, totalExp
 end
 
 function Program.updatePCHeals()

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -7,6 +7,9 @@ Tracker.DataMessage = "" -- Used for StartupScreen to display info about tracked
 Tracker.ForceUpdateData = {
 	pokemonData = {
 		abilityNum = true,
+		experience = true,
+		currentExp = true,
+		totalExp = true,
 	},
 }
 
@@ -448,6 +451,9 @@ function Tracker.getDefaultPokemon()
 		movelvls = { {}, {} },
 		weight = 0.0,
 		personality = 0,
+		experience = 0,
+		currentExp = 0,
+		totalExp = 100,
 		friendship = 0,
 		heldItem = 0,
 		level = 0,

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -139,6 +139,8 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 	data.p.bst = viewedPokemon.bst or Constants.BLANKLINE
 	data.p.lastlevel = Tracker.getLastLevelSeen(viewedPokemon.pokemonID) or ""
 	data.p.status = MiscData.StatusCodeMap[viewedPokemon.status] or ""
+	data.p.curExp = viewedPokemon.currentExp or 0
+	data.p.totalExp = viewedPokemon.totalExp or 100
 
 	-- Add: Stats, Stages, and Nature
 	data.p.nature = viewedPokemon.nature

--- a/ironmon_tracker/screens/GameOptionsScreen.lua
+++ b/ironmon_tracker/screens/GameOptionsScreen.lua
@@ -18,6 +18,7 @@ GameOptionsScreen.OptionKeys = {
 	"Count enemy PP usage",
 	"Show last damage calcs",
 	"Reveal info if randomized",
+	"Show experience points bar",
 }
 
 GameOptionsScreen.Buttons = {

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -732,9 +732,19 @@ function TrackerScreen.drawPokemonInfoArea(data)
 		extraInfoColor = Theme.COLORS["Intermediate text"]
 	end
 
-	local levelEvoText = "Lv." .. data.p.level .. " ("
-	local evoSpacing = offsetX + string.len(levelEvoText) * 3 + string.len(data.p.level) * 2
-	levelEvoText = levelEvoText .. data.p.evo .. ")"
+	local levelEvoText, evoSpacing
+	if data.p.evo == Constants.BLANKLINE then
+		levelEvoText = string.format("Lv.%s", data.p.level)
+	else
+		levelEvoText = string.format("Lv.%s (", data.p.level)
+		evoSpacing = offsetX + string.len(levelEvoText) * 3 + string.len(data.p.level) * 2
+		levelEvoText = levelEvoText .. data.p.evo .. ")"
+	end
+
+	-- Squeeze text together a bit to show the exp bar
+	if Options["Show experience points bar"] and Tracker.Data.isViewingOwn then
+		linespacing = linespacing - 1
+	end
 
 	-- POKEMON NAME
 	Drawing.drawText(Constants.SCREEN.WIDTH + offsetX, offsetY, data.p.name, Theme.COLORS["Default text"], shadowcolor)
@@ -747,7 +757,7 @@ function TrackerScreen.drawPokemonInfoArea(data)
 		offsetY = offsetY + linespacing
 
 		Drawing.drawText(Constants.SCREEN.WIDTH + offsetX, offsetY, levelEvoText, Theme.COLORS["Default text"], shadowcolor)
-		if data.p.evo ~= Constants.BLANKLINE then
+		if data.p.evo ~= Constants.BLANKLINE and evoSpacing ~= nil then
 			-- Draw over the evo method in the new color to reflect if evo is possible/ready
 			local evoTextColor = Theme.COLORS["Default text"]
 			if Tracker.Data.isViewingOwn then
@@ -771,6 +781,12 @@ function TrackerScreen.drawPokemonInfoArea(data)
 		offsetY = offsetY + linespacing
 	end
 
+	if Options["Show experience points bar"] and Tracker.Data.isViewingOwn then
+		local expPercentage = data.p.curExp / data.p.totalExp
+		Drawing.drawExpBar(Constants.SCREEN.WIDTH + offsetX + 2, offsetY + 2, 60, 3, expPercentage)
+		offsetY = offsetY + 5
+	end
+
 	-- Tracker.Data.isViewingOwn and
 	if data.p.status ~= MiscData.StatusCodeMap[MiscData.StatusType.None] then
 		Drawing.drawStatusIcon(data.p.status, Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 30 - 16 + 1, Constants.SCREEN.MARGIN + 1)
@@ -781,6 +797,11 @@ function TrackerScreen.drawPokemonInfoArea(data)
 	offsetY = offsetY + linespacing
 	Drawing.drawText(Constants.SCREEN.WIDTH + offsetX, offsetY, data.p.line2, Theme.COLORS["Intermediate text"], shadowcolor)
 	offsetY = offsetY + linespacing
+
+	-- Unsqueeze the text
+	if Options["Show experience points bar"] and Tracker.Data.isViewingOwn then
+		linespacing = linespacing + 1
+	end
 
 	-- HEALS INFO / ENCOUNTER INFO
 	local infoBoxHeight = 23


### PR DESCRIPTION
This adds an option to allow the player to add a cool experience points bar on the Tracker screen. This feature means that exp info for the full player's team is read in and can be displayed. Currently, only the lead Pokemon's exp is shown (as normal), but in a future update i want to have a full party display that includes exp bars for each Pokemon in the party.

This PR also changes the default visual behavior of the info line for Level + Evolution. If the Pokemon does not evolve, then nothing is shown at all, implying no evolve.

![image](https://user-images.githubusercontent.com/4258818/221065010-77261f6d-53e2-449e-ae6e-e6f878ebc32a.png)