### PR TITLE
Add an option to turn off friendship calculations

### DIFF
--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -112,6 +112,7 @@ Constants.OrderedLists = {
 		"Show physical special icons",
 		"Show move effectiveness",
 		"Calculate variable damage",
+		"Determine friendship readiness",
 		"Count enemy PP usage",
 		"Track PC Heals",
 		"PC heals count downward",

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -20,6 +20,7 @@ Options = {
 	["Show physical special icons"] = true,
 	["Show move effectiveness"] = true,
 	["Calculate variable damage"] = true,
+	["Determine friendship readiness"] = true,
 	["Count enemy PP usage"] = true,
 	["Track PC Heals"] = false,
 	["PC heals count downward"] = true,

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -582,7 +582,7 @@ end
 -- For Return & Frustration
 -- Only shows if close to max strength; won't return exact values to avoid revealing friendship amount
 function Utils.calculateFriendshipBasedDamage(movePower, friendship)
-	if movePower ~= ">FR" and movePower ~= "<FR" then
+	if not Options["Determine friendship readiness"] or (movePower ~= ">FR" and movePower ~= "<FR") then
 		return movePower
 	end
 

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -170,7 +170,8 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 	end
 
 	-- Update: Pokemon Evolution
-	if data.x.viewingOwn and data.p.evo == PokemonData.Evolutions.FRIEND and viewedPokemon.friendship >= Program.friendshipRequired then
+	local isFriendEvoReady = data.p.evo == PokemonData.Evolutions.FRIEND and viewedPokemon.friendship >= Program.friendshipRequired
+	if Options["Determine friendship readiness"] and data.x.viewingOwn and isFriendEvoReady then
 		data.p.evo = PokemonData.Evolutions.FRIEND_READY
 	end
 

--- a/ironmon_tracker/screens/GameOptionsScreen.lua
+++ b/ironmon_tracker/screens/GameOptionsScreen.lua
@@ -12,13 +12,14 @@ GameOptionsScreen = {
 GameOptionsScreen.OptionKeys = {
 	"Auto swap to enemy",
 	"Hide stats until summary shown",  -- Text referenced in initialize()
+	"Show experience points bar",
 	"Show physical special icons",
 	"Show move effectiveness",
 	"Calculate variable damage",
+	"Determine friendship readiness",
 	"Count enemy PP usage",
 	"Show last damage calcs",
 	"Reveal info if randomized",
-	"Show experience points bar",
 }
 
 GameOptionsScreen.Buttons = {

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -760,7 +760,7 @@ function TrackerScreen.drawPokemonInfoArea(data)
 		if data.p.evo ~= Constants.BLANKLINE and evoSpacing ~= nil then
 			-- Draw over the evo method in the new color to reflect if evo is possible/ready
 			local evoTextColor = Theme.COLORS["Default text"]
-			if Tracker.Data.isViewingOwn then
+			if Options["Determine friendship readiness"] and Tracker.Data.isViewingOwn then
 				local evoReadyFriendship = (data.p.evo == PokemonData.Evolutions.FRIEND_READY)
 				local evoReadyLevel = Utils.isReadyToEvolveByLevel(data.p.evo, data.p.level)
 				local evoReadyStone = Utils.isReadyToEvolveByStone(data.p.evo)


### PR DESCRIPTION
This adds an option to the Tracker to allow the player to disable the Tracker from telling them when their Pokemon has enough friendship for certain things, such as a friendship evolution is ready or Return's power is maxed.

There weren't too many places that required changes to implement this. So I think I got them all. Also worth noting the Return/Frustration are behind two options now (intentional). In order for it to show you when you're close, you have to enable both "Calculate variable damage" and "Determine friendship readiness", as its possible some people want friendship readiness for evos but dont want move powers calculated for them.

![image](https://user-images.githubusercontent.com/4258818/221146022-2a5467c3-2e50-4705-b88c-5f8923e198f3.png)
