### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Use this to report any bugs with the Ironmon Tracker
+title: "[Bug]: "
+labels: ["Bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! We just need some information to help understand what is going on.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of the bug. Include relevant details of what happened and what you expect to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Describe how we can make this bug happen ourselves.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: What tracker version are you using?
+      description: You can find this from the tracker's settings menu or the lua/scripting console output as you load the tracker.
+      placeholder: e.g. v7.3.2
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: What operating system are you using?
+      placeholder: e.g. Windows 10, Linux, MacOS
+    validations:
+      required: true
+  - type: dropdown
+    id: emulators
+    attributes:
+      label: What emulator(s) are you seeing the problem on?
+      multiple: true
+      options:
+        - Bizhawk 2.8
+        - Bizhawk 2.9
+        - mGBA 0.10.0
+        - mGBA 0.10.1
+        - Other (Tell us in Additional Information)
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please check the lua/scripting console for errors. Copy and paste the entire output into this box.
+      render: shell
+  - type: textarea
+    id: other-info
+    attributes:
+      label: Additional Information
+      description: "Leave any other relevant comments or screenshots here. Tip: You can attach images by dragging them into this box!"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ironmon Tracker Wiki
+    url: https://github.com/besteon/Ironmon-Tracker/wiki
+    about: Check our wiki for information about the Ironmon Tracker
+  - name: Ironmon Discord Server
+    url: https://discord.com/invite/jFPYsZAhjX
+    about: You can also contact us in the Ironmon Discord if you have questions about the tracker

--- a/.github/ISSUE_TEMPLATE/extension.yaml
+++ b/.github/ISSUE_TEMPLATE/extension.yaml
@@ -1,0 +1,38 @@
+name: Custom Code Extensions
+description: Use this to submit your custom code extension (or idea for one)
+title: "[Custom Code Extension]: "
+labels: ["Custom Code Extension"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before you submit a custom code extension or idea, please check our main README about [what is a good fit for the Ironmon Tracker](https://github.com/besteon/Ironmon-Tracker#what-is-a-good-fit-for-the-ironmon-tracker).
+        
+        Also check our [User-Created Extensions](https://github.com/besteon/Ironmon-Tracker/wiki/Tracker-Add-ons#user-created-extensions) to see if your idea already exists.
+  - type: dropdown
+    id: idea-or-submission
+    attributes:
+      label: Are you submitting an extension, or an idea?
+      options:
+        - Extension
+        - Idea
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Tell us about your extension / idea
+      description: Provide a detailed description of your extension / idea.
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: Link to extension
+      description: If you are submitting an extension you made, provide the URL where people can find it here.
+      placeholder: https://github.com/[USER]/[REPOSITORY]
+  - type: textarea
+    id: other-info
+    attributes:
+      label: Additional Information
+      description: "Leave any other relevant comments or screenshots here. Tip: You can attach images by dragging them into this box!"

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,21 @@
+name: Feature Request
+description: Use this to suggest new features or changes to the Ironmon Tracker
+title: "[Feature Request]: "
+labels: ["Feature Request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before you submit a feature request, please check our main README about [what is a good fit for the Ironmon Tracker](https://github.com/besteon/Ironmon-Tracker#what-is-a-good-fit-for-the-ironmon-tracker).
+  - type: textarea
+    id: description
+    attributes:
+      label: Tell us about your request
+      description: Provide a detailed description of your request, as well as reasons for why it would be a good improvement to the tracker.
+    validations:
+      required: true
+  - type: textarea
+    id: other-info
+    attributes:
+      label: Additional Information
+      description: "Leave any other relevant comments or screenshots here. Tip: You can attach images by dragging them into this box!"


### PR DESCRIPTION
Adds issue templates for the following:
- Bug reports
- Feature Requests
- Custom Code Extension submissions/ideas

The templates provide a form for the user to fill out, and auto-applies the relevant label to the issue. The default blank issues can still be made if desired

If you want to try out how these look, I have a temporary testing repo [here](https://github.com/Fellshadow/TestingIssueTemplates/issues/new/choose) (I'll most likely delete this repo later on when these templates are applied here and we're happy with them, so I don't mind if you actually submit issues to try it out lol)

Note: These won't actually take effect until this is merged into the main branch, we could directly commit this to main if wanted but there's a couple of recent commits from dev that would also be added