### PR TITLE
7.4.2 Release Patch

### DIFF
--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "7", minor = "4", patch = "1" }
+Main.Version = { major = "7", minor = "4", patch = "2" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -96,11 +96,9 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 		data.x.viewingOwn = forceView
 	end
 
-	-- Mostly useful for doubles; if viewing own, defaults to { slot=Battle.Combatants.LeftOther, target=1, isLeft=true, isOwner=false }
 	local targetInfo = Battle.getDoublesCursorTargetInfo()
-
 	local viewedPokemon = Battle.getViewedPokemon(data.x.viewingOwn)
-	local opposingPokemon = Tracker.getPokemon(targetInfo.slot, targetInfo.isOwner)-- currently used exclusively for Low Kick weight calcs
+	local opposingPokemon = Tracker.getPokemon(targetInfo.slot, targetInfo.isOwner) -- currently used exclusively for Low Kick weight calcs
 
 	if viewedPokemon == nil or viewedPokemon.pokemonID == 0 or not Program.isValidMapLocation() then
 		viewedPokemon = Tracker.getDefaultPokemon()

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -96,22 +96,11 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 		data.x.viewingOwn = forceView
 	end
 
-	-- If not in doubles, this defaults to [Battle.Combatants.LeftOther, false]
-	local cursorSlot, targetIsOwn = Battle.getDoublesCursorTargetInfo()
+	-- Mostly useful for doubles; if viewing own, defaults to { slot=Battle.Combatants.LeftOther, target=1, isLeft=true, isOwner=false }
+	local targetInfo = Battle.getDoublesCursorTargetInfo()
 
-	local viewedPokemon
-	local opposingPokemon -- currently used exclusively for Low Kick weight calcs
-	if data.x.viewingOwn then
-		viewedPokemon = Battle.getViewedPokemon(true)
-		if Battle.numBattlers == 2 then
-			opposingPokemon = Tracker.getPokemon(Battle.Combatants.LeftOther, false)
-		else
-			opposingPokemon = Tracker.getPokemon(cursorSlot, targetIsOwn)
-		end
-	else
-		viewedPokemon = Battle.getViewedPokemon(false)
-		opposingPokemon = Tracker.getPokemon(Battle.Combatants.LeftOwn, true)
-	end
+	local viewedPokemon = Battle.getViewedPokemon(data.x.viewingOwn)
+	local opposingPokemon = Tracker.getPokemon(targetInfo.slot, targetInfo.isOwner)-- currently used exclusively for Low Kick weight calcs
 
 	if viewedPokemon == nil or viewedPokemon.pokemonID == 0 or not Program.isValidMapLocation() then
 		viewedPokemon = Tracker.getDefaultPokemon()
@@ -324,8 +313,7 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 
 		-- Update: Calculate move effectiveness
 		if move.showeffective then
-			local isCursorOnLeft = (Battle.numBattlers == 2) or (cursorSlot == 0 or cursorSlot == 1) -- 0 & 2 is own and 1 & 3 is enemy
-			local enemyTypes = Program.getPokemonTypes(targetIsOwn, isCursorOnLeft)
+			local enemyTypes = Program.getPokemonTypes(targetInfo.isOwner, targetInfo.isLeft)
 			move.effectiveness = Utils.netEffectiveness(move, move.type, enemyTypes)
 		else
 			move.effectiveness = 1


### PR DESCRIPTION
Patch 7.4.1 fixed several issues with doubles battles but introduced a new issue. The target cursor information wasn't providing accurate details for the cases where it was being used. Thus, when Pokémon were KO'd in doubles battles, the new slots/targets were incorrectly calculated for purposes of move effectiveness.

This patch resolves this new issue.

Release Notes to append to 7.4.1:
[7.4.2] Fixed yet another doubles battle related issue where move effectiveness was inaccurate if trainer team had 3 or more Pokémon.