### PR TITLE
Battle targeting: enemy viewed mons fix

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -962,14 +962,14 @@ function Battle.getDoublesCursorTargetInfo()
 		targetInfo.isLeft = false
 	end
 
-	-- Not all games have this address
-	if GameSettings.gMultiUsePlayerCursor == nil then
+	-- Viewing an enemy pokemon should always calc stats against your default pokemon; Also, not all games have this address
+	if not Tracker.Data.isViewingOwn or GameSettings.gMultiUsePlayerCursor == nil then
 		return targetInfo
 	end
 
 	local target = Memory.readbyte(GameSettings.gMultiUsePlayerCursor)
 	if target < 0 or target > 4 then
-		-- If not target selected, the value is 255
+		-- If no is target selected, the value is 255
 		return targetInfo
 	end
 


### PR DESCRIPTION
Super quick fixed. When viewing an enemy pokemon on the Tracker screen, it should always calculate move effectiveness and other things against YOUR pokemon, instead of its own teammates or itself.

Houndoom is being targetting by my salamence. I'm viewing houndoom on the tracker. Its calc against my default (left) pokemon
![image](https://user-images.githubusercontent.com/4258818/224648542-eef73ee9-508c-4196-820f-0439ddf354f1.png)
