### PR TITLE
Log Parser: Adding support for custom Pokémon names

### DIFF
--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -537,7 +537,6 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 	data.p = {} -- data about the Pokemon itself
 	data.x = {} -- misc data to display, such as notes
 
-	-- TODO: (Types, Abilities, etc) need to be read-in from the log in case its not the current game being viewed
 	local pokemonDex
 	if pokemonID == nil or not PokemonData.isValid(pokemonID) then
 		pokemonDex = PokemonData.BlankPokemon
@@ -548,20 +547,19 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 	local pokemonLog = RandomizerLog.Data.Pokemon[pokemonID]
 
 	data.p.id = pokemonDex.pokemonID or 0
-	data.p.name = pokemonDex.name or Constants.BLANKLINE
+	data.p.name = pokemonLog.Name or pokemonDex.name or Constants.BLANKLINE
 	data.p.bst = pokemonDex.bst or Constants.BLANKLINE
-	data.p.types = { pokemonDex.types[1], pokemonDex.types[2] }
+	data.p.types = {
+		pokemonLog.Types[1],
+		pokemonLog.Types[2],
+	}
 	data.p.abilities = {
-		PokemonData.getAbilityId(pokemonDex.pokemonID, 0),
-		PokemonData.getAbilityId(pokemonDex.pokemonID, 1),
+		pokemonLog.Abilities[1],
+		pokemonLog.Abilities[2],
 	}
 
 	-- The following are all Randomizer Log information
-	if pokemonLog.BaseStats ~= nil then
-		data.p.helditems = pokemonLog.BaseStats.helditems or Constants.BLANKLINE -- unsure how this is formatted
-	else
-		data.p.helditems = Constants.BLANKLINE
-	end
+	data.p.helditems = pokemonLog.HeldItems or Constants.BLANKLINE -- unsure how this is formatted
 
 	-- The Pokemon's randomized base stats
 	for _, statKey in ipairs(Constants.OrderedLists.STATSTAGES) do
@@ -596,13 +594,18 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 	-- The Pokemon's level-up move list, in order of levels
 	data.p.moves = {}
 	for _, move in ipairs(pokemonLog.MoveSet or {}) do
-		local moveDex = MoveData.Moves[move.moveId]
 		local moveInfo = {
 			id = move.moveId,
 			level = move.level,
-			name = moveDex.name,
-			isstab = Utils.isSTAB(moveDex, moveDex.type, data.p.types),
 		}
+		local moveDex = MoveData.Moves[move.moveId]
+		if moveDex ~= nil then
+			moveInfo.name = moveDex.name
+			moveInfo.isstab = Utils.isSTAB(moveDex, moveDex.type, data.p.types)
+		else
+			moveInfo.name = move.name or Constants.BLANKLINE
+			moveInfo.isstab = false
+		end
 		table.insert(data.p.moves, moveInfo)
 	end
 
@@ -615,15 +618,20 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 	-- The Pokemon's TM Move Compatibility, which moves it can learn from TMs
 	data.p.tmmoves = {}
 	for _, tmNumber in ipairs(pokemonLog.TMMoves or {}) do
-		local moveId = RandomizerLog.Data.TMs[tmNumber] or 0
-		local moveDex = MoveData.Moves[moveId]
+		local tm = RandomizerLog.Data.TMs[tmNumber]
 		local tmInfo = {
 			tm = tmNumber,
-			moveId = moveId,
-			moveName = MoveData.Moves[moveId].name,
+			moveId = tm.moveId,
 			gymNum = gymTMs[tmNumber] or 9,
-			isstab = Utils.isSTAB(moveDex, moveDex.type, data.p.types),
 		}
+		local moveDex = MoveData.Moves[tm.moveId]
+		if moveDex ~= nil then
+			tmInfo.moveName = moveDex.name
+			tmInfo.isstab = Utils.isSTAB(moveDex, moveDex.type, data.p.types)
+		else
+			tmInfo.moveName = tm.name or Constants.BLANKLINE
+			tmInfo.isstab = false
+		end
 		table.insert(data.p.tmmoves, tmInfo)
 	end
 
@@ -655,11 +663,12 @@ function DataHelper.buildTrainerLogDisplay(trainerId)
 	for _, partyMon in ipairs(trainer.party or {}) do
 		local pokemonInfo = {
 			id = partyMon.pokemonID or 0,
-			name = PokemonData.Pokemon[partyMon.pokemonID].name or Constants.BLANKLINE,
+			name = RandomizerLog.Data.Pokemon[partyMon.pokemonID].Name or Constants.BLANKLINE,
 			level = partyMon.level or 0,
 			moves = {},
 			helditem = partyMon.helditem,
 		}
+
 		local movesLeftToAdd = 4
 		local pokemonMoves = RandomizerLog.Data.Pokemon[partyMon.pokemonID].MoveSet or {}
 		-- Pokemon forget moves in order from 1st learned to last, so figure out current moveset working backwards
@@ -667,8 +676,13 @@ function DataHelper.buildTrainerLogDisplay(trainerId)
 			if pokemonMoves[j].level <= partyMon.level then
 				local moveToAdd = {
 					moveId = pokemonMoves[j].moveId,
-					name = MoveData.Moves[pokemonMoves[j].moveId].name,
 				}
+				local moveDex = MoveData.Moves[pokemonMoves[j].moveId]
+				if moveDex ~= nil then
+					moveToAdd.name = moveDex.name
+				else
+					moveToAdd.name = pokemonMoves[j].name or Constants.BLANKLINE
+				end
 				table.insert(pokemonInfo.moves, 1, moveToAdd) -- insert at the front to add them in "reverse" or bottom-up
 				movesLeftToAdd = movesLeftToAdd - 1
 				if movesLeftToAdd <= 0 then

--- a/ironmon_tracker/data/RandomizerLog.lua
+++ b/ironmon_tracker/data/RandomizerLog.lua
@@ -2,11 +2,11 @@
 RandomizerLog = {}
 
 RandomizerLog.Patterns = {
-	RandomizerVersion = "Randomizer Version:%s*([%d%.]+)%s*$", -- Note: log file line 1 does NOT start with "Rando..."
+	RandomizerVersion = "Randomizer Version:%s*([%d%.]+).*$", -- Note: log file line 1 does NOT start with "Rando..."
 	RandomizerSeed = "^Random Seed:%s*(%d+)%s*$",
 	RandomizerSettings = "^Settings String:%s*(.+)%s*$",
 	RandomizerGame = "^Randomization of%s*(.+)%s+completed",
-	PokemonName = "([%a%d%.]* ?[%a%d%.'%-♀♂%?]+).-",
+	PokemonName = "([%a%d%.]* ?[%a%d%.!'%-♀♂%?]+).-",
 	-- MoveName = "([%u%d%.'%-%?]+)", -- might figure out later
 	-- ItemName = "([%u%d%.'%-%?]+)", -- might figure out later
 	getSectorHeaderPattern = function(sectorName)
@@ -25,8 +25,8 @@ RandomizerLog.Sectors = {
 	},
 	BaseStatsItems = {
 		HeaderPattern = RandomizerLog.Patterns.getSectorHeaderPattern("Pokemon Base Stats & Types"),
-		-- Matches: pokemon, hp, atk, def, spatk, spdef, spd, helditems
-		PokemonBSTPattern = "^.*|" .. RandomizerLog.Patterns.PokemonName .. "%s*|.*|%s*(%d*)|%s*(%d*)|%s*(%d*)|%s*(%d*)|%s*(%d*)|%s*(%d*)|.*|.*|(.*)",
+		-- Matches: id, pokemon, types, hp, atk, def, spatk, spdef, spd, ability1, ability2, helditems
+		PokemonBSTPattern = "^%s*(%d*)|" .. RandomizerLog.Patterns.PokemonName .. "%s*|(.-)%s*|%s*(%d*)|%s*(%d*)|%s*(%d*)|%s*(%d*)|%s*(%d*)|%s*(%d*)|(.-)%s*|(.-)%s*|(.*)",
 	},
 	MoveSets = {
 		HeaderPattern = RandomizerLog.Patterns.getSectorHeaderPattern("Pokemon Movesets"),
@@ -44,7 +44,7 @@ RandomizerLog.Sectors = {
 	TMCompatibility = {
 		HeaderPattern = RandomizerLog.Patterns.getSectorHeaderPattern("TM Compatibility"),
 		-- Matches: pokemon
-		NextMonPattern = "^[%s%d]+%s" .. RandomizerLog.Patterns.PokemonName .. "%s*|(.*)",
+		NextMonPattern = "^%s*%d+%s*" .. RandomizerLog.Patterns.PokemonName .. "%s*|(.*)",
 		-- Matches: tmNumber
 		TMPattern = "TM(%d+)",
 	},
@@ -84,8 +84,8 @@ function RandomizerLog.parseLog(filepath)
 
 	RandomizerLog.setupMappings()
 	RandomizerLog.parseRandomizerSettings(logLines)
+	RandomizerLog.parseBaseStatsItems(logLines) -- required to parse first
 	RandomizerLog.parseEvolutions(logLines)
-	RandomizerLog.parseBaseStatsItems(logLines)
 	RandomizerLog.parseMoveSets(logLines)
 	RandomizerLog.parseTMMoves(logLines)
 	RandomizerLog.parseTMCompatibility(logLines)
@@ -106,7 +106,7 @@ function RandomizerLog.formatInput(str)
 	str = str:gsub("’", "'")
 	str = str:gsub("é", Constants.getC("é"))
 	str = str:gsub("%[PK%]%[MN%]", "PKMN")
-	str = str:match("^%s*(.*)%s*$") or str -- remove leading/trailing spaces
+	str = str:match("^%s*(.-)%s*$") or str -- remove leading/trailing spaces
 	return str:lower()
 end
 
@@ -138,7 +138,10 @@ function RandomizerLog.resetData()
 
 	for id = 1, PokemonData.totalPokemon, 1 do
 		if id <= 251 or id >= 277 then -- celebi / treecko
-			RandomizerLog.Data.Pokemon[id] = {}
+			RandomizerLog.Data.Pokemon[id] = {
+				Types = {},
+				Abilities = {},
+			}
 		end
 	end
 end
@@ -200,6 +203,7 @@ function RandomizerLog.parseEvolutions(logLines)
 		local pokemonId = RandomizerLog.PokemonNameToIdMap[pokemon]
 		RandomizerLog.Data.Pokemon[pokemonId].Evolutions = {}
 
+		-- Replace any "and" to make parsing lowercase-named log files easier.
 		evos = evos:gsub(" and ", ", ")
 		for evo in string.gmatch(evos, RandomizerLog.Patterns.PokemonName) do
 			local evoToAdd = RandomizerLog.formatInput(evo)
@@ -227,18 +231,30 @@ function RandomizerLog.parseBaseStatsItems(logLines)
 	-- Parse the sector
 	local index = RandomizerLog.Sectors.BaseStatsItems.LineNumber + 1 -- remove the first line to skip the table header
 	while index <= #logLines do
-		local pokemon, hp, atk, def, spa, spd, spe, helditems = string.match(logLines[index] or "", RandomizerLog.Sectors.BaseStatsItems.PokemonBSTPattern)
+		local id, pokemon, types, hp, atk, def, spa, spd, spe, ability1, ability2, helditems = string.match(logLines[index] or "", RandomizerLog.Sectors.BaseStatsItems.PokemonBSTPattern)
 		pokemon = RandomizerLog.formatInput(pokemon)
 		pokemon = RandomizerLog.alternateNidorans(pokemon)
 
 		-- If nothing matches, end of sector
-		if pokemon == nil or spe == nil or RandomizerLog.PokemonNameToIdMap[pokemon] == nil then
+		if pokemon == nil or spe == nil then
 			return
 		end
 
-		local pokemonId = RandomizerLog.PokemonNameToIdMap[pokemon]
+		local pokemonId = RouteData.verifyPID(tonumber(tostring(id)) or 0)
 		local pokemonData = RandomizerLog.Data.Pokemon[pokemonId]
 		if pokemonData ~= nil then
+			-- Setup future lookups to handle custom names
+			RandomizerLog.PokemonNameToIdMap[pokemon] = pokemonId
+
+			pokemonData.Name = Utils.firstToUpper(pokemon)
+
+			types = RandomizerLog.formatInput(types) or ""
+			local type1, type2 = string.match(types, "([^/]+)/?(.*)")
+			pokemonData.Types = {
+				PokemonData.Types[string.upper(type1 or "")] or PokemonData.Types.EMPTY,
+				PokemonData.Types[string.upper(type2 or "")] or PokemonData.Types.EMPTY,
+			}
+
 			pokemonData.BaseStats = {
 				hp = tonumber(hp) or 0,
 				atk = tonumber(atk) or 0,
@@ -247,9 +263,19 @@ function RandomizerLog.parseBaseStatsItems(logLines)
 				spd = tonumber(spd) or 0,
 				spe = tonumber(spe) or 0,
 			}
+
+			ability1 = RandomizerLog.formatInput(ability1) or ""
+			ability2 = RandomizerLog.formatInput(ability2) or "" -- Log shows empty abilities as "-------", which results in nil via lookup
+			pokemonData.Abilities = {
+				RandomizerLog.AbilityNameToIdMap[ability1] or AbilityData.DefaultAbility.id,
+				RandomizerLog.AbilityNameToIdMap[ability2],
+			}
+
 			if helditems ~= nil and helditems ~= "" then
-				pokemonData.BaseStats.helditems = RandomizerLog.formatInput(helditems)
+				pokemonData.HeldItems = RandomizerLog.formatInput(helditems)
 			end
+		else
+			Utils.printDebug(">%s< >%s<", pokemonId, pokemon)
 		end
 		index = index + 1
 	end
@@ -291,7 +317,8 @@ function RandomizerLog.parseMoveSets(logLines)
 			while level ~= nil and movename ~= nil do
 				local nextMove = {
 					level = tonumber(RandomizerLog.formatInput(level)) or 0,
-					moveId = RandomizerLog.MoveNameToIdMap[RandomizerLog.formatInput(movename)]
+					moveId = RandomizerLog.MoveNameToIdMap[RandomizerLog.formatInput(movename)] or 0,
+					name = movename, -- For custom move names
 				}
 				table.insert(RandomizerLog.Data.Pokemon[pokemonId].MoveSet, nextMove)
 
@@ -317,15 +344,16 @@ function RandomizerLog.parseTMMoves(logLines)
 	while index <= #logLines do
 		local tmNumber, movename = string.match(logLines[index] or "", RandomizerLog.Sectors.TMMoves.TMPattern)
 		tmNumber = tonumber(RandomizerLog.formatInput(tmNumber) or "") -- nil if not a number
-		movename = RandomizerLog.formatInput(movename)
 
 		-- If nothing matches, end of sector
-		if tmNumber == nil or movename == nil or RandomizerLog.MoveNameToIdMap[movename] == nil then
+		if tmNumber == nil or RandomizerLog.formatInput(movename) == nil then
 			return
 		end
 
-		local moveId = RandomizerLog.MoveNameToIdMap[movename]
-		RandomizerLog.Data.TMs[tmNumber] = moveId
+		RandomizerLog.Data.TMs[tmNumber] = {
+			moveId = RandomizerLog.MoveNameToIdMap[RandomizerLog.formatInput(movename)] or 0,
+			name = movename, -- For custom move names
+		}
 
 		index = index + 1
 	end
@@ -351,8 +379,8 @@ function RandomizerLog.parseTMCompatibility(logLines)
 		local pokemonId = RandomizerLog.PokemonNameToIdMap[pokemon]
 		RandomizerLog.Data.Pokemon[pokemonId].TMMoves = {}
 
-		for tmNumber in string.gmatch(tms, RandomizerLog.Sectors.TMCompatibility.TMPattern) do
-			tmNumber = tonumber(RandomizerLog.formatInput(tmNumber) or "") -- nil if not a number
+		for tmNumberStr in string.gmatch(tms, RandomizerLog.Sectors.TMCompatibility.TMPattern) do
+			local tmNumber = tonumber(RandomizerLog.formatInput(tmNumberStr) or "") -- nil if not a number
 			if tmNumber ~= nil and RandomizerLog.Data.TMs[tmNumber] ~= nil then
 				table.insert(RandomizerLog.Data.Pokemon[pokemonId].TMMoves, tmNumber)
 			end
@@ -456,398 +484,7 @@ function RandomizerLog.printMoveIds()
 end
 
 function RandomizerLog.setupMappings()
-	RandomizerLog.PokemonNameToIdMap = {
-		["bulbasaur"] = 1,
-		["ivysaur"] = 2,
-		["venusaur"] = 3,
-		["charmander"] = 4,
-		["charmeleon"] = 5,
-		["charizard"] = 6,
-		["squirtle"] = 7,
-		["wartortle"] = 8,
-		["blastoise"] = 9,
-		["caterpie"] = 10,
-		["metapod"] = 11,
-		["butterfree"] = 12,
-		["weedle"] = 13,
-		["kakuna"] = 14,
-		["beedrill"] = 15,
-		["pidgey"] = 16,
-		["pidgeotto"] = 17,
-		["pidgeot"] = 18,
-		["rattata"] = 19,
-		["raticate"] = 20,
-		["spearow"] = 21,
-		["fearow"] = 22,
-		["ekans"] = 23,
-		["arbok"] = 24,
-		["pikachu"] = 25,
-		["raichu"] = 26,
-		["sandshrew"] = 27,
-		["sandslash"] = 28,
-		["nidoran f"] = 29,
-		["nidorina"] = 30,
-		["nidoqueen"] = 31,
-		["nidoran m"] = 32,
-		["nidorino"] = 33,
-		["nidoking"] = 34,
-		["clefairy"] = 35,
-		["clefable"] = 36,
-		["vulpix"] = 37,
-		["ninetales"] = 38,
-		["jigglypuff"] = 39,
-		["wigglytuff"] = 40,
-		["zubat"] = 41,
-		["golbat"] = 42,
-		["oddish"] = 43,
-		["gloom"] = 44,
-		["vileplume"] = 45,
-		["paras"] = 46,
-		["parasect"] = 47,
-		["venonat"] = 48,
-		["venomoth"] = 49,
-		["diglett"] = 50,
-		["dugtrio"] = 51,
-		["meowth"] = 52,
-		["persian"] = 53,
-		["psyduck"] = 54,
-		["golduck"] = 55,
-		["mankey"] = 56,
-		["primeape"] = 57,
-		["growlithe"] = 58,
-		["arcanine"] = 59,
-		["poliwag"] = 60,
-		["poliwhirl"] = 61,
-		["poliwrath"] = 62,
-		["abra"] = 63,
-		["kadabra"] = 64,
-		["alakazam"] = 65,
-		["machop"] = 66,
-		["machoke"] = 67,
-		["machamp"] = 68,
-		["bellsprout"] = 69,
-		["weepinbell"] = 70,
-		["victreebel"] = 71,
-		["tentacool"] = 72,
-		["tentacruel"] = 73,
-		["geodude"] = 74,
-		["graveler"] = 75,
-		["golem"] = 76,
-		["ponyta"] = 77,
-		["rapidash"] = 78,
-		["slowpoke"] = 79,
-		["slowbro"] = 80,
-		["magnemite"] = 81,
-		["magneton"] = 82,
-		["farfetch'd"] = 83,
-		["farfetchd"] = 83,
-		["farfetch"] = 83,
-		["doduo"] = 84,
-		["dodrio"] = 85,
-		["seel"] = 86,
-		["dewgong"] = 87,
-		["grimer"] = 88,
-		["muk"] = 89,
-		["shellder"] = 90,
-		["cloyster"] = 91,
-		["gastly"] = 92,
-		["haunter"] = 93,
-		["gengar"] = 94,
-		["onix"] = 95,
-		["drowzee"] = 96,
-		["hypno"] = 97,
-		["krabby"] = 98,
-		["kingler"] = 99,
-		["voltorb"] = 100,
-		["electrode"] = 101,
-		["exeggcute"] = 102,
-		["exeggutor"] = 103,
-		["cubone"] = 104,
-		["marowak"] = 105,
-		["hitmonlee"] = 106,
-		["hitmonchan"] = 107,
-		["lickitung"] = 108,
-		["koffing"] = 109,
-		["weezing"] = 110,
-		["rhyhorn"] = 111,
-		["rhydon"] = 112,
-		["chansey"] = 113,
-		["tangela"] = 114,
-		["kangaskhan"] = 115,
-		["horsea"] = 116,
-		["seadra"] = 117,
-		["goldeen"] = 118,
-		["seaking"] = 119,
-		["staryu"] = 120,
-		["starmie"] = 121,
-		["mr. mime"] = 122,
-		["scyther"] = 123,
-		["jynx"] = 124,
-		["electabuzz"] = 125,
-		["magmar"] = 126,
-		["pinsir"] = 127,
-		["tauros"] = 128,
-		["magikarp"] = 129,
-		["gyarados"] = 130,
-		["lapras"] = 131,
-		["ditto"] = 132,
-		["eevee"] = 133,
-		["vaporeon"] = 134,
-		["jolteon"] = 135,
-		["flareon"] = 136,
-		["porygon"] = 137,
-		["omanyte"] = 138,
-		["omastar"] = 139,
-		["kabuto"] = 140,
-		["kabutops"] = 141,
-		["aerodactyl"] = 142,
-		["snorlax"] = 143,
-		["articuno"] = 144,
-		["zapdos"] = 145,
-		["moltres"] = 146,
-		["dratini"] = 147,
-		["dragonair"] = 148,
-		["dragonite"] = 149,
-		["mewtwo"] = 150,
-		["mew"] = 151,
-
-		["chikorita"] = 152,
-		["bayleef"] = 153,
-		["meganium"] = 154,
-		["cyndaquil"] = 155,
-		["quilava"] = 156,
-		["typhlosion"] = 157,
-		["totodile"] = 158,
-		["croconaw"] = 159,
-		["feraligatr"] = 160,
-		["sentret"] = 161,
-		["furret"] = 162,
-		["hoothoot"] = 163,
-		["noctowl"] = 164,
-		["ledyba"] = 165,
-		["ledian"] = 166,
-		["spinarak"] = 167,
-		["ariados"] = 168,
-		["crobat"] = 169,
-		["chinchou"] = 170,
-		["lanturn"] = 171,
-		["pichu"] = 172,
-		["cleffa"] = 173,
-		["igglybuff"] = 174,
-		["togepi"] = 175,
-		["togetic"] = 176,
-		["natu"] = 177,
-		["xatu"] = 178,
-		["mareep"] = 179,
-		["flaaffy"] = 180,
-		["ampharos"] = 181,
-		["bellossom"] = 182,
-		["marill"] = 183,
-		["azumarill"] = 184,
-		["sudowoodo"] = 185,
-		["politoed"] = 186,
-		["hoppip"] = 187,
-		["skiploom"] = 188,
-		["jumpluff"] = 189,
-		["aipom"] = 190,
-		["sunkern"] = 191,
-		["sunflora"] = 192,
-		["yanma"] = 193,
-		["wooper"] = 194,
-		["quagsire"] = 195,
-		["espeon"] = 196,
-		["umbreon"] = 197,
-		["murkrow"] = 198,
-		["slowking"] = 199,
-		["misdreavus"] = 200,
-		["unown"] = 201,
-		["wobbuffet"] = 202,
-		["girafarig"] = 203,
-		["pineco"] = 204,
-		["forretress"] = 205,
-		["dunsparce"] = 206,
-		["gligar"] = 207,
-		["steelix"] = 208,
-		["snubbull"] = 209,
-		["granbull"] = 210,
-		["qwilfish"] = 211,
-		["scizor"] = 212,
-		["shuckle"] = 213,
-		["heracross"] = 214,
-		["sneasel"] = 215,
-		["teddiursa"] = 216,
-		["ursaring"] = 217,
-		["slugma"] = 218,
-		["magcargo"] = 219,
-		["swinub"] = 220,
-		["piloswine"] = 221,
-		["corsola"] = 222,
-		["remoraid"] = 223,
-		["octillery"] = 224,
-		["delibird"] = 225,
-		["mantine"] = 226,
-		["skarmory"] = 227,
-		["houndour"] = 228,
-		["houndoom"] = 229,
-		["kingdra"] = 230,
-		["phanpy"] = 231,
-		["donphan"] = 232,
-		["porygon2"] = 233,
-		["stantler"] = 234,
-		["smeargle"] = 235,
-		["tyrogue"] = 236,
-		["hitmontop"] = 237,
-		["smoochum"] = 238,
-		["elekid"] = 239,
-		["magby"] = 240,
-		["miltank"] = 241,
-		["blissey"] = 242,
-		["raikou"] = 243,
-		["entei"] = 244,
-		["suicune"] = 245,
-		["larvitar"] = 246,
-		["pupitar"] = 247,
-		["tyranitar"] = 248,
-		["lugia"] = 249,
-		["ho-oh"] = 250,
-		["celebi"] = 251,
-
-		["treecko"] = 277,
-		["grovyle"] = 278,
-		["sceptile"] = 279,
-		["torchic"] = 280,
-		["combusken"] = 281,
-		["blaziken"] = 282,
-		["mudkip"] = 283,
-		["marshtomp"] = 284,
-		["swampert"] = 285,
-		["poochyena"] = 286,
-		["mightyena"] = 287,
-		["zigzagoon"] = 288,
-		["linoone"] = 289,
-		["wurmple"] = 290,
-		["silcoon"] = 291,
-		["beautifly"] = 292,
-		["cascoon"] = 293,
-		["dustox"] = 294,
-		["lotad"] = 295,
-		["lombre"] = 296,
-		["ludicolo"] = 297,
-		["seedot"] = 298,
-		["nuzleaf"] = 299,
-		["shiftry"] = 300,
-		["nincada"] = 301,
-		["ninjask"] = 302,
-		["shedinja"] = 303,
-		["taillow"] = 304,
-		["swellow"] = 305,
-		["shroomish"] = 306,
-		["breloom"] = 307,
-		["spinda"] = 308,
-		["wingull"] = 309,
-		["pelipper"] = 310,
-		["surskit"] = 311,
-		["masquerain"] = 312,
-		["wailmer"] = 313,
-		["wailord"] = 314,
-		["skitty"] = 315,
-		["delcatty"] = 316,
-		["kecleon"] = 317,
-		["baltoy"] = 318,
-		["claydol"] = 319,
-		["nosepass"] = 320,
-		["torkoal"] = 321,
-		["sableye"] = 322,
-		["barboach"] = 323,
-		["whiscash"] = 324,
-		["luvdisc"] = 325,
-		["corphish"] = 326,
-		["crawdaunt"] = 327,
-		["feebas"] = 328,
-		["milotic"] = 329,
-		["carvanha"] = 330,
-		["sharpedo"] = 331,
-		["trapinch"] = 332,
-		["vibrava"] = 333,
-		["flygon"] = 334,
-		["makuhita"] = 335,
-		["hariyama"] = 336,
-		["electrike"] = 337,
-		["manectric"] = 338,
-		["numel"] = 339,
-		["camerupt"] = 340,
-		["spheal"] = 341,
-		["sealeo"] = 342,
-		["walrein"] = 343,
-		["cacnea"] = 344,
-		["cacturne"] = 345,
-		["snorunt"] = 346,
-		["glalie"] = 347,
-		["lunatone"] = 348,
-		["solrock"] = 349,
-		["azurill"] = 350,
-		["spoink"] = 351,
-		["grumpig"] = 352,
-		["plusle"] = 353,
-		["minun"] = 354,
-		["mawile"] = 355,
-		["meditite"] = 356,
-		["medicham"] = 357,
-		["swablu"] = 358,
-		["altaria"] = 359,
-		["wynaut"] = 360,
-		["duskull"] = 361,
-		["dusclops"] = 362,
-		["roselia"] = 363,
-		["slakoth"] = 364,
-		["vigoroth"] = 365,
-		["slaking"] = 366,
-		["gulpin"] = 367,
-		["swalot"] = 368,
-		["tropius"] = 369,
-		["whismur"] = 370,
-		["loudred"] = 371,
-		["exploud"] = 372,
-		["clamperl"] = 373,
-		["huntail"] = 374,
-		["gorebyss"] = 375,
-		["absol"] = 376,
-		["shuppet"] = 377,
-		["banette"] = 378,
-		["seviper"] = 379,
-		["zangoose"] = 380,
-		["relicanth"] = 381,
-		["aron"] = 382,
-		["lairon"] = 383,
-		["aggron"] = 384,
-		["castform"] = 385,
-		["volbeat"] = 386,
-		["illumise"] = 387,
-		["lileep"] = 388,
-		["cradily"] = 389,
-		["anorith"] = 390,
-		["armaldo"] = 391,
-		["ralts"] = 392,
-		["kirlia"] = 393,
-		["gardevoir"] = 394,
-		["bagon"] = 395,
-		["shelgon"] = 396,
-		["salamence"] = 397,
-		["beldum"] = 398,
-		["metang"] = 399,
-		["metagross"] = 400,
-		["regirock"] = 401,
-		["regice"] = 402,
-		["registeel"] = 403,
-		["kyogre"] = 404,
-		["groudon"] = 405,
-		["rayquaza"] = 406,
-		["latias"] = 407,
-		["latios"] = 408,
-		["jirachi"] = 409,
-		["deoxys"] = 410,
-		["chimecho"] = 411,
-	}
+	RandomizerLog.PokemonNameToIdMap = {} -- setup later while parsing the first important log sector
 	RandomizerLog.MoveNameToIdMap = {
 		["pound"] = 1,
 		["karate chop"] = 2,
@@ -1204,10 +841,17 @@ function RandomizerLog.setupMappings()
 		["doom desire"] = 353,
 		["psycho boost"] = 354,
 	}
+	RandomizerLog.AbilityNameToIdMap = {}
+	for _, abilityInfo in ipairs(AbilityData.Abilities) do
+		if abilityInfo.id ~= nil and abilityInfo.name ~= nil and abilityInfo.name ~= "" then
+			RandomizerLog.AbilityNameToIdMap[abilityInfo.name:lower()] = abilityInfo.id
+		end
+	end
 end
 
 function RandomizerLog.removeMappings()
 	RandomizerLog.PokemonNameToIdMap = nil
 	RandomizerLog.MoveNameToIdMap = nil
+	RandomizerLog.AbilityNameToIdMap = nil
 	collectgarbage()
 end

--- a/ironmon_tracker/screens/LogOverlay.lua
+++ b/ironmon_tracker/screens/LogOverlay.lua
@@ -676,7 +676,7 @@ function LogOverlay.buildPagedButtons()
 	end
 
 	LogOverlay.PagedButtons.TMs = {}
-	for tmNumber, moveId in pairs(RandomizerLog.Data.TMs) do
+	for tmNumber, tm in pairs(RandomizerLog.Data.TMs) do
 		local gymLeader, gymNumber, trainerId, filterGroup
 		if gymTMs[tmNumber] ~= nil then
 			gymLeader = gymTMs[tmNumber].leader
@@ -688,12 +688,18 @@ function LogOverlay.buildPagedButtons()
 			gymNumber = 0
 			-- if not a gym TM, then it doesn't have a trainerId or filterGroup
 		end
+		local moveName
+		if MoveData.Moves[tm.moveId] ~= nil then
+			moveName = MoveData.Moves[tm.moveId].name
+		else
+			moveName = tm.name
+		end
 		local button = {
 			type = Constants.ButtonTypes.NO_BORDER,
-			text = string.format("TM%02d  %s", tmNumber, MoveData.Moves[moveId].name),
+			text = string.format("TM%02d  %s", tmNumber, moveName),
 			textColor = "Default text",
 			tmNumber = tmNumber,
-			moveId = moveId,
+			moveId = tm.moveId,
 			gymLeader = gymLeader,
 			gymNumber = gymNumber,
 			trainerId = trainerId,


### PR DESCRIPTION
For cases where the player has modified their rom to replace Pokemon names and move names with custom names. The log viewer now properly parses *most* of this information and displays it. There are some cases where this can fail, such as duplicate custom names (no unique identifier) or weird symbols.

There are quite a few wonky changes necessary to get the parser compatible with custom named logs, so feel free to just skim through this quickly. Mostly just wanted a second set of eyes if anything looks completely out of place here.

I tested on a custom log from a streamer where many Pokémon names and moves are renamed. I also test that it can properly load up different logs and use all info from that log instead of relying on info from the game rom itself. In the past, the abilities of pokemon and the types of pokemon were just retrieved from the rom, but this fails when wanting to view a previous log from a different rom (future feature)