### PR TITLE
Add button to view previous log

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -124,6 +124,7 @@ function Battle.updateBattleStatus()
 		if not Battle.isWildEncounter then
 			GameOverScreen.incrementLosses()
 		end
+		LogOverlay.isGameOver = true
 		GameOverScreen.randomizeAnnouncerQuote()
 		GameOverScreen.nextTeamPokemon()
 		Program.changeScreenView(GameOverScreen)

--- a/ironmon_tracker/data/RandomizerLog.lua
+++ b/ironmon_tracker/data/RandomizerLog.lua
@@ -1,5 +1,7 @@
 -- A collection of tools for viewing a Randomized Pokémon game log
-RandomizerLog = {}
+RandomizerLog = {
+	currentLog = nil,
+}
 
 RandomizerLog.Patterns = {
 	RandomizerVersion = "Randomizer Version:%s*([%d%.]+).*$", -- Note: log file line 1 does NOT start with "Rando..."

--- a/ironmon_tracker/data/RandomizerLog.lua
+++ b/ironmon_tracker/data/RandomizerLog.lua
@@ -1,6 +1,6 @@
 -- A collection of tools for viewing a Randomized Pokémon game log
 RandomizerLog = {
-	currentLog = nil,
+	loadedLogPath = nil, -- Holds the path of the previously loaded log file. This is used to check if a new file needs to be parsed
 }
 
 RandomizerLog.Patterns = {

--- a/ironmon_tracker/screens/ExtrasScreen.lua
+++ b/ironmon_tracker/screens/ExtrasScreen.lua
@@ -113,6 +113,7 @@ function ExtrasScreen.createLogViewButtons()
 				if RandomizerLog.Data.Settings ~= nil then
 					LogOverlay.parseAndDisplay()
 				else
+					LogOverlay.openLogFilePrompt()
 				end
 			end
 

--- a/ironmon_tracker/screens/ExtrasScreen.lua
+++ b/ironmon_tracker/screens/ExtrasScreen.lua
@@ -9,8 +9,8 @@ ExtrasScreen = {
 		resultAboveAverage = "Above average!",
 		resultDecent = "Decent.",
 		resultUnavailable = "Estimate is unavailable.",
-        viewLogFile = "View log",
-		viewPreviousLogFile= "Previous log",
+		viewLogFile = "View log",
+		viewPreviousLogFile = "Previous log",
 	},
 	Colors = {
 		text = "Lower box text",
@@ -107,12 +107,12 @@ function ExtrasScreen.createLogViewButtons()
 		box = viewPrevLogButtonBox,
 		onClick = function(self)
 			Utils.tempDisableBizhawkSound()
-			if not ExtrasScreen.viewPreviousLogFile() then
+			if not LogOverlay.viewLogFile(FileManager.PostFixes.PREVIOUSATTEMPT) then
+				LogOverlay.openLogFilePrompt()
 				-- If the log file was already parsed, re-use that
 				if RandomizerLog.Data.Settings ~= nil then
 					LogOverlay.parseAndDisplay()
 				else
-					GameOverScreen.openLogFilePrompt()
 				end
 			end
 
@@ -231,39 +231,7 @@ function ExtrasScreen.drawScreen()
 	end
 
 	local ivBtn = ExtrasScreen.Buttons.EstimateIVs
-	if ivBtn then
-		Drawing.drawText(topboxX + 4, ivBtn.box[2] + ivBtn.box[4] + 1, ivBtn.ivText, Theme.COLORS[ivBtn.textColor],
+	Drawing.drawText(topboxX + 4, ivBtn.box[2] + ivBtn.box[4] + 1, ivBtn.ivText, Theme.COLORS[ivBtn.textColor],
 		shadowcolor)
-	end
 end
 
-function ExtrasScreen.viewPreviousLogFile()
-	local romname, rompath
-	if Options["Use premade ROMs"] and Options.FILES["ROMs Folder"] ~= nil then
-		-- First make sure the ROMs Folder ends with a slash
-		if Options.FILES["ROMs Folder"]:sub(-1) ~= FileManager.slash then
-			Options.FILES["ROMs Folder"] = Options.FILES["ROMs Folder"] .. FileManager.slash
-		end
-
-		romname = GameSettings.getRomName() or ""
-		rompath = Options.FILES["ROMs Folder"] .. romname .. FileManager.Extensions.GBA_ROM
-		if not FileManager.fileExists(rompath) then
-			romname = romname:gsub(" ", "_")
-			rompath = Options.FILES["ROMs Folder"] .. romname .. FileManager.Extensions.GBA_ROM
-		end
-	elseif Options["Generate ROM each time"] then
-		-- Filename of the AutoRandomized ROM is based on the settings file (for cases of playing Kaizo + Survival + Others)
-		local quickloadFiles = Main.GetQuickloadFiles()
-		local settingsFileName = FileManager.extractFileNameFromPath(quickloadFiles.settingsList[1] or "")
-		romname = string.format("%s %s%s", settingsFileName, FileManager.PostFixes.PREVIOUSATTEMPT,
-		FileManager.Extensions.GBA_ROM)
-		rompath = FileManager.prependDir(romname)
-	end
-
-	local logpath = FileManager.getPathIfExists((rompath or "") .. FileManager.Extensions.RANDOMIZER_LOGFILE)
-	if logpath == nil then
-		return false
-	end
-
-	return LogOverlay.parseAndDisplay(logpath)
-end

--- a/ironmon_tracker/screens/ExtrasScreen.lua
+++ b/ironmon_tracker/screens/ExtrasScreen.lua
@@ -108,7 +108,6 @@ function ExtrasScreen.createLogViewButtons()
 		onClick = function(self)
 			Utils.tempDisableBizhawkSound()
 			if not LogOverlay.viewLogFile(FileManager.PostFixes.PREVIOUSATTEMPT) then
-				LogOverlay.openLogFilePrompt()
 				-- If the log file was already parsed, re-use that
 				if RandomizerLog.Data.Settings ~= nil then
 					LogOverlay.parseAndDisplay()

--- a/ironmon_tracker/screens/ExtrasScreen.lua
+++ b/ironmon_tracker/screens/ExtrasScreen.lua
@@ -58,9 +58,9 @@ ExtrasScreen.Buttons = {
 		end
 	},
 }
--- Creates the buttons for the screen
+-- Creates the log view buttons
 -- Buttons are stored in ExtrasScreen.Buttons
-function ExtrasScreen.CreateButtons()
+function ExtrasScreen.createLogViewButtons()
 
 	local topboxX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN
 	local topboxY = Constants.SCREEN.MARGIN + 10
@@ -90,7 +90,7 @@ function ExtrasScreen.CreateButtons()
 	viewPrevLogButtonBox[1] = viewLogButtonBox[1] + viewLogButtonBox[3] + Constants.SCREEN.MARGIN
 	viewPrevLogButtonBox[2] = viewLogButtonBox[2]
 
-	local ViewLogFile = {
+	local viewLogFile = {
 		type = Constants.ButtonTypes.ICON_BORDER,
 		image = Constants.PixelImages.MAGNIFYING_GLASS,
 		text = ExtrasScreen.Labels.viewLogFile,
@@ -100,7 +100,7 @@ function ExtrasScreen.CreateButtons()
 		end,
 	}
 
-	local ViewPreviousLogFile = {
+	local viewPreviousLogFile = {
 		type = Constants.ButtonTypes.ICON_BORDER,
 		image = Constants.PixelImages.MAGNIFYING_GLASS,
 		text = ExtrasScreen.Labels.viewPreviousLogFile,
@@ -120,12 +120,12 @@ function ExtrasScreen.CreateButtons()
 		end
 	}
 
-	table.insert(ExtrasScreen.Buttons, ViewLogFile)
-	table.insert(ExtrasScreen.Buttons, ViewPreviousLogFile)
+	table.insert(ExtrasScreen.Buttons, viewLogFile)
+	table.insert(ExtrasScreen.Buttons, viewPreviousLogFile)
 end
 
 function ExtrasScreen.initialize()
-	ExtrasScreen.CreateButtons()
+	ExtrasScreen.createLogViewButtons()
 	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4
 	local startY = ExtrasScreen.Buttons[#ExtrasScreen.Buttons].box[2] +
 	ExtrasScreen.Buttons[#ExtrasScreen.Buttons].box[4] + Constants.SCREEN.MARGIN + 2

--- a/ironmon_tracker/screens/ExtrasScreen.lua
+++ b/ironmon_tracker/screens/ExtrasScreen.lua
@@ -64,6 +64,25 @@ ExtrasScreen.Buttons = {
 			Program.changeScreenView(NavigationMenu)
 		end
 	},
+	ViewPreviousLogFile= {
+		type = Constants.ButtonTypes.ICON_BORDER,
+		image = Constants.PixelImages.MAGNIFYING_GLASS,
+		text = ExtrasScreen.Labels.viewPreviousLogFile,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 14, Constants.SCREEN.MARGIN + 129, 112, 16 },
+		onClick = function(self)
+			Utils.tempDisableBizhawkSound()
+			if not ExtrasScreen.viewPreviousLogFile() then
+				-- If the log file was already parsed, re-use that
+				if RandomizerLog.Data.Settings ~= nil then
+					LogOverlay.parseAndDisplay()
+				else
+					GameOverScreen.openLogFilePrompt()
+				end
+			end
+
+			Utils.tempEnableBizhawkSound()
+		end
+	},
 }
 
 function ExtrasScreen.initialize()
@@ -172,4 +191,35 @@ function ExtrasScreen.drawScreen()
 
 	local ivBtn = ExtrasScreen.Buttons.EstimateIVs
 	Drawing.drawText(topboxX + 4, ivBtn.box[2] + ivBtn.box[4] + 1, ivBtn.ivText, Theme.COLORS[ivBtn.textColor], shadowcolor)
+end
+
+function ExtrasScreen.viewPreviousLogFile()
+	local romname, rompath
+	if Options["Use premade ROMs"] and Options.FILES["ROMs Folder"] ~= nil then
+		-- First make sure the ROMs Folder ends with a slash
+		if Options.FILES["ROMs Folder"]:sub(-1) ~= FileManager.slash then
+			Options.FILES["ROMs Folder"] = Options.FILES["ROMs Folder"] .. FileManager.slash
+		end
+
+		romname = GameSettings.getRomName() or ""
+		rompath = Options.FILES["ROMs Folder"] .. romname .. FileManager.Extensions.GBA_ROM
+		if not FileManager.fileExists(rompath) then
+			romname = romname:gsub(" ", "_")
+			rompath = Options.FILES["ROMs Folder"] .. romname .. FileManager.Extensions.GBA_ROM
+		end
+	elseif Options["Generate ROM each time"] then
+		-- Filename of the AutoRandomized ROM is based on the settings file (for cases of playing Kaizo + Survival + Others)
+		local quickloadFiles = Main.GetQuickloadFiles()
+		local settingsFileName = FileManager.extractFileNameFromPath(quickloadFiles.settingsList[1] or "")
+		romname = string.format("%s %s%s", settingsFileName, FileManager.PostFixes.PREVIOUSATTEMPT,
+		FileManager.Extensions.GBA_ROM)
+		rompath = FileManager.prependDir(romname)
+	end
+
+	local logpath = FileManager.getPathIfExists((rompath or "") .. FileManager.Extensions.RANDOMIZER_LOGFILE)
+	if logpath == nil then
+		return false
+	end
+
+	return LogOverlay.parseAndDisplay(logpath)
 end

--- a/ironmon_tracker/screens/ExtrasScreen.lua
+++ b/ironmon_tracker/screens/ExtrasScreen.lua
@@ -9,7 +9,8 @@ ExtrasScreen = {
 		resultAboveAverage = "Above average!",
 		resultDecent = "Decent.",
 		resultUnavailable = "Estimate is unavailable.",
-		viewLogFile = "View the log",
+        viewLogFile = "View log",
+		viewPreviousLogFile= "Past log",
 	},
 	Colors = {
 		text = "Lower box text",
@@ -24,51 +25,60 @@ ExtrasScreen.OptionKeys = {
 	"Display pedometer",
 	"Animated Pokemon popout", -- Text referenced in initialize()
 }
-
+-- Holds all the buttons for the screen
+-- Buttons are created in CreateButtons()
 ExtrasScreen.Buttons = {
-	ViewLogFile = {
+
+
+}
+-- Creates the buttons for the screen
+-- Buttons are stored in ExtrasScreen.Buttons
+function ExtrasScreen.CreateButtons()
+	local tempButtons = {}
+
+	local topboxX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN
+	local topboxY = Constants.SCREEN.MARGIN + 10
+	local topboxWidth = Constants.SCREEN.RIGHT_GAP - (Constants.SCREEN.MARGIN * 2)
+
+	local magnifyingGlassSize = #Constants.PixelImages.MAGNIFYING_GLASS[1]
+	local logViewButtonsWidth = Constants.SCREEN.MARGIN * 2 + magnifyingGlassSize +
+		math.max(math.floor((16 - magnifyingGlassSize) / 2), 0) + 1
+
+	-- Center the two buttons within the top box
+	local viewLogButtonBox = {
+		0,
+		0,
+		Utils.calcWordPixelLength(ExtrasScreen.Labels.viewLogFile) + logViewButtonsWidth,
+		Constants.SCREEN.LINESPACING + 5
+	}
+	local viewPrevLogButtonBox = {
+		0,
+		0,
+		Utils.calcWordPixelLength(ExtrasScreen.Labels.viewPreviousLogFile) + logViewButtonsWidth,
+		Constants.SCREEN.LINESPACING + 5
+	}
+
+	local totalViewLogButtonsWidth = viewLogButtonBox[3] + viewPrevLogButtonBox[3] + Constants.SCREEN.MARGIN
+	viewLogButtonBox[1] = topboxX + (topboxWidth - totalViewLogButtonsWidth) / 2
+	viewLogButtonBox[2] = topboxY + Constants.SCREEN.MARGIN + 1
+	viewPrevLogButtonBox[1] = viewLogButtonBox[1] + viewLogButtonBox[3] + Constants.SCREEN.MARGIN
+	viewPrevLogButtonBox[2] = viewLogButtonBox[2]
+
+	local ViewLogFile = {
 		type = Constants.ButtonTypes.ICON_BORDER,
 		image = Constants.PixelImages.MAGNIFYING_GLASS,
 		text = ExtrasScreen.Labels.viewLogFile,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 30, Constants.SCREEN.MARGIN + 69, 78, 16 },
+		box = viewLogButtonBox,
 		onClick = function(self)
 			Program.changeScreenView(ViewLogWarningScreen)
 		end,
-	},
-	TimeMachine = {
-		type = Constants.ButtonTypes.ICON_BORDER,
-		text = ExtrasScreen.Labels.timeMachineBtn,
-		image = Constants.PixelImages.CLOCK,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 30, Constants.SCREEN.MARGIN + 89, 78, 16},
-		-- isVisible = function() return true end,
-		onClick = function()
-			TimeMachineScreen.buildOutPagedButtons()
-			Program.changeScreenView(TimeMachineScreen)
-		end
-	},
-	EstimateIVs = {
-		type = Constants.ButtonTypes.FULL_BORDER,
-		text = ExtrasScreen.Labels.estimateIvBtn,
-		ivText = "",
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 5, Constants.SCREEN.MARGIN + 109, 130, 11 },
-		onClick = function() ExtrasScreen.displayJudgeMessage() end
-	},
-	Back = {
-		type = Constants.ButtonTypes.FULL_BORDER,
-		text = "Back",
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 112, Constants.SCREEN.MARGIN + 135, 24, 11 },
-		onClick = function(self)
-			ExtrasScreen.Buttons.EstimateIVs.ivText = "" -- keep hidden
-			-- Save all of the Options to the Settings.ini file, and navigate back to the main Tracker screen
-			Main.SaveSettings()
-			Program.changeScreenView(NavigationMenu)
-		end
-	},
-	ViewPreviousLogFile= {
+	}
+
+	local ViewPreviousLogFile = {
 		type = Constants.ButtonTypes.ICON_BORDER,
 		image = Constants.PixelImages.MAGNIFYING_GLASS,
 		text = ExtrasScreen.Labels.viewPreviousLogFile,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 14, Constants.SCREEN.MARGIN + 129, 112, 16 },
+		box = viewPrevLogButtonBox,
 		onClick = function(self)
 			Utils.tempDisableBizhawkSound()
 			if not ExtrasScreen.viewPreviousLogFile() then
@@ -82,12 +92,52 @@ ExtrasScreen.Buttons = {
 
 			Utils.tempEnableBizhawkSound()
 		end
-	},
-}
+	}
+
+	table.insert(tempButtons, ViewLogFile)
+
+	local TimeMachine = {
+		type = Constants.ButtonTypes.ICON_BORDER,
+		text = ExtrasScreen.Labels.timeMachineBtn,
+		image = Constants.PixelImages.CLOCK,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 30, Constants.SCREEN.MARGIN + 89, 78, 16},
+		-- isVisible = function() return true end,
+		onClick = function()
+			TimeMachineScreen.buildOutPagedButtons()
+			Program.changeScreenView(TimeMachineScreen)
+		end
+	}
+	table.insert(tempButtons, TimeMachine)
+	local EstimateIVs = {
+		type = Constants.ButtonTypes.FULL_BORDER,
+		text = ExtrasScreen.Labels.estimateIvBtn,
+		ivText = "",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 5, Constants.SCREEN.MARGIN + 109, 130, 11 },
+		onClick = function() ExtrasScreen.displayJudgeMessage() end
+	}
+	table.insert(tempButtons, EstimateIVs)
+	local Back = {
+		type = Constants.ButtonTypes.FULL_BORDER,
+		text = "Back",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 112, Constants.SCREEN.MARGIN + 135, 24, 11 },
+		onClick = function(self)
+			ExtrasScreen.Buttons.EstimateIVs.ivText = "" -- keep hidden
+			-- Save all of the Options to the Settings.ini file, and navigate back to the main Tracker screen
+			Main.SaveSettings()
+			Program.changeScreenView(NavigationMenu)
+		end
+	}
+	table.insert(tempButtons, Back)
+
+	table.insert(tempButtons, ViewPreviousLogFile)
+	ExtrasScreen.Buttons = tempButtons
+end
 
 function ExtrasScreen.initialize()
+	ExtrasScreen.CreateButtons()
 	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4
-	local startY = Constants.SCREEN.MARGIN + 14
+	local startY = ExtrasScreen.Buttons[#ExtrasScreen.Buttons].box[2] +
+	ExtrasScreen.Buttons[#ExtrasScreen.Buttons].box[4] + Constants.SCREEN.MARGIN + 2
 	local linespacing = Constants.SCREEN.LINESPACING + 1
 
 	for _, optionKey in ipairs(ExtrasScreen.OptionKeys) do
@@ -190,7 +240,10 @@ function ExtrasScreen.drawScreen()
 	end
 
 	local ivBtn = ExtrasScreen.Buttons.EstimateIVs
-	Drawing.drawText(topboxX + 4, ivBtn.box[2] + ivBtn.box[4] + 1, ivBtn.ivText, Theme.COLORS[ivBtn.textColor], shadowcolor)
+	if ivBtn then
+		Drawing.drawText(topboxX + 4, ivBtn.box[2] + ivBtn.box[4] + 1, ivBtn.ivText, Theme.COLORS[ivBtn.textColor],
+		shadowcolor)
+	end
 end
 
 function ExtrasScreen.viewPreviousLogFile()

--- a/ironmon_tracker/screens/ExtrasScreen.lua
+++ b/ironmon_tracker/screens/ExtrasScreen.lua
@@ -10,7 +10,7 @@ ExtrasScreen = {
 		resultDecent = "Decent.",
 		resultUnavailable = "Estimate is unavailable.",
         viewLogFile = "View log",
-		viewPreviousLogFile= "Past log",
+		viewPreviousLogFile= "Previous log",
 	},
 	Colors = {
 		text = "Lower box text",
@@ -28,13 +28,39 @@ ExtrasScreen.OptionKeys = {
 -- Holds all the buttons for the screen
 -- Buttons are created in CreateButtons()
 ExtrasScreen.Buttons = {
-
-
+	TimeMachine = {
+		type = Constants.ButtonTypes.ICON_BORDER,
+		text = ExtrasScreen.Labels.timeMachineBtn,
+		image = Constants.PixelImages.CLOCK,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 30, Constants.SCREEN.MARGIN + 89, 78, 16 },
+		-- isVisible = function() return true end,
+		onClick = function()
+			TimeMachineScreen.buildOutPagedButtons()
+			Program.changeScreenView(TimeMachineScreen)
+		end
+	},
+	EstimateIVs = {
+		type = Constants.ButtonTypes.FULL_BORDER,
+		text = ExtrasScreen.Labels.estimateIvBtn,
+		ivText = "",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 5, Constants.SCREEN.MARGIN + 109, 130, 11 },
+		onClick = function() ExtrasScreen.displayJudgeMessage() end
+	},
+	Back = {
+		type = Constants.ButtonTypes.FULL_BORDER,
+		text = "Back",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 112, Constants.SCREEN.MARGIN + 135, 24, 11 },
+		onClick = function(self)
+			ExtrasScreen.Buttons.EstimateIVs.ivText = "" -- keep hidden
+			-- Save all of the Options to the Settings.ini file, and navigate back to the main Tracker screen
+			Main.SaveSettings()
+			Program.changeScreenView(NavigationMenu)
+		end
+	},
 }
 -- Creates the buttons for the screen
 -- Buttons are stored in ExtrasScreen.Buttons
 function ExtrasScreen.CreateButtons()
-	local tempButtons = {}
 
 	local topboxX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN
 	local topboxY = Constants.SCREEN.MARGIN + 10
@@ -94,43 +120,8 @@ function ExtrasScreen.CreateButtons()
 		end
 	}
 
-	table.insert(tempButtons, ViewLogFile)
-
-	local TimeMachine = {
-		type = Constants.ButtonTypes.ICON_BORDER,
-		text = ExtrasScreen.Labels.timeMachineBtn,
-		image = Constants.PixelImages.CLOCK,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 30, Constants.SCREEN.MARGIN + 89, 78, 16},
-		-- isVisible = function() return true end,
-		onClick = function()
-			TimeMachineScreen.buildOutPagedButtons()
-			Program.changeScreenView(TimeMachineScreen)
-		end
-	}
-	table.insert(tempButtons, TimeMachine)
-	local EstimateIVs = {
-		type = Constants.ButtonTypes.FULL_BORDER,
-		text = ExtrasScreen.Labels.estimateIvBtn,
-		ivText = "",
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 5, Constants.SCREEN.MARGIN + 109, 130, 11 },
-		onClick = function() ExtrasScreen.displayJudgeMessage() end
-	}
-	table.insert(tempButtons, EstimateIVs)
-	local Back = {
-		type = Constants.ButtonTypes.FULL_BORDER,
-		text = "Back",
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 112, Constants.SCREEN.MARGIN + 135, 24, 11 },
-		onClick = function(self)
-			ExtrasScreen.Buttons.EstimateIVs.ivText = "" -- keep hidden
-			-- Save all of the Options to the Settings.ini file, and navigate back to the main Tracker screen
-			Main.SaveSettings()
-			Program.changeScreenView(NavigationMenu)
-		end
-	}
-	table.insert(tempButtons, Back)
-
-	table.insert(tempButtons, ViewPreviousLogFile)
-	ExtrasScreen.Buttons = tempButtons
+	table.insert(ExtrasScreen.Buttons, ViewLogFile)
+	table.insert(ExtrasScreen.Buttons, ViewPreviousLogFile)
 end
 
 function ExtrasScreen.initialize()

--- a/ironmon_tracker/screens/GameOverScreen.lua
+++ b/ironmon_tracker/screens/GameOverScreen.lua
@@ -143,12 +143,12 @@ GameOverScreen.Buttons = {
 		onClick = function(self)
 			Utils.tempDisableBizhawkSound()
 
-			if not GameOverScreen.viewLogFile() then
+			if not LogOverlay.viewLogFile(FileManager.PostFixes.AUTORANDOMIZED) then
 				-- If the log file was already parsed, re-use that
 				if RandomizerLog.Data.Settings ~= nil then
 					LogOverlay.parseAndDisplay()
 				else
-					GameOverScreen.openLogFilePrompt()
+					LogOverlay.openLogFilePrompt()
 				end
 			end
 
@@ -323,56 +323,7 @@ function GameOverScreen.saveCurrentGameFiles()
 	return true
 end
 
---Attempts to get the Randomizer log filepath based on the currently loaded ROM's filepath (usually both in same folder)
-function GameOverScreen.viewLogFile()
-	local romname, rompath
-	if Options["Use premade ROMs"] and Options.FILES["ROMs Folder"] ~= nil then
-		-- First make sure the ROMs Folder ends with a slash
-		if Options.FILES["ROMs Folder"]:sub(-1) ~= FileManager.slash then
-			Options.FILES["ROMs Folder"] = Options.FILES["ROMs Folder"] .. FileManager.slash
-		end
 
-		romname = GameSettings.getRomName() or ""
-		rompath = Options.FILES["ROMs Folder"] .. romname .. FileManager.Extensions.GBA_ROM
-		if not FileManager.fileExists(rompath) then
-			romname = romname:gsub(" ", "_")
-			rompath = Options.FILES["ROMs Folder"] .. romname .. FileManager.Extensions.GBA_ROM
-		end
-	elseif Options["Generate ROM each time"] then
-		-- Filename of the AutoRandomized ROM is based on the settings file (for cases of playing Kaizo + Survival + Others)
-		local quickloadFiles = Main.GetQuickloadFiles()
-		local settingsFileName = FileManager.extractFileNameFromPath(quickloadFiles.settingsList[1] or "")
-		romname = string.format("%s %s%s", settingsFileName, FileManager.PostFixes.AUTORANDOMIZED, FileManager.Extensions.GBA_ROM)
-		rompath = FileManager.prependDir(romname)
-	end
-
-	local logpath = FileManager.getPathIfExists((rompath or "") .. FileManager.Extensions.RANDOMIZER_LOGFILE)
-	if logpath == nil then
-		return false
-	end
-
-	return LogOverlay.parseAndDisplay(logpath)
-end
-
--- Prompts user to select a log file to parse, then displays the parsed data on a new left-screen
-function GameOverScreen.openLogFilePrompt()
-	local suggestedFileName = (GameSettings.getRomName() or "") .. FileManager.Extensions.RANDOMIZER_LOGFILE
-	local filterOptions = "Randomizer Log (*.log)|*.log|All files (*.*)|*.*"
-
-	local workingDir = FileManager.dir
-	if workingDir ~= "" then
-		workingDir = workingDir:sub(1, -2) -- remove trailing slash
-	end
-
-	Utils.tempDisableBizhawkSound()
-
-	local filepath = forms.openfile(suggestedFileName, workingDir, filterOptions)
-	if filepath ~= nil and filepath ~= "" then
-		LogOverlay.parseAndDisplay(filepath)
-	end
-
-	Utils.tempEnableBizhawkSound()
-end
 
 -- USER INPUT FUNCTIONS
 function GameOverScreen.checkInput(xmouse, ymouse)

--- a/ironmon_tracker/screens/GameOverScreen.lua
+++ b/ironmon_tracker/screens/GameOverScreen.lua
@@ -70,6 +70,7 @@ GameOverScreen.Buttons = {
 			if Battle.defeatedSteven then
 				Battle.defeatedSteven = false
 			end
+			LogOverlay.isGameOver = false
 			LogOverlay.isDisplayed = false
 			GameOverScreen.refreshButtons()
 			Program.changeScreenView(TrackerScreen)

--- a/ironmon_tracker/screens/LogOverlay.lua
+++ b/ironmon_tracker/screens/LogOverlay.lua
@@ -466,6 +466,11 @@ function LogOverlay.initialize()
 end
 
 function LogOverlay.parseAndDisplay(logpath)
+	-- Check for what log we're trying to display, and if it's already been parsed
+	if RandomizerLog.currentLog ~= logpath then
+		RandomizerLog.Data = {}
+		RandomizerLog.currentLog = logpath
+	end
 	-- Check first if data has already been loaded and parsed
 	if RandomizerLog.Data.Settings ~= nil or RandomizerLog.parseLog(logpath) then
 		LogOverlay.isDisplayed = true

--- a/ironmon_tracker/screens/LogOverlay.lua
+++ b/ironmon_tracker/screens/LogOverlay.lua
@@ -33,7 +33,8 @@ LogOverlay = {
 	currentEvoSet = 1, -- Ideally move this somewhere else
 	prevEvosPerSet = 1,
 	evosPerSet = 3, -- Ideally move this somewhere else
-	preEvoSetting = "Show Pre Evolutions"
+    preEvoSetting = "Show Pre Evolutions",
+	isGameOver = false, -- Set to true when game is over, so we known to show game over screen if X is pressed
 }
 
 LogOverlay.Windower = {
@@ -272,7 +273,11 @@ LogOverlay.TabBarButtons = {
 			if self.image == Constants.PixelImages.CLOSE then
 				LogOverlay.TabHistory = {}
 				LogOverlay.isDisplayed = false
-				Program.changeScreenView(GameOverScreen)
+				if LogOverlay.isGameOver then
+					Program.changeScreenView(GameOverScreen)
+				else
+					Program.changeScreenView(TrackerScreen)
+				end
 			else -- Constants.PixelImages.PREVIOUS_BUTTON
 				LogOverlay.Windower:changeTab(LogOverlay.Tabs.GO_BACK)
 				Program.redraw(true)

--- a/ironmon_tracker/screens/LogOverlay.lua
+++ b/ironmon_tracker/screens/LogOverlay.lua
@@ -33,7 +33,7 @@ LogOverlay = {
 	currentEvoSet = 1, -- Ideally move this somewhere else
 	prevEvosPerSet = 1,
 	evosPerSet = 3, -- Ideally move this somewhere else
-    preEvoSetting = "Show Pre Evolutions",
+	preEvoSetting = "Show Pre Evolutions",
 	isGameOver = false, -- Set to true when game is over, so we known to show game over screen if X is pressed
 }
 
@@ -472,9 +472,9 @@ end
 
 function LogOverlay.parseAndDisplay(logpath)
 	-- Check for what log we're trying to display, and if it's already been parsed
-	if RandomizerLog.currentLog ~= logpath then
+	if RandomizerLog.loadedLogPath ~= logpath then
 		RandomizerLog.Data = {}
-		RandomizerLog.currentLog = logpath
+		RandomizerLog.loadedLogPath = logpath
 	end
 	-- Check first if data has already been loaded and parsed
 	if RandomizerLog.Data.Settings ~= nil or RandomizerLog.parseLog(logpath) then
@@ -2056,4 +2056,59 @@ function LogOverlay.drawTrainerZoomed(x, y, width, height)
 	end
 
 	return borderColor, shadowcolor
+end
+
+--- Views the log file via the log overlay screen
+--- @param postFix string The file's postFix, most likely FileManager.PostFixes.AUTORANDOMIZED or FileManager.PostFixes.PREVIOUSATTEMPT
+--- @return boolean LogOverlay.isDisplayed
+function LogOverlay.viewLogFile(postFix)
+	if postFix == nil then postFix = FileManager.PostFixes.AUTORANDOMIZED end
+	local romname, rompath
+	if Options["Use premade ROMs"] and Options.FILES["ROMs Folder"] ~= nil then
+		-- First make sure the ROMs Folder ends with a slash
+		if Options.FILES["ROMs Folder"]:sub(-1) ~= FileManager.slash then
+			Options.FILES["ROMs Folder"] = Options.FILES["ROMs Folder"] .. FileManager.slash
+		end
+
+		romname = GameSettings.getRomName() or ""
+		rompath = Options.FILES["ROMs Folder"] .. romname .. FileManager.Extensions.GBA_ROM
+		if not FileManager.fileExists(rompath) then
+			romname = romname:gsub(" ", "_")
+			rompath = Options.FILES["ROMs Folder"] .. romname .. FileManager.Extensions.GBA_ROM
+		end
+	elseif Options["Generate ROM each time"] then
+		-- Filename of the AutoRandomized ROM is based on the settings file (for cases of playing Kaizo + Survival + Others)
+		local quickloadFiles = Main.GetQuickloadFiles()
+		local settingsFileName = FileManager.extractFileNameFromPath(quickloadFiles.settingsList[1] or "")
+		romname = string.format("%s %s%s", settingsFileName, postFix, FileManager.Extensions.GBA_ROM)
+		rompath = FileManager.prependDir(romname)
+	end
+
+	local logpath = FileManager.getPathIfExists((rompath or "") .. FileManager.Extensions.RANDOMIZER_LOGFILE)
+	if logpath == nil then
+		return false
+	end
+
+	return LogOverlay.parseAndDisplay(logpath)
+end
+
+--- Prompts user to select a log file to parse, then displays the parsed data on a new left-screen
+--- @return nil
+function LogOverlay.openLogFilePrompt()
+	local suggestedFileName = (GameSettings.getRomName() or "") .. FileManager.Extensions.RANDOMIZER_LOGFILE
+	local filterOptions = "Randomizer Log (*.log)|*.log|All files (*.*)|*.*"
+
+	local workingDir = FileManager.dir
+	if workingDir ~= "" then
+		workingDir = workingDir:sub(1, -2) -- remove trailing slash
+	end
+
+	Utils.tempDisableBizhawkSound()
+
+	local filepath = forms.openfile(suggestedFileName, workingDir, filterOptions)
+	if filepath ~= nil and filepath ~= "" then
+		LogOverlay.parseAndDisplay(filepath)
+	end
+
+	Utils.tempEnableBizhawkSound()
 end

--- a/ironmon_tracker/screens/ViewLogWarningScreen.lua
+++ b/ironmon_tracker/screens/ViewLogWarningScreen.lua
@@ -44,12 +44,12 @@ ViewLogWarningScreen.Buttons = {
 		onClick = function(self)
 			-- Function lifted from GameOverScreen.lua
 			Utils.tempDisableBizhawkSound()
-			if not GameOverScreen.viewLogFile() then
+			if not LogOverlay.viewLogFile(FileManager.PostFixes.AUTORANDOMIZED) then
 				-- If the log file was already parsed, re-use that
 				if RandomizerLog.Data.Settings ~= nil then
 					LogOverlay.parseAndDisplay()
 				else
-					GameOverScreen.openLogFilePrompt()
+					LogOverlay.openLogFilePrompt()
 				end
 			end
 


### PR DESCRIPTION
I also fixed the tracker always showing the game over screen when exiting the log overlay, now it should only show the game over screen if an actual game over has occurred before the log overlay was shown.

Video shows me navigating the deoxys in the log viewer just to show that all pokemon are parsed with the recent log viewer changes in dev

https://user-images.githubusercontent.com/19582161/226546464-c2c447da-d9c5-42f2-b27d-fa28287baaf5.mov

