### PR TITLE
InfoScreen Header Adjustments

### DIFF
--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -16,6 +16,7 @@ Constants.SCREEN = {
 
 Constants.Font = {
 	SIZE = 9,
+	HEADERSIZE = 16,
 	FAMILY = "Franklin Gothic Medium",
 	STYLE = "regular", -- Style options are: regular, bold, italic, strikethrough, underline
 }

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -75,6 +75,21 @@ function Drawing.drawText(x, y, text, color, shadowcolor, size, family, style)
 	gui.drawText(x, y, text, color, nil, size or Constants.Font.SIZE, family or Constants.Font.FAMILY, style)
 end
 
+function Drawing.drawHeader(x, y, text, color, shadowcolor, size, family, style)
+	-- For some reason on Linux the text is offset by 1 pixel (tested on Bizhawk 2.9)
+	if Main.OS == "Linux" then
+		x = x + 1
+		y = y - 1
+	end
+
+	-- For now, don't draw shadows for smaller-than-normal text (old behavior)
+	if Theme.DRAW_TEXT_SHADOWS and shadowcolor ~= nil and size == nil then
+		gui.drawText(x + 1, y + 1, text, shadowcolor, nil, size or Constants.Font.HEADERSIZE, family or Constants.Font.FAMILY, style)
+	end
+	-- void gui.drawText(x, y, message, forecolor, backcolor, fontsize, fontfamily, fontstyle, horizalign, vertalign, surfacename)
+	gui.drawText(x, y, text, color, nil, size or Constants.Font.HEADERSIZE, family or Constants.Font.FAMILY, style)
+end
+
 function Drawing.drawNumber(x, y, number, spacing, color, shadowcolor, size, family, style)
 	if Options["Right justified numbers"] then
 		Drawing.drawRightJustifiedNumber(x, y, number, spacing, color, shadowcolor, size, family, style)

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -35,7 +35,7 @@ InfoScreen.Buttons = {
 		type = Constants.ButtonTypes.PIXELIMAGE,
 		image = Constants.PixelImages.MAGNIFYING_GLASS,
 		textColor = "Default text",
-		box = { Constants.SCREEN.WIDTH + 92, 9, 10, 10, },
+		box = { Constants.SCREEN.WIDTH + 93, 21, 10, 10, },
 		boxColors = { "Upper box border", "Upper box background" },
 		isVisible = function() return InfoScreen.viewScreen == InfoScreen.Screens.POKEMON_INFO end,
 		onClick = function(self) InfoScreen.openPokemonInfoWindow() end
@@ -44,7 +44,7 @@ InfoScreen.Buttons = {
 		type = Constants.ButtonTypes.PIXELIMAGE,
 		image = Constants.PixelImages.RIGHT_ARROW,
 		textColor = "Default text",
-		box = { Constants.SCREEN.WIDTH + 99, 23, 10, 10, },
+		box = { Constants.SCREEN.WIDTH + 100, 31, 10, 10, },
 		boxColors = { "Upper box border", "Upper box background" },
 		isVisible = function() return InfoScreen.viewScreen == InfoScreen.Screens.POKEMON_INFO end,
 		onClick = function(self) InfoScreen.showNextPokemon() end
@@ -53,7 +53,7 @@ InfoScreen.Buttons = {
 		type = Constants.ButtonTypes.PIXELIMAGE,
 		image = Constants.PixelImages.LEFT_ARROW,
 		textColor = "Default text",
-		box = { Constants.SCREEN.WIDTH + 85, 23, 10, 10, },
+		box = { Constants.SCREEN.WIDTH + 87, 31, 10, 10, },
 		boxColors = { "Upper box border", "Upper box background" },
 		isVisible = function() return InfoScreen.viewScreen == InfoScreen.Screens.POKEMON_INFO end,
 		onClick = function(self) InfoScreen.showNextPokemon(-1) end
@@ -191,7 +191,7 @@ InfoScreen.Buttons = {
 		type = Constants.ButtonTypes.PIXELIMAGE,
 		image = Constants.PixelImages.LEFT_ARROW,
 		textColor = "Default text",
-		box = { Constants.SCREEN.WIDTH + 116, Constants.SCREEN.MARGIN + 31, 10, 10 },
+		box = { Constants.SCREEN.WIDTH + 113, Constants.SCREEN.MARGIN + 40, 10, 10 },
 		isVisible = function()
 			if InfoScreen.viewScreen ~= InfoScreen.Screens.MOVE_INFO or InfoScreen.infoLookup ~= 237 then return false end
 			-- Only reveal the HP set arrows if the player's active Pokemon has the move
@@ -224,7 +224,7 @@ InfoScreen.Buttons = {
 		type = Constants.ButtonTypes.PIXELIMAGE,
 		image = Constants.PixelImages.RIGHT_ARROW,
 		textColor = "Default text",
-		box = { Constants.SCREEN.WIDTH + 129, Constants.SCREEN.MARGIN + 31, 10, 10 },
+		box = { Constants.SCREEN.WIDTH + 130, Constants.SCREEN.MARGIN + 40, 10, 10 },
 		isVisible = function() return InfoScreen.Buttons.HiddenPowerPrev:isVisible() end,
 		onClick = function(self)
 			-- If the player's lead pokemon has Hidden Power, lookup that tracked typing
@@ -600,10 +600,7 @@ function InfoScreen.drawPokemonInfoScreen(pokemonID)
 	-- POKEMON NAME
 	offsetY = offsetY - 3
 	local pokemonName = data.p.name:upper()
-	if Theme.DRAW_TEXT_SHADOWS then
-		Drawing.drawText(offsetX + 1 - 1, offsetY + 1, pokemonName, boxInfoTopShadow, nil, 12, Constants.Font.FAMILY, "bold")
-	end
-	Drawing.drawText(offsetX - 1, offsetY, pokemonName, Theme.COLORS["Default text"], nil, 12, Constants.Font.FAMILY, "bold")
+	Drawing.drawHeader(offsetX - 1, offsetY - 1, pokemonName, Theme.COLORS["Default text"], boxInfoTopShadow, 15)
 
 	-- POKEMON ICON & TYPES
 	offsetY = offsetY - 7
@@ -618,7 +615,7 @@ function InfoScreen.drawPokemonInfoScreen(pokemonID)
 	if data.p.types[2] ~= data.p.types[1] then
 		Drawing.drawTypeIcon(data.p.types[2], offsetX + 106, offsetY + 49)
 	end
-	offsetY = offsetY + 11 + linespacing
+	offsetY = offsetY + 12 + linespacing
 
 	-- BST
 	Drawing.drawText(offsetX, offsetY, "BST:", Theme.COLORS["Default text"], boxInfoTopShadow)
@@ -775,21 +772,19 @@ function InfoScreen.drawMoveInfoScreen(moveId)
 
 	-- MOVE NAME
 	data.m.name = data.m.name:upper()
-	if Theme.DRAW_TEXT_SHADOWS then
-		Drawing.drawText(offsetX + 1 - 1, offsetY + 1 - 3, data.m.name, boxInfoTopShadow, nil, 12, Constants.Font.FAMILY, "bold")
-	end
-	Drawing.drawText(offsetX - 1, offsetY - 3, data.m.name, Theme.COLORS["Default text"], nil, 12, Constants.Font.FAMILY, "bold")
+	Drawing.drawHeader(offsetX - 1, offsetY - 4, data.m.name, Theme.COLORS["Default text"], boxInfoTopShadow)
 
-	if data.x.ownHasHiddenPower then
-		Drawing.drawText(offsetX + 103, offsetY + linespacing * 2 - 4, "Set type", Theme.COLORS["Positive text"], boxInfoTopShadow)
-	end
 
 	-- TYPE ICON
-	offsetY = offsetY + 1
+	offsetY = offsetY + linespacing + 4
 	gui.drawRectangle(offsetX + 106, offsetY + 1, 31, 13, boxInfoTopShadow, boxInfoTopShadow)
 	gui.drawRectangle(offsetX + 105, offsetY, 31, 13, Theme.COLORS["Upper box border"], Theme.COLORS["Upper box border"])
 	Drawing.drawTypeIcon(data.m.type, offsetX + 106, offsetY + 1)
-	offsetY = offsetY + linespacing
+	offsetY = offsetY - 2
+
+	if data.x.ownHasHiddenPower then
+		Drawing.drawText(offsetX + 103, offsetY + linespacing * 2 - 6, "Set type", Theme.COLORS["Positive text"], boxInfoTopShadow)
+	end
 
 	-- CATEGORY
 	if data.m.category == MoveData.Categories.PHYSICAL then
@@ -886,10 +881,7 @@ function InfoScreen.drawAbilityInfoScreen(abilityId)
 
 	-- Ability NAME
 	data.a.name = data.a.name:upper():gsub(" ", "  ")
-	if Theme.DRAW_TEXT_SHADOWS then
-		Drawing.drawText(offsetX - 1 + 1, offsetY + 1 - 3, data.a.name, boxInfoTopShadow, nil, 12, Constants.Font.FAMILY, "bold")
-	end
-	Drawing.drawText(offsetX - 1, offsetY - 3, data.a.name, Theme.COLORS["Default text"], nil, 12, Constants.Font.FAMILY, "bold")
+	Drawing.drawHeader(offsetX - 1, offsetY - 3, data.a.name, Theme.COLORS["Default text"], boxInfoTopShadow)
 
 	--SEARCH ICON
 	local lookupAbility = InfoScreen.Buttons.LookupAbility


### PR DESCRIPTION
- Adds `Drawing.drawHeader`, which functions similarly to `Drawing.drawText` but instead using `Constants.Font.HEADERSIZE` as the default font size (set to 16)
- Changes the InfoScreen headers from size 12 bold font to size 16 regular font, to space the text out better horizontally to be more legible
- As a result, elements on the InfoScreen pages for pokémon and moves had to be adjusted, as the header takes up more horizontal space than before

Example images of how the changed InfoScreens look with the update:
![image](https://user-images.githubusercontent.com/106463662/228085104-73a8864c-f626-4c2b-8b14-2baa88700086.png)
![image](https://user-images.githubusercontent.com/106463662/228085327-53fe6429-14c5-432c-bc2c-2338c6a2f39e.png)
![image](https://user-images.githubusercontent.com/106463662/228085146-db17c581-f96c-4243-807c-9310b921306a.png)
