### PR TITLE
Fix Levitate ability revealing under some conditions when it shouldn't

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -570,7 +570,7 @@ function Battle.checkAbilitiesToTrack()
 
 	local levitateCheck = Memory.readbyte(GameSettings.gBattleCommunication + 0x6)
 	for i = 0, Battle.numBattlers - 1, 1 do
-		if levitateCheck == 4 and Battle.attacker ~= i then
+		if levitateCheck == 4 and Battle.attacker ~= i and Battle.attacker ~= Battle.battlerTarget then
 			combatantIndexesToTrack[Battle.battlerTarget] = Battle.battlerTarget
 		--check for first Damp mon
 		elseif abilityMsg ~= nil and abilityMsg.scope == "both" then


### PR DESCRIPTION
- Fixes an issue where the attacking pokemon was updated from memory about a frame before the levitate message was cleared, so very rarely the attacking mon would have its ability tracked at the end of levitate proccing.