### PR TITLE
Patch 8.0.1

### DIFF
--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -582,7 +582,7 @@ function Drawing.drawRepelUsage()
 	local xOffset = Constants.SCREEN.WIDTH - 24
 	local yOffset = 0
 	if Options["Display play time"] and Program.GameTimer.location == "UpperRight" then
-		yOffset = Program.GameTimer.box.height + Program.GameTimer.box.margin + 1
+		yOffset = (Program.GameTimer.box.height or 9) + (Program.GameTimer.margin or 0) + 1
 	end
 	-- Draw repel item icon
 	local repelImage = FileManager.buildImagePath(FileManager.Folders.Icons, FileManager.Files.Other.REPEL)

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -175,11 +175,13 @@ function Input.checkMouseInput(xmouse, ymouse)
 
 	Program.GameTimer:checkInput(xmouse, ymouse)
 
-	-- The extra screens don't occupy the same screen space and need their own check
+	-- The extra screens don't occupy the same screen space and need their own check; order matters
 	if TeamViewArea.isDisplayed() then
 		TeamViewArea.checkInput(xmouse, ymouse)
 	end
-	if LogOverlay.isDisplayed then
+	if UpdateScreen.showNotes then
+		Input.checkButtonsClicked(xmouse, ymouse, UpdateScreen.Pager.Buttons)
+	elseif LogOverlay.isDisplayed then
 		LogOverlay.checkInput(xmouse, ymouse)
 	end
 end

--- a/ironmon_tracker/Languages/English.lua
+++ b/ironmon_tracker/Languages/English.lua
@@ -3134,7 +3134,7 @@ GameResources{
 		},
 		{
 			NameKey = "Shield Dust",
-			Description = "Unaffected by secondary effects of damaging moves.",
+			Description = "Unaffected by the additional effects of other Pokémon's damaging moves. For example, a Pokémon with this ability cannot be frozen by Blizzard or made to flinch by Fake Out.",
 		},
 		{
 			NameKey = "Own Tempo",

--- a/ironmon_tracker/Languages/French.lua
+++ b/ironmon_tracker/Languages/French.lua
@@ -2720,7 +2720,7 @@ GameResources{
 		},
 		{
 			NameKey = "Shield Dust",
-			Description = "Unaffected by secondary effects of damaging moves.", -- NEEDS TRANSLATION
+			Description = "Unaffected by the additional effects of other Pokémon's damaging moves. For example, a Pokémon with this ability cannot be frozen by Blizzard or made to flinch by Fake Out.", -- NEEDS TRANSLATION
 		},
 		{
 			NameKey = "Own Tempo",

--- a/ironmon_tracker/Languages/German.lua
+++ b/ironmon_tracker/Languages/German.lua
@@ -2720,7 +2720,7 @@ GameResources{
 		},
 		{
 			NameKey = "Shield Dust",
-			Description = "Unaffected by secondary effects of damaging moves.", -- NEEDS TRANSLATION
+			Description = "Unaffected by the additional effects of other Pokémon's damaging moves. For example, a Pokémon with this ability cannot be frozen by Blizzard or made to flinch by Fake Out.", -- NEEDS TRANSLATION
 		},
 		{
 			NameKey = "Own Tempo",

--- a/ironmon_tracker/Languages/Italian.lua
+++ b/ironmon_tracker/Languages/Italian.lua
@@ -2720,7 +2720,7 @@ GameResources{
 		},
 		{
 			NameKey = "Shield Dust",
-			Description = "Unaffected by secondary effects of damaging moves.", -- NEEDS TRANSLATION
+			Description = "Unaffected by the additional effects of other Pokémon's damaging moves. For example, a Pokémon with this ability cannot be frozen by Blizzard or made to flinch by Fake Out.", -- NEEDS TRANSLATION
 		},
 		{
 			NameKey = "Own Tempo",

--- a/ironmon_tracker/Languages/Japanese.lua
+++ b/ironmon_tracker/Languages/Japanese.lua
@@ -3136,7 +3136,7 @@ GameResources{
 		},
 		{
 			NameKey = "Shield Dust",
-			Description = "Unaffected by secondary effects of damaging moves.", -- NEEDS TRANSLATION
+			Description = "Unaffected by the additional effects of other Pokémon's damaging moves. For example, a Pokémon with this ability cannot be frozen by Blizzard or made to flinch by Fake Out.", -- NEEDS TRANSLATION
 		},
 		{
 			NameKey = "Own Tempo",

--- a/ironmon_tracker/Languages/Spanish.lua
+++ b/ironmon_tracker/Languages/Spanish.lua
@@ -2720,7 +2720,7 @@ GameResources{
 		},
 		{
 			NameKey = "Shield Dust",
-			Description = "Unaffected by secondary effects of damaging moves.", -- NEEDS TRANSLATION
+			Description = "Unaffected by the additional effects of other Pokémon's damaging moves. For example, a Pokémon with this ability cannot be frozen by Blizzard or made to flinch by Fake Out.", -- NEEDS TRANSLATION
 		},
 		{
 			NameKey = "Own Tempo",

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -26,6 +26,8 @@ function Main.Initialize()
 	Main.Version.showUpdate = false
 	-- Informs the Tracker to perform an update the next time that Tracker is loaded.
 	Main.Version.updateAfterRestart = false
+	-- Used to display the release notes once, after each new version update
+	Main.Version.showReleaseNotes = false
 
 	Main.MetaSettings = {}
 	Main.CrashReport = {
@@ -298,6 +300,14 @@ function Main.AfterStartupScreenRedirect()
 	if Main.CrashReport.crashedOccurred then
 		CrashRecoveryScreen.previousScreen = Program.currentScreen
 		Program.changeScreenView(CrashRecoveryScreen)
+	end
+
+	if Main.Version.showReleaseNotes then
+		UpdateScreen.showNotes = true
+		Main.Version.showReleaseNotes = false
+		UpdateScreen.buildOutPagedButtons()
+		UpdateScreen.refreshButtons()
+		Main.SaveSettings(true)
 	end
 
 	if Main.Version.updateAfterRestart then
@@ -899,6 +909,9 @@ function Main.LoadSettings()
 		if settings.config.UpdateAfterRestart ~= nil then
 			Main.Version.updateAfterRestart = settings.config.UpdateAfterRestart
 		end
+		if settings.config.ShowReleaseNotes ~= nil then
+			Main.Version.showReleaseNotes = settings.config.ShowReleaseNotes
+		end
 
 		for configKey, _ in pairs(Options.FILES) do
 			local configValue = settings.config[string.gsub(configKey, " ", "_")]
@@ -1002,6 +1015,7 @@ function Main.SaveSettings(forced)
 	settings.config.DateLastChecked = Main.Version.dateChecked
 	settings.config.ShowUpdateNotification = Main.Version.showUpdate
 	settings.config.UpdateAfterRestart = Main.Version.updateAfterRestart
+	settings.config.ShowReleaseNotes = Main.Version.showReleaseNotes
 
 	for configKey, _ in pairs(Options.FILES) do
 		local encodedKey = string.gsub(configKey, " ", "_")

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "8", minor = "0", patch = "0" }
+Main.Version = { major = "8", minor = "0", patch = "1" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -26,8 +26,8 @@ function Main.Initialize()
 	Main.Version.showUpdate = false
 	-- Informs the Tracker to perform an update the next time that Tracker is loaded.
 	Main.Version.updateAfterRestart = false
-	-- Used to display the release notes once, after each new version update
-	Main.Version.showReleaseNotes = false
+	-- Used to display the release notes once, after each new version update. Defaults true for updates that didn't have this
+	Main.Version.showReleaseNotes = true
 
 	Main.MetaSettings = {}
 	Main.CrashReport = {

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -293,13 +293,14 @@ function Main.DisplayError(errMessage)
 end
 
 function Main.AfterStartupScreenRedirect()
-	if not Main.IsOnBizhawk() or Main.hasRunOnce then
+	if not Main.IsOnBizhawk() then
 		return
 	end
 
 	if Main.CrashReport.crashedOccurred then
 		CrashRecoveryScreen.previousScreen = Program.currentScreen
 		Program.changeScreenView(CrashRecoveryScreen)
+		return
 	end
 
 	if Main.Version.showReleaseNotes then
@@ -310,7 +311,7 @@ function Main.AfterStartupScreenRedirect()
 		Main.SaveSettings(true)
 	end
 
-	if Main.Version.updateAfterRestart then
+	if Main.Version.updateAfterRestart and not Main.hasRunOnce then
 		UpdateScreen.currentState = UpdateScreen.States.NOT_UPDATED
 		Program.changeScreenView(UpdateScreen)
 	end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -255,8 +255,10 @@ function Program.redraw(forced)
 		Program.ActiveRepel:draw()
 		Program.GameTimer:draw()
 
-		-- The LogOverlay viewer doesn't occupy the same screen space and needs its own check
-		if LogOverlay.isDisplayed then
+		-- These screens occupy the main game screen space, overlayed on top, and need their own check; order matters
+		if UpdateScreen.showNotes then
+			UpdateScreen.drawReleaseNotesOverlay()
+		elseif LogOverlay.isDisplayed then
 			LogOverlay.drawScreen()
 		end
 

--- a/ironmon_tracker/screens/MoveHistoryScreen.lua
+++ b/ironmon_tracker/screens/MoveHistoryScreen.lua
@@ -100,6 +100,13 @@ function MoveHistoryScreen.buildOutHistory(pokemonID, startingLevel)
 				textColor = MoveHistoryScreen.Colors.text,
 				trackedMove = tMove,
 				isVisible = function(self) return self.pageVisible == MoveHistoryScreen.Pagination.currentPage end,
+				draw = function(self, shadowcolor)
+					-- Implied move text is drawn, then the levels off to the right-side
+					local minLvTxt = self.trackedMove.minLv or self.trackedMove.level
+					local maxLvTxt = self.trackedMove.maxLv or self.trackedMove.level
+					Drawing.drawNumber(self.box[1] + 74 + 3, self.box[2], minLvTxt, 2, Theme.COLORS[MoveHistoryScreen.Colors.text], shadowcolor) -- 74 from drawScreen()
+					Drawing.drawNumber(self.box[1] + 99 + 3, self.box[2], maxLvTxt, 2, Theme.COLORS[MoveHistoryScreen.Colors.text], shadowcolor) -- 99 from drawScreen()
+				end,
 				onClick = function(self)
 					InfoScreen.changeScreenView(InfoScreen.Screens.MOVE_INFO, tMove.id)
 				end
@@ -210,18 +217,12 @@ function MoveHistoryScreen.drawScreen()
 	Drawing.drawText(offsetX + maxColX, topboxY, Resources.MoveHistoryScreen.HeaderMax, Theme.COLORS[MoveHistoryScreen.Colors.headerMoves], shadowcolor)
 	topboxY = topboxY + Constants.SCREEN.LINESPACING
 
-	for _, button in ipairs(MoveHistoryScreen.TemporaryButtons) do
-		if button:isVisible() then
-			local minLvTxt = button.trackedMove.minLv or button.trackedMove.level
-			local maxLvTxt = button.trackedMove.maxLv or button.trackedMove.level
-			Drawing.drawText(button.box[1], button.box[2], button.text, Theme.COLORS[MoveHistoryScreen.Colors.text], shadowcolor)
-			Drawing.drawNumber(button.box[1] + minColX + 3, button.box[2], minLvTxt, 2, Theme.COLORS[MoveHistoryScreen.Colors.text], shadowcolor)
-			Drawing.drawNumber(button.box[1] + maxColX + 3, button.box[2], maxLvTxt, 2, Theme.COLORS[MoveHistoryScreen.Colors.text], shadowcolor)
-		end
-	end
-
 	if #MoveHistoryScreen.TemporaryButtons == 0 then
 		Drawing.drawText(offsetX, topboxY + 5, Resources.MoveHistoryScreen.NoTrackedMoves, Theme.COLORS[MoveHistoryScreen.Colors.text], shadowcolor)
+	else
+		for _, button in ipairs(MoveHistoryScreen.TemporaryButtons) do
+			Drawing.drawButton(button, shadowcolor)
+		end
 	end
 
 	-- Draw all buttons

--- a/ironmon_tracker/screens/UpdateScreen.lua
+++ b/ironmon_tracker/screens/UpdateScreen.lua
@@ -245,10 +245,6 @@ function UpdateScreen.initialize()
 
 	UpdateScreen.currentState = UpdateScreen.States.NOT_UPDATED
 
-	if Main.Version.updateAfterRestart then
-		UpdateScreen.showNotes = true
-		UpdateScreen.buildOutPagedButtons()
-	end
 	UpdateScreen.refreshButtons()
 end
 
@@ -276,6 +272,7 @@ function UpdateScreen.exitScreenAndRemindMe(shouldRemindMe)
 	Program.changeScreenView(NavigationMenu)
 end
 
+-- These buttons are only displayed when 'showNotes' is enabled, and input checks are performed separately
 function UpdateScreen.buildOutPagedButtons()
 	if #Main.Version.releaseNotes == 0 then
 		Main.updateReleaseNotes()
@@ -305,7 +302,7 @@ function UpdateScreen.buildOutPagedButtons()
 	end
 
 	local x = 4
-	local y = 19
+	local y = 18
 	local colSpacer = 1
 	local rowSpacer = 4
 	UpdateScreen.Pager:realignButtonsToGrid(x, y, colSpacer, rowSpacer)
@@ -340,6 +337,7 @@ function UpdateScreen.performAutoUpdate()
 		UpdateScreen.currentState = UpdateScreen.States.SUCCESS
 		Main.Version.showUpdate = false
 		Main.Version.updateAfterRestart = false
+		Main.Version.showReleaseNotes = true
 		Main.SaveSettings(true)
 	else
 		UpdateScreen.currentState = UpdateScreen.States.ERROR
@@ -362,17 +360,12 @@ end
 -- USER INPUT FUNCTIONS
 function UpdateScreen.checkInput(xmouse, ymouse)
 	Input.checkButtonsClicked(xmouse, ymouse, UpdateScreen.Buttons)
-	Input.checkButtonsClicked(xmouse, ymouse, UpdateScreen.Pager.Buttons)
 end
 
 -- DRAWING FUNCTIONS
 function UpdateScreen.drawScreen()
 	Drawing.drawBackgroundAndMargins()
 	gui.defaultTextBackground(Theme.COLORS[UpdateScreen.Colors.boxFill])
-
-	if UpdateScreen.showNotes then
-		UpdateScreen.drawReleaseNotesOverlay()
-	end
 
 	local topBox = {
 		x = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN,


### PR DESCRIPTION
I also fixed the timing of when release notes were shown on screen. They now appear **after** a successful update to a new version, instead of before.

I also updated the move description for Shield Dust. I don't think this or the above change need to be mentioned in the release notes though.

Release notes to include with the 8.0.0 notes
- [v8.0.1] Fixed an issue when using both on-screen timer and repel usage
- [v8.0.1] Fixed an issue with move names being invisible on the Move History screen