### PR TITLE
Patch 8.0.2

### DIFF
--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "8", minor = "0", patch = "1" }
+Main.Version = { major = "8", minor = "0", patch = "2" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/screens/UpdateScreen.lua
+++ b/ironmon_tracker/screens/UpdateScreen.lua
@@ -338,6 +338,8 @@ function UpdateScreen.performAutoUpdate()
 		Main.Version.showUpdate = false
 		Main.Version.updateAfterRestart = false
 		Main.Version.showReleaseNotes = true
+		-- Emulator is closing as expected; no crash
+		CrashRecoveryScreen.logCrashReport(false)
 		Main.SaveSettings(true)
 	else
 		UpdateScreen.currentState = UpdateScreen.States.ERROR


### PR DESCRIPTION
Like clockwise, there's always a few things missed. Luckily this one was also an easy fix.

### Release Notes
- [v8.0.2] Fixed an issue where the Crash Recovery screen would appear after a successful Tracker update