### PR TITLE
Patch 8.0.3

### DIFF
--- a/UpdateOrInstall.lua
+++ b/UpdateOrInstall.lua
@@ -11,7 +11,7 @@ UpdateOrInstall = {
 	archiveFolder = "Ironmon-Tracker-main",
 }
 
--- Beta testers can have this enabled to receive live updates from STAGING branch
+-- Beta testers can have this enabled to receive live updates from "beta-test" branch
 UpdateOrInstall.Dev = {
 	enabled = false, -- Verify this remains "false" for main release
 	TAR_URL = "https://github.com/besteon/Ironmon-Tracker/archive/refs/heads/beta-test.tar.gz",

--- a/ironmon_tracker/FileManager.lua
+++ b/ironmon_tracker/FileManager.lua
@@ -123,10 +123,10 @@ FileManager.LuaCode = {
 	{ name = "CustomExtensionsScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "CustomExtensionsScreen.lua", },
 	{ name = "SingleExtensionScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "SingleExtensionScreen.lua", },
 	{ name = "ViewLogWarningScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "ViewLogWarningScreen.lua", },
-	{ name = "CrashRecoveryScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "CrashRecoveryScreen.lua "},
+	{ name = "CrashRecoveryScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "CrashRecoveryScreen.lua"},
 	{ name = "LogOverlay", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "LogOverlay.lua", },
 	{ name = "TeamViewArea", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "TeamViewArea.lua", },
-	{ name = "LogSearchScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "LogSearchScreen.lua "},
+	{ name = "LogSearchScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "LogSearchScreen.lua"},
 	-- Miscellaneous files
 	{ name = "CustomCode", filepath = "CustomCode.lua", },
 }

--- a/ironmon_tracker/Languages/English.lua
+++ b/ironmon_tracker/Languages/English.lua
@@ -423,8 +423,8 @@ ScreenResources{
 		OptionEnableRestorePoints = "Enable restore points",
 		DescInstructions = "Select a restore point below to go back to that point in time.",
 		DescNoRestorePoints = "No restore points are available; one is created every 5 minutes.",
-		RestorePointAge = "created %s minute%s ago", -- Usage: "created 5 minutes ago"
-		RestorePointAgeS = "s", -- Appended to "minute" above, or leave empty ""
+		RestorePointAgeSingular = "created 1 minute ago",
+		RestorePointAgePlural = "created %s minutes ago",
 		UndoAndReturnBack = "Return back to the future",
 		ConfirmationRestore = "Confirm restore?",
 		LocationUnknownArea = "Unknown Area",

--- a/ironmon_tracker/Languages/French.lua
+++ b/ironmon_tracker/Languages/French.lua
@@ -348,7 +348,7 @@ ScreenResources{
 		-- Pokémon Info
 		ButtonHistory = "History", -- NEEDS TRANSLATION
 		ButtonResistances = "Show resistances", -- NEEDS TRANSLATION
-		KilogramAbbreviation = "kg", -- NEEDS TRANSLATION
+		KilogramAbbreviation = "kg",
 		LabelWeight = "Weight", -- NEEDS TRANSLATION
 		LabelEvolution = "Evolution", -- NEEDS TRANSLATION
 		LabelLearnMove = "Learns a move at level", -- NEEDS TRANSLATION
@@ -423,8 +423,8 @@ ScreenResources{
 		OptionEnableRestorePoints = "Enable restore points", -- NEEDS TRANSLATION
 		DescInstructions = "Select a restore point below to go back to that point in time.", -- NEEDS TRANSLATION
 		DescNoRestorePoints = "No restore points are available; one is created every 5 minutes.", -- NEEDS TRANSLATION
-		RestorePointAge = "created %s minute%s ago", -- Usage: "created 5 minutes ago" -- NEEDS TRANSLATION
-		RestorePointAgeS = "s", -- Appended to "minute" above, or leave empty "" -- NEEDS TRANSLATION
+		RestorePointAgeSingular = "created 1 minute ago", -- NEEDS TRANSLATION
+		RestorePointAgePlural = "created %s minutes ago", -- NEEDS TRANSLATION
 		UndoAndReturnBack = "Return back to the future", -- NEEDS TRANSLATION
 		ConfirmationRestore = "Confirm restore?", -- NEEDS TRANSLATION
 		LocationUnknownArea = "Unknown Area", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/German.lua
+++ b/ironmon_tracker/Languages/German.lua
@@ -348,7 +348,7 @@ ScreenResources{
 		-- Pokémon Info
 		ButtonHistory = "History", -- NEEDS TRANSLATION
 		ButtonResistances = "Show resistances", -- NEEDS TRANSLATION
-		KilogramAbbreviation = "kg", -- NEEDS TRANSLATION
+		KilogramAbbreviation = "kg",
 		LabelWeight = "Weight", -- NEEDS TRANSLATION
 		LabelEvolution = "Evolution", -- NEEDS TRANSLATION
 		LabelLearnMove = "Learns a move at level", -- NEEDS TRANSLATION
@@ -423,8 +423,8 @@ ScreenResources{
 		OptionEnableRestorePoints = "Enable restore points", -- NEEDS TRANSLATION
 		DescInstructions = "Select a restore point below to go back to that point in time.", -- NEEDS TRANSLATION
 		DescNoRestorePoints = "No restore points are available; one is created every 5 minutes.", -- NEEDS TRANSLATION
-		RestorePointAge = "created %s minute%s ago", -- Usage: "created 5 minutes ago" -- NEEDS TRANSLATION
-		RestorePointAgeS = "s", -- Appended to "minute" above, or leave empty "" -- NEEDS TRANSLATION
+		RestorePointAgeSingular = "created 1 minute ago", -- NEEDS TRANSLATION
+		RestorePointAgePlural = "created %s minutes ago", -- NEEDS TRANSLATION
 		UndoAndReturnBack = "Return back to the future", -- NEEDS TRANSLATION
 		ConfirmationRestore = "Confirm restore?", -- NEEDS TRANSLATION
 		LocationUnknownArea = "Unknown Area", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Italian.lua
+++ b/ironmon_tracker/Languages/Italian.lua
@@ -348,7 +348,7 @@ ScreenResources{
 		-- Pokémon Info
 		ButtonHistory = "History", -- NEEDS TRANSLATION
 		ButtonResistances = "Show resistances", -- NEEDS TRANSLATION
-		KilogramAbbreviation = "kg", -- NEEDS TRANSLATION
+		KilogramAbbreviation = "kg",
 		LabelWeight = "Weight", -- NEEDS TRANSLATION
 		LabelEvolution = "Evolution", -- NEEDS TRANSLATION
 		LabelLearnMove = "Learns a move at level", -- NEEDS TRANSLATION
@@ -423,8 +423,8 @@ ScreenResources{
 		OptionEnableRestorePoints = "Enable restore points", -- NEEDS TRANSLATION
 		DescInstructions = "Select a restore point below to go back to that point in time.", -- NEEDS TRANSLATION
 		DescNoRestorePoints = "No restore points are available; one is created every 5 minutes.", -- NEEDS TRANSLATION
-		RestorePointAge = "created %s minute%s ago", -- Usage: "created 5 minutes ago" -- NEEDS TRANSLATION
-		RestorePointAgeS = "s", -- Appended to "minute" above, or leave empty "" -- NEEDS TRANSLATION
+		RestorePointAgeSingular = "created 1 minute ago", -- NEEDS TRANSLATION
+		RestorePointAgePlural = "created %s minutes ago", -- NEEDS TRANSLATION
 		UndoAndReturnBack = "Return back to the future", -- NEEDS TRANSLATION
 		ConfirmationRestore = "Confirm restore?", -- NEEDS TRANSLATION
 		LocationUnknownArea = "Unknown Area", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Japanese.lua
+++ b/ironmon_tracker/Languages/Japanese.lua
@@ -425,8 +425,8 @@ ScreenResources{
 		OptionEnableRestorePoints = "Enable restore points", -- NEEDS TRANSLATION
 		DescInstructions = "Select a restore point below to go back to that point in time.", -- NEEDS TRANSLATION
 		DescNoRestorePoints = "No restore points are available; one is created every 5 minutes.", -- NEEDS TRANSLATION
-		RestorePointAge = "created %s minute%s ago", -- Usage: "created 5 minutes ago" -- NEEDS TRANSLATION
-		RestorePointAgeS = "s", -- Appended to "minute" above, or leave empty "" -- NEEDS TRANSLATION
+		RestorePointAgeSingular = "created 1 minute ago", -- NEEDS TRANSLATION
+		RestorePointAgePlural = "created %s minutes ago", -- NEEDS TRANSLATION
 		UndoAndReturnBack = "Return back to the future", -- NEEDS TRANSLATION
 		ConfirmationRestore = "Confirm restore?", -- NEEDS TRANSLATION
 		LocationUnknownArea = "Unknown Area", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Spanish.lua
+++ b/ironmon_tracker/Languages/Spanish.lua
@@ -348,7 +348,7 @@ ScreenResources{
 		-- Pokémon Info
 		ButtonHistory = "History", -- NEEDS TRANSLATION
 		ButtonResistances = "Show resistances", -- NEEDS TRANSLATION
-		KilogramAbbreviation = "kg", -- NEEDS TRANSLATION
+		KilogramAbbreviation = "kg",
 		LabelWeight = "Weight", -- NEEDS TRANSLATION
 		LabelEvolution = "Evolution", -- NEEDS TRANSLATION
 		LabelLearnMove = "Learns a move at level", -- NEEDS TRANSLATION
@@ -423,8 +423,8 @@ ScreenResources{
 		OptionEnableRestorePoints = "Enable restore points", -- NEEDS TRANSLATION
 		DescInstructions = "Select a restore point below to go back to that point in time.", -- NEEDS TRANSLATION
 		DescNoRestorePoints = "No restore points are available; one is created every 5 minutes.", -- NEEDS TRANSLATION
-		RestorePointAge = "created %s minute%s ago", -- Usage: "created 5 minutes ago" -- NEEDS TRANSLATION
-		RestorePointAgeS = "s", -- Appended to "minute" above, or leave empty "" -- NEEDS TRANSLATION
+		RestorePointAgeSingular = "created 1 minute ago", -- NEEDS TRANSLATION
+		RestorePointAgePlural = "created %s minutes ago", -- NEEDS TRANSLATION
 		UndoAndReturnBack = "Return back to the future", -- NEEDS TRANSLATION
 		ConfirmationRestore = "Confirm restore?", -- NEEDS TRANSLATION
 		LocationUnknownArea = "Unknown Area", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "8", minor = "0", patch = "2" }
+Main.Version = { major = "8", minor = "0", patch = "3" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/screens/TimeMachineScreen.lua
+++ b/ironmon_tracker/screens/TimeMachineScreen.lua
@@ -265,8 +265,12 @@ function TimeMachineScreen.buildOutPagedButtons()
 			end,
 			draw = function(self, shadowcolor)
 				local minutesAgo = math.ceil((os.time() - restorePoint.timestamp) / 60)
-				local includeS = Utils.inlineIf(minutesAgo ~= 1, Resources.TimeMachineScreen.RestorePointAgeS, "")
-				local timestampText = string.format(Resources.TimeMachineScreen.RestorePointAge, minutesAgo, includeS)
+				local timestampText
+				if minutesAgo == 1 then
+					timestampText = Resources.TimeMachineScreen.RestorePointAgeSingular
+				else
+					timestampText = string.format(Resources.TimeMachineScreen.RestorePointAgePlural, minutesAgo)
+				end
 				local rightAlignOffset = self.box[3] - Utils.calcWordPixelLength(timestampText) - 2
 				Drawing.drawText(self.box[1] + rightAlignOffset, self.box[2] + self.box[4] + 1, timestampText, Theme.COLORS[TimeMachineScreen.Colors.text], shadowcolor)
 			end,


### PR DESCRIPTION
Somehow an extra space snuck in to two recent screen files, which caused the files to file to load on Mac and Linux machines. This fixes that problem (someone helped me test it)

I also made that minor Resource change for the "minute" vs "minutes" language entry. I tested this briefly on the Time Machine screen and it worked fine. No need to mention in the release notes, as its a non-functional change.

### Release Notes
- [v8.0.3] Fixed a critical bug that prevented the Tracker from loading on Mac and Linux