### PR TITLE
Adding in friendship tracker evo progress bar

### DIFF
--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -128,6 +128,8 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 	data.p.status = MiscData.StatusCodeMap[viewedPokemon.status] or ""
 	data.p.curExp = viewedPokemon.currentExp or 0
 	data.p.totalExp = viewedPokemon.totalExp or 100
+	data.p.friendship = viewedPokemon.friendship or 70 -- Add friendship as a discoverable stat -Tainted_wolf
+	data.p.friendshipbase = viewedPokemon.friendshipbase -- Add friendship as a discoverable stat -Tainted_wolf
 
 	-- Add: Stats, Stages, and Nature
 	data.p.nature = viewedPokemon.nature

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -128,8 +128,8 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 	data.p.status = MiscData.StatusCodeMap[viewedPokemon.status] or ""
 	data.p.curExp = viewedPokemon.currentExp or 0
 	data.p.totalExp = viewedPokemon.totalExp or 100
-	data.p.friendship = viewedPokemon.friendship or 70 -- Add friendship as a discoverable stat -Tainted_wolf
-	data.p.friendshipBase = viewedPokemon.friendshipBase or 70 -- Add friendship as a discoverable stat -Tainted_wolf
+	data.p.friendship = viewedPokemon.friendship or 70 -- Current friendship value; 70 is default for most Pokémon
+	data.p.friendshipBase = viewedPokemon.friendshipBase or 70 -- The starting friendship value of the Pokémon
 
 	-- Add: Stats, Stages, and Nature
 	data.p.nature = viewedPokemon.nature

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -129,7 +129,7 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 	data.p.curExp = viewedPokemon.currentExp or 0
 	data.p.totalExp = viewedPokemon.totalExp or 100
 	data.p.friendship = viewedPokemon.friendship or 70 -- Add friendship as a discoverable stat -Tainted_wolf
-	data.p.friendshipbase = viewedPokemon.friendshipbase -- Add friendship as a discoverable stat -Tainted_wolf
+	data.p.friendshipBase = viewedPokemon.friendshipBase or 70 -- Add friendship as a discoverable stat -Tainted_wolf
 
 	-- Add: Stats, Stages, and Nature
 	data.p.nature = viewedPokemon.nature

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -5,6 +5,7 @@ PokemonData = {
 PokemonData.IsRand = {
 	pokemonTypes = false,
 	pokemonAbilities = false, -- Currently unused by the Tracker, as it never reveals this information by default
+	pokemonFriendship = false,
 }
 
 -- Enumerated constants that defines the various types a Pokémon and its Moves are
@@ -137,8 +138,8 @@ PokemonData.BlankPokemon = {
 	bst = Constants.BLANKLINE,
 	movelvls = { {}, {} },
 	weight = 0.0,
-	friendship = 0, -- setting default friendship for blank pokemon in case something goes wrong -Tainted_Wolf
-	friendshipBase = 0, -- setting default base friendship
+	friendship = 0,
+	friendshipBase = 0,
 }
 
 function PokemonData.initialize()
@@ -160,10 +161,11 @@ function PokemonData.initialize()
 					pokemonData.abilities = abilities
 				end
 			end
-			-- read in base friendship from Rom file for all mons - Tainted_wolf
-			local friendshipBase = PokemonData.readPokemonBaseFriendshipFromMemory(pokemonID)
-			if friendshipBase ~= nil then
-				pokemonData.friendshipBase = friendshipBase
+			if Pokemondata.IsRand.pokemonFriendship then
+				local friendshipBase = PokemonData.readPokemonBaseFriendshipFromMemory(pokemonID)
+				if friendshipBase ~= 0 then
+					pokemonData.friendshipBase = friendshipBase
+				end
 			end
 		end
 	end
@@ -252,7 +254,6 @@ function PokemonData.readPokemonAbilitiesFromMemory(pokemonID)
 	}
 end
 
---Tainted_Wolf Attempting to read base friendship from rom :/
 function PokemonData.readPokemonBaseFriendshipFromMemory(pokemonID)
 	local baseFriendshipData = Memory.readword(GameSettings.gBaseStats + (pokemonID * 0x1C) + 0x12)
 	local friendshipBase = Utils.getbits(baseFriendshipData, 0, 8)
@@ -303,6 +304,7 @@ function PokemonData.checkIfDataIsRandomized()
 	-- For now, read in all ability data since it's not stored in the PokemonData.Pokemon below
 	areAbilitiesRandomized = true
 	PokemonData.IsRand.pokemonAbilities = areAbilitiesRandomized
+	PokemonData.IsRand.pokemonFriendship = areBaseFriendshipsModified
 
 	return areTypesRandomized or areAbilitiesRandomized or areBaseFriendshipsModified
 end
@@ -745,8 +747,7 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "455",
 		movelvls = { { 6, 11, 16, 21, 28, 35, 42, 49, 56 }, { 6, 11, 16, 21, 28, 35, 42, 49, 56 } },
-		weight = 55.0,
-		friendshipBase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		weight = 55.0
 	},
 	{
 		name = "Oddish",
@@ -1315,7 +1316,7 @@ PokemonData.Pokemon = {
 		bst = "450",
 		movelvls = { { 5, 9, 13, 17, 23, 29, 35, 41, 49, 57 }, { 5, 9, 13, 17, 23, 29, 35, 41, 49, 57 } },
 		weight = 34.6,
-		friendshipBase = 140 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		friendshipBase = 140
 	},
 	{
 		name = "Tangela",
@@ -1787,8 +1788,7 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "205",
 		movelvls = { { 6, 8, 11 }, { 6, 8, 11 } },
-		weight = 2.0,
-		friendshipBase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		weight = 2.0
 	},
 	{
 		name = "Cleffa",
@@ -1797,7 +1797,7 @@ PokemonData.Pokemon = {
 		bst = "218",
 		movelvls = { { 4, 8, 13 }, { 4, 8, 13, 17 } },
 		weight = 3.0,
-		friendshipBase = 140 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		friendshipBase = 140
 	},
 	{
 		name = "Igglybuff",
@@ -1805,8 +1805,7 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "210",
 		movelvls = { { 4, 9, 14 }, { 4, 9, 14 } },
-		weight = 1.0,
-		friendshipBase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		weight = 1.0
 	},
 	{
 		name = "Togepi",
@@ -1814,8 +1813,7 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "245",
 		movelvls = { { 6, 11, 16, 21, 26, 31, 36, 41 }, { 4, 9, 13, 17, 21, 25, 29, 33, 37, 41 } },
-		weight = 1.5,
-		friendshipBase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		weight = 1.5
 	},
 	{
 		name = "Togetic",
@@ -3215,8 +3213,7 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "190",
 		movelvls = { { 3, 6, 10, 15, 21 }, { 3, 6, 10, 15, 21 } },
-		weight = 2.0,
-		friendshipBase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		weight = 2.0
 	},
 	{
 		name = "Spoink",

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -1862,8 +1862,7 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.NONE,
 		bst = "410",
 		movelvls = { { 3, 6, 10, 15, 24, 34, 45, 57 }, { 3, 6, 10, 15, 24, 34, 45, 57 } },
-		weight = 28.5,
-		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		weight = 28.5
 	},
 	{
 		name = "Sudowoodo",
@@ -3191,7 +3190,8 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "190",
 		movelvls = { { 3, 6, 10, 15, 21 }, { 3, 6, 10, 15, 21 } },
-		weight = 2.0
+		weight = 2.0,
+		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Spoink",

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -161,7 +161,7 @@ function PokemonData.initialize()
 					pokemonData.abilities = abilities
 				end
 			end
-			if Pokemondata.IsRand.pokemonFriendship then
+			if PokemonData.IsRand.pokemonFriendship then
 				local friendshipBase = PokemonData.readPokemonBaseFriendshipFromMemory(pokemonID)
 				if friendshipBase ~= 0 then
 					pokemonData.friendshipBase = friendshipBase
@@ -277,7 +277,7 @@ function PokemonData.checkIfDataIsRandomized()
 	if abilities ~= nil then
 		areAbilitiesRandomized = abilities[1] ~= 65 or abilities[2] ~= 65 -- 65 = Overgrow
 	end
-	if friendshipBase ~= nil then
+	if friendshipBase ~= 0 then
 		areBaseFriendshipsModified = friendshipBase ~= 70  -- Bulbasaur's base friendship is 70
 	end
 
@@ -293,8 +293,8 @@ function PokemonData.checkIfDataIsRandomized()
 		if abilities ~= nil and (abilities[1] ~= 11 or abilities[2] ~= 75) then -- 11 = Water Absorb, 75 = Shell Armor
 			areAbilitiesRandomized = true
 		end
-		if friendshipBase ~= nil then
-			areBaseFriendshipsModified = friendshipBase ~= 70  -- Lapras' base friendship is 70
+		if friendshipBase ~= 0 and (friendshipBase ~= 70) then -- Lapras' base friendship is 70
+			areBaseFriendshipsModified = true  
 		end
 	end
 	

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -137,6 +137,7 @@ PokemonData.BlankPokemon = {
 	bst = Constants.BLANKLINE,
 	movelvls = { {}, {} },
 	weight = 0.0,
+	friendship = 0, -- setting default friendship for blank pokemon in case something goes wrong -Tainted_Wolf
 }
 
 function PokemonData.initialize()
@@ -719,7 +720,8 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "455",
 		movelvls = { { 6, 11, 16, 21, 28, 35, 42, 49, 56 }, { 6, 11, 16, 21, 28, 35, 42, 49, 56 } },
-		weight = 55.0
+		weight = 55.0,
+		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Oddish",
@@ -1287,7 +1289,8 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "450",
 		movelvls = { { 5, 9, 13, 17, 23, 29, 35, 41, 49, 57 }, { 5, 9, 13, 17, 23, 29, 35, 41, 49, 57 } },
-		weight = 34.6
+		weight = 34.6,
+		friendshipbase = 140 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Tangela",
@@ -1759,7 +1762,8 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "205",
 		movelvls = { { 6, 8, 11 }, { 6, 8, 11 } },
-		weight = 2.0
+		weight = 2.0,
+		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Cleffa",
@@ -1767,7 +1771,8 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "218",
 		movelvls = { { 4, 8, 13 }, { 4, 8, 13, 17 } },
-		weight = 3.0
+		weight = 3.0,
+		friendshipbase = 140 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Igglybuff",
@@ -1775,7 +1780,8 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "210",
 		movelvls = { { 4, 9, 14 }, { 4, 9, 14 } },
-		weight = 1.0
+		weight = 1.0,
+		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Togepi",
@@ -1783,7 +1789,8 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.FRIEND,
 		bst = "245",
 		movelvls = { { 6, 11, 16, 21, 26, 31, 36, 41 }, { 4, 9, 13, 17, 21, 25, 29, 33, 37, 41 } },
-		weight = 1.5
+		weight = 1.5,
+		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Togetic",
@@ -1855,7 +1862,8 @@ PokemonData.Pokemon = {
 		evolution = PokemonData.Evolutions.NONE,
 		bst = "410",
 		movelvls = { { 3, 6, 10, 15, 24, 34, 45, 57 }, { 3, 6, 10, 15, 24, 34, 45, 57 } },
-		weight = 28.5
+		weight = 28.5,
+		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Sudowoodo",

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -138,6 +138,7 @@ PokemonData.BlankPokemon = {
 	movelvls = { {}, {} },
 	weight = 0.0,
 	friendship = 0, -- setting default friendship for blank pokemon in case something goes wrong -Tainted_Wolf
+	friendshipBase = 0, -- setting default base friendship
 }
 
 function PokemonData.initialize()
@@ -158,6 +159,11 @@ function PokemonData.initialize()
 				if abilities ~= nil then
 					pokemonData.abilities = abilities
 				end
+			end
+			-- read in base friendship from Rom file for all mons - Tainted_wolf
+			local friendshipBase = PokemonData.readPokemonBaseFriendshipFromMemory(pokemonID)
+			if friendshipBase ~= nil then
+				pokemonData.friendshipBase = friendshipBase
 			end
 		end
 	end
@@ -246,13 +252,23 @@ function PokemonData.readPokemonAbilitiesFromMemory(pokemonID)
 	}
 end
 
+--Tainted_Wolf Attempting to read base friendship from rom :/
+function PokemonData.readPokemonBaseFriendshipFromMemory(pokemonID)
+	local baseFriendshipData = Memory.readword(GameSettings.gBaseStats + (pokemonID * 0x1C) + 0x12)
+	local friendshipBase = Utils.getbits(baseFriendshipData, 0, 8)
+
+	return friendshipBase
+end
+
 function PokemonData.checkIfDataIsRandomized()
 	local areTypesRandomized = false
 	local areAbilitiesRandomized = false
+	local areBaseFriendshipsModified = false
 
 	-- Check once if any data was randomized
 	local types = PokemonData.readPokemonTypesFromMemory(1) -- Bulbasaur
 	local abilities = PokemonData.readPokemonAbilitiesFromMemory(1) -- Bulbasaur
+	local friendshipBase = PokemonData.readPokemonBaseFriendshipFromMemory(1) -- Bulbasaur
 
 	if types ~= nil then
 		areTypesRandomized = types[1] ~= PokemonData.Types.GRASS or types[2] ~= PokemonData.Types.POISON
@@ -260,11 +276,15 @@ function PokemonData.checkIfDataIsRandomized()
 	if abilities ~= nil then
 		areAbilitiesRandomized = abilities[1] ~= 65 or abilities[2] ~= 65 -- 65 = Overgrow
 	end
+	if friendshipBase ~= nil then
+		areBaseFriendshipsModified = friendshipBase ~= 70  -- Bulbasaur's base friendship is 70
+	end
 
 	-- Check twice if any data was randomized (Randomizer does *not* force a change)
-	if not areTypesRandomized or not areAbilitiesRandomized then
+	if not areTypesRandomized or not areAbilitiesRandomized or not areBaseFriendshipsModified then
 		types = PokemonData.readPokemonTypesFromMemory(131) -- Lapras
 		abilities = PokemonData.readPokemonAbilitiesFromMemory(131) -- Lapras
+		friendshipBase = PokemonData.readPokemonBaseFriendshipFromMemory(131) --Lapras
 
 		if types ~= nil and (types[1] ~= PokemonData.Types.WATER or types[2] ~= PokemonData.Types.ICE) then
 			areTypesRandomized = true
@@ -272,14 +292,19 @@ function PokemonData.checkIfDataIsRandomized()
 		if abilities ~= nil and (abilities[1] ~= 11 or abilities[2] ~= 75) then -- 11 = Water Absorb, 75 = Shell Armor
 			areAbilitiesRandomized = true
 		end
+		if friendshipBase ~= nil then
+			areBaseFriendshipsModified = friendshipBase ~= 70  -- Lapras' base friendship is 70
+		end
 	end
+	
+	
 
 	PokemonData.IsRand.pokemonTypes = areTypesRandomized
 	-- For now, read in all ability data since it's not stored in the PokemonData.Pokemon below
 	areAbilitiesRandomized = true
 	PokemonData.IsRand.pokemonAbilities = areAbilitiesRandomized
 
-	return areTypesRandomized or areAbilitiesRandomized
+	return areTypesRandomized or areAbilitiesRandomized or areBaseFriendshipsModified
 end
 
 function PokemonData.getAbilityId(pokemonID, abilityNum)
@@ -721,7 +746,7 @@ PokemonData.Pokemon = {
 		bst = "455",
 		movelvls = { { 6, 11, 16, 21, 28, 35, 42, 49, 56 }, { 6, 11, 16, 21, 28, 35, 42, 49, 56 } },
 		weight = 55.0,
-		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		friendshipBase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Oddish",
@@ -1290,7 +1315,7 @@ PokemonData.Pokemon = {
 		bst = "450",
 		movelvls = { { 5, 9, 13, 17, 23, 29, 35, 41, 49, 57 }, { 5, 9, 13, 17, 23, 29, 35, 41, 49, 57 } },
 		weight = 34.6,
-		friendshipbase = 140 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		friendshipBase = 140 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Tangela",
@@ -1763,7 +1788,7 @@ PokemonData.Pokemon = {
 		bst = "205",
 		movelvls = { { 6, 8, 11 }, { 6, 8, 11 } },
 		weight = 2.0,
-		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		friendshipBase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Cleffa",
@@ -1772,7 +1797,7 @@ PokemonData.Pokemon = {
 		bst = "218",
 		movelvls = { { 4, 8, 13 }, { 4, 8, 13, 17 } },
 		weight = 3.0,
-		friendshipbase = 140 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		friendshipBase = 140 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Igglybuff",
@@ -1781,7 +1806,7 @@ PokemonData.Pokemon = {
 		bst = "210",
 		movelvls = { { 4, 9, 14 }, { 4, 9, 14 } },
 		weight = 1.0,
-		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		friendshipBase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Togepi",
@@ -1790,7 +1815,7 @@ PokemonData.Pokemon = {
 		bst = "245",
 		movelvls = { { 6, 11, 16, 21, 26, 31, 36, 41 }, { 4, 9, 13, 17, 21, 25, 29, 33, 37, 41 } },
 		weight = 1.5,
-		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		friendshipBase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Togetic",
@@ -3191,7 +3216,7 @@ PokemonData.Pokemon = {
 		bst = "190",
 		movelvls = { { 3, 6, 10, 15, 21 }, { 3, 6, 10, 15, 21 } },
 		weight = 2.0,
-		friendshipbase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
+		friendshipBase = 70 -- setting important default base friendships for Friend tracking -Tainted_Wolf
 	},
 	{
 		name = "Spoink",

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -807,14 +807,12 @@ function TrackerScreen.drawPokemonInfoArea(data)
 			if (data.p.evo == PokemonData.Evolutions.FRIEND) and Options["Determine friendship readiness"] and Tracker.Data.isViewingOwn then 
 				local friendshipRequired = Memory.readbyte(GameSettings.FriendshipRequiredToEvo) + 1 --Read in Friendship requirement level
 				local evoFriendshipRatio = ((data.p.friendship-data.p.friendshipbase)/friendshipRequired) -- Read in friendship level from the pokemon and get ratio
-				local friendshiptext = Utils.getEvoAbbreviation(data.p.evo)
-				local evotypestringlength = string.len(friendshiptext) --setting up so we know how many letters to color
-				local lettersoffriendtocolor =  math.floor((evotypestringlength*evoFriendshipRatio)+.5)
-				local firststring = string.sub(friendshiptext,1,lettersoffriendtocolor)
-				local secondstring = string.sub(friendshiptext,lettersoffriendtocolor+1,evotypestringlength)
-				-- local firststringspacing = 
-				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, firststring, Theme.COLORS["Positive text"], shadowcolor) --show percent of friendship
-			--	Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing + firststringspacing , offsetY, secondstring, Theme.COLORS["Default text"], shadowcolor) --default text for rest of it 
+				--print(evoFriendshipRatio)
+				local friendshipText = Utils.getEvoAbbreviation(data.p.evo)
+				local evoTypeStringLength = string.len(friendshipText) --setting up so we know how many letters to color
+				local lettersOfFriendToColor =  math.floor((evoTypeStringLength * evoFriendshipRatio))
+				local firstString = string.sub(friendshipText, 1, lettersOfFriendToColor)
+				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, firstString, Theme.COLORS["Positive text"], shadowcolor) --show percent of friendship
 			else 
 				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, abbreviationText, evoTextColor, shadowcolor)
 			end

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -803,16 +803,13 @@ function TrackerScreen.drawPokemonInfoArea(data)
 			else
 				evoTextColor = Theme.COLORS["Default text"]
 			end			
-			-- Adding in a frienship loop lookup to try and print out multicolor letters :) -Tainted_wolf
+			-- Adding in a frienship loop lookup to try and print out multicolor letters based on freindship :) -Tainted_wolf
 			if (data.p.evo == PokemonData.Evolutions.FRIEND) and Options["Determine friendship readiness"] and Tracker.Data.isViewingOwn then 
-				local friendshipRequired = Memory.readbyte(GameSettings.FriendshipRequiredToEvo) + 1 --Read in Friendship requirement level
-				local evoFriendshipRatio = ((data.p.friendship-data.p.friendshipbase)/friendshipRequired) -- Read in friendship level from the pokemon and get ratio
-				--print(evoFriendshipRatio)
-				local friendshipText = Utils.getEvoAbbreviation(data.p.evo)
-				local evoTypeStringLength = string.len(friendshipText) --setting up so we know how many letters to color
-				local lettersOfFriendToColor =  math.floor((evoTypeStringLength * evoFriendshipRatio))
-				local firstString = string.sub(friendshipText, 1, lettersOfFriendToColor)
-				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, firstString, Theme.COLORS["Positive text"], shadowcolor) --show percent of friendship
+				local evoFriendshipRatio = ((data.p.friendship-data.p.friendshipBase)/(Program.GameData.friendshipRequired-data.p.friendshipBase)) -- Read in friendship level from the pokemon and get ratio
+				local evoTypeStringLength = string.len(abbreviationText ) --setting up so we know how many letters to color
+				local lettersToHighlight =  math.floor((evoTypeStringLength * evoFriendshipRatio))
+				local highlightedString = string.sub(abbreviationText , 1, lettersToHighlight)
+				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, highlightedString, Theme.COLORS["Positive text"], shadowcolor) --show percent of friendship
 			else 
 				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, abbreviationText, evoTextColor, shadowcolor)
 			end

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -803,12 +803,12 @@ function TrackerScreen.drawPokemonInfoArea(data)
 			else
 				evoTextColor = Theme.COLORS["Default text"]
 			end			
-			-- Adding in a frienship loop lookup to try and print out multicolor letters based on freindship :) -Tainted_wolf
+			-- Highlight letters for friendship evo to show % of progress
 			if (data.p.evo == PokemonData.Evolutions.FRIEND) and Options["Determine friendship readiness"] and Tracker.Data.isViewingOwn then 
-				local evoFriendshipRatio = ((data.p.friendship-data.p.friendshipBase)/(Program.GameData.friendshipRequired-data.p.friendshipBase)) -- Read in friendship level from the pokemon and get ratio
-				local evoTypeStringLength = string.len(abbreviationText) --setting up so we know how many letters to color
-				local numberLettersToHighlight =  math.floor((evoTypeStringLength * evoFriendshipRatio))
-				local highlightedString = string.sub(abbreviationText , 1, numberLettersToHighlight)
+				local percentFill = (data.p.friendship - data.p.friendshipBase) / (Program.GameData.friendshipRequired - data.p.friendshipBase) -- Read in friendship level from the pokemon and get ratio
+				local evoTypeStringLength = string.len(abbreviationText)
+				local numberLettersToHighlight =  math.floor(string.len(abbreviationText) * percentFill)
+				local highlightedString = abbreviationText:sub(1, numberLettersToHighlight)
 				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, highlightedString, Theme.COLORS["Positive text"], shadowcolor) --show percent of friendship
 			else 
 				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, abbreviationText, evoTextColor, shadowcolor)

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -806,9 +806,9 @@ function TrackerScreen.drawPokemonInfoArea(data)
 			-- Adding in a frienship loop lookup to try and print out multicolor letters based on freindship :) -Tainted_wolf
 			if (data.p.evo == PokemonData.Evolutions.FRIEND) and Options["Determine friendship readiness"] and Tracker.Data.isViewingOwn then 
 				local evoFriendshipRatio = ((data.p.friendship-data.p.friendshipBase)/(Program.GameData.friendshipRequired-data.p.friendshipBase)) -- Read in friendship level from the pokemon and get ratio
-				local evoTypeStringLength = string.len(abbreviationText ) --setting up so we know how many letters to color
-				local lettersToHighlight =  math.floor((evoTypeStringLength * evoFriendshipRatio))
-				local highlightedString = string.sub(abbreviationText , 1, lettersToHighlight)
+				local evoTypeStringLength = string.len(abbreviationText) --setting up so we know how many letters to color
+				local numberLettersToHighlight =  math.floor((evoTypeStringLength * evoFriendshipRatio))
+				local highlightedString = string.sub(abbreviationText , 1, numberLettersToHighlight)
 				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, highlightedString, Theme.COLORS["Positive text"], shadowcolor) --show percent of friendship
 			else 
 				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, abbreviationText, evoTextColor, shadowcolor)

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -802,8 +802,22 @@ function TrackerScreen.drawPokemonInfoArea(data)
 				end
 			else
 				evoTextColor = Theme.COLORS["Default text"]
+			end			
+			-- Adding in a frienship loop lookup to try and print out multicolor letters :) -Tainted_wolf
+			if (data.p.evo == PokemonData.Evolutions.FRIEND) and Options["Determine friendship readiness"] and Tracker.Data.isViewingOwn then 
+				local friendshipRequired = Memory.readbyte(GameSettings.FriendshipRequiredToEvo) + 1 --Read in Friendship requirement level
+				local evoFriendshipRatio = ((data.p.friendship-data.p.friendshipbase)/friendshipRequired) -- Read in friendship level from the pokemon and get ratio
+				local friendshiptext = Utils.getEvoAbbreviation(data.p.evo)
+				local evotypestringlength = string.len(friendshiptext) --setting up so we know how many letters to color
+				local lettersoffriendtocolor =  math.floor((evotypestringlength*evoFriendshipRatio)+.5)
+				local firststring = string.sub(friendshiptext,1,lettersoffriendtocolor)
+				local secondstring = string.sub(friendshiptext,lettersoffriendtocolor+1,evotypestringlength)
+				-- local firststringspacing = 
+				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, firststring, Theme.COLORS["Positive text"], shadowcolor) --show percent of friendship
+			--	Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing + firststringspacing , offsetY, secondstring, Theme.COLORS["Default text"], shadowcolor) --default text for rest of it 
+			else 
+				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, abbreviationText, evoTextColor, shadowcolor)
 			end
-			Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, abbreviationText, evoTextColor, shadowcolor)
 		end
 		offsetY = offsetY + linespacing
 	else

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -802,15 +802,14 @@ function TrackerScreen.drawPokemonInfoArea(data)
 				end
 			else
 				evoTextColor = Theme.COLORS["Default text"]
-			end			
-			-- Highlight letters for friendship evo to show % of progress
-			if (data.p.evo == PokemonData.Evolutions.FRIEND) and Options["Determine friendship readiness"] and Tracker.Data.isViewingOwn then 
-				local percentFill = (data.p.friendship - data.p.friendshipBase) / (Program.GameData.friendshipRequired - data.p.friendshipBase) -- Read in friendship level from the pokemon and get ratio
-				local evoTypeStringLength = string.len(abbreviationText)
-				local numberLettersToHighlight =  math.floor(string.len(abbreviationText) * percentFill)
-				local highlightedString = abbreviationText:sub(1, numberLettersToHighlight)
-				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, highlightedString, Theme.COLORS["Positive text"], shadowcolor) --show percent of friendship
-			else 
+			end
+			-- Highlight some % of the evo text based on progress towards friendship requirement
+			if (data.p.evo == PokemonData.Evolutions.FRIEND) and Options["Determine friendship readiness"] and Tracker.Data.isViewingOwn then
+				local percentFill = (data.p.friendship - data.p.friendshipBase) / (Program.GameData.friendshipRequired - data.p.friendshipBase)
+				local numHighlightedChars = math.floor(abbreviationText:len() * percentFill)
+				local highlightedEvo = abbreviationText:sub(1, numHighlightedChars)
+				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, highlightedEvo, Theme.COLORS["Positive text"], shadowcolor)
+			else
 				Drawing.drawText(Constants.SCREEN.WIDTH + evoSpacing, offsetY, abbreviationText, evoTextColor, shadowcolor)
 			end
 		end


### PR DESCRIPTION
Set up changes to mimic the friendship tracking like the gen 4-5 trackers.

When tracking is turned on we will show a green letters to indicate how far friendship has come
![FriendshipTracker new](https://github.com/besteon/Ironmon-Tracker/assets/139718649/dab3ae40-dcfa-4454-a7b5-816691b3d0e1)

With viewing friendship off, we go back to default.
![frienshipTrackingTurnedOff](https://github.com/besteon/Ironmon-Tracker/assets/139718649/f69c9843-3fe7-45ac-aa3d-f75134b7b66b)


I've added a few variables to data.p that can be used. If you accept this and like this functionality I can go add base friendship to all the mons so we can use it for Return/Frustration as well.