### PR TITLE
Open Book play mode feature

### DIFF
--- a/ironmon_tracker/Constants.lua
+++ b/ironmon_tracker/Constants.lua
@@ -145,6 +145,7 @@ Constants.OrderedLists = {
 		"Show Team View",
 		"Show Pre Evolutions",
 		"Use Custom Trainer Names",
+		"Open Book Play Mode",
 	},
 	CONTROLS = {
 		"Load next seed",

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -357,6 +357,7 @@ end
 
 function Drawing.drawImageAsPixels(imageMatrix, x, y, colorList, shadowcolor)
 	if imageMatrix == nil then return end
+	colorList = colorList or Theme.COLORS["Default text"]
 
 	-- Convert to a list if only a single color is supplied
 	if type(colorList) == "number" then

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -221,26 +221,29 @@ end
 
 function Input.checkAnyMovesClicked(xmouse, ymouse)
 	local pokemon = Tracker.getViewedPokemon()
-	local pokemonMoves = nil
-	if pokemon ~= nil then
-		if not Tracker.Data.isViewingOwn then
-			pokemonMoves = Tracker.getMoves(pokemon.pokemonID) -- tracked moves only
-		elseif Tracker.Data.hasCheckedSummary then
-			pokemonMoves = pokemon.moves
-		end
+	if pokemon == nil then
+		return
+	end
+
+	local pokemonMoves
+	if not Tracker.Data.isViewingOwn and not Options["Open Book Play Mode"] then
+		pokemonMoves = Tracker.getMoves(pokemon.pokemonID) -- tracked moves only
+	elseif Tracker.Data.hasCheckedSummary then
+		pokemonMoves = pokemon.moves
+	end
+	if pokemonMoves == nil then
+		return
 	end
 
 	-- move info lookup, only if pokemon exists and the user should know about its moves already
 	-- TODO: Turn these into buttons
-	if pokemonMoves ~= nil then
-		local moveOffsetX = Constants.SCREEN.WIDTH + 7
-		local moveOffsetY = 95
-		for moveIndex = 1, 4, 1 do
-			if Input.isMouseInArea(xmouse, ymouse, moveOffsetX, moveOffsetY, 75, 10) then
-				InfoScreen.changeScreenView(InfoScreen.Screens.MOVE_INFO, pokemonMoves[moveIndex].id)
-				break
-			end
-			moveOffsetY = moveOffsetY + 10
+	local moveOffsetX = Constants.SCREEN.WIDTH + 7
+	local moveOffsetY = 95
+	for moveIndex = 1, 4, 1 do
+		if Input.isMouseInArea(xmouse, ymouse, moveOffsetX, moveOffsetY, 75, 10) then
+			InfoScreen.changeScreenView(InfoScreen.Screens.MOVE_INFO, pokemonMoves[moveIndex].id)
+			break
 		end
+		moveOffsetY = moveOffsetY + 10
 	end
 end

--- a/ironmon_tracker/Languages/English.lua
+++ b/ironmon_tracker/Languages/English.lua
@@ -510,7 +510,7 @@ ScreenResources{
 		CheckboxShowPreEvolutions = "Show Pre Evolutions",
 		CheckboxCustomTrainerNames = "Custom Trainer Names",
 		CheckboxOpenBookMode = "Open Book Play Mode",
-		LabelExtraTimeWarning = "Adds 2 seconds to game load",
+		LabelExtraTimeWarning = "May add extra load time",
 		PromptShareSeedTitle = "Share Randomizer Seed",
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.",
 	},

--- a/ironmon_tracker/Languages/English.lua
+++ b/ironmon_tracker/Languages/English.lua
@@ -509,6 +509,8 @@ ScreenResources{
 		ButtonShareSeed = "Share Seed",
 		CheckboxShowPreEvolutions = "Show Pre Evolutions",
 		CheckboxCustomTrainerNames = "Custom Trainer Names",
+		CheckboxOpenBookMode = "Open Book Play Mode",
+		LabelExtraTimeWarning = "Adds 2 seconds to game load",
 		PromptShareSeedTitle = "Share Randomizer Seed",
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.",
 	},

--- a/ironmon_tracker/Languages/French.lua
+++ b/ironmon_tracker/Languages/French.lua
@@ -510,7 +510,7 @@ ScreenResources{
 		CheckboxShowPreEvolutions = "Show Pre Evolutions", -- NEEDS TRANSLATION
 		CheckboxCustomTrainerNames = "Custom Trainer Names", -- NEEDS TRANSLATION
 		CheckboxOpenBookMode = "Open Book Play Mode", -- NEEDS TRANSLATION
-		LabelExtraTimeWarning = "Adds 2 seconds to game load", -- NEEDS TRANSLATION
+		LabelExtraTimeWarning = "May add extra load time", -- NEEDS TRANSLATION
 		PromptShareSeedTitle = "Share Randomizer Seed", -- NEEDS TRANSLATION
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.", -- NEEDS TRANSLATION
 	},

--- a/ironmon_tracker/Languages/French.lua
+++ b/ironmon_tracker/Languages/French.lua
@@ -509,6 +509,8 @@ ScreenResources{
 		ButtonShareSeed = "Share Seed", -- NEEDS TRANSLATION
 		CheckboxShowPreEvolutions = "Show Pre Evolutions", -- NEEDS TRANSLATION
 		CheckboxCustomTrainerNames = "Custom Trainer Names", -- NEEDS TRANSLATION
+		CheckboxOpenBookMode = "Open Book Play Mode", -- NEEDS TRANSLATION
+		LabelExtraTimeWarning = "Adds 2 seconds to game load", -- NEEDS TRANSLATION
 		PromptShareSeedTitle = "Share Randomizer Seed", -- NEEDS TRANSLATION
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.", -- NEEDS TRANSLATION
 	},

--- a/ironmon_tracker/Languages/German.lua
+++ b/ironmon_tracker/Languages/German.lua
@@ -510,7 +510,7 @@ ScreenResources{
 		CheckboxShowPreEvolutions = "Show Pre Evolutions", -- NEEDS TRANSLATION
 		CheckboxCustomTrainerNames = "Custom Trainer Names", -- NEEDS TRANSLATION
 		CheckboxOpenBookMode = "Open Book Play Mode", -- NEEDS TRANSLATION
-		LabelExtraTimeWarning = "Adds 2 seconds to game load", -- NEEDS TRANSLATION
+		LabelExtraTimeWarning = "May add extra load time", -- NEEDS TRANSLATION
 		PromptShareSeedTitle = "Share Randomizer Seed", -- NEEDS TRANSLATION
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.", -- NEEDS TRANSLATION
 	},

--- a/ironmon_tracker/Languages/German.lua
+++ b/ironmon_tracker/Languages/German.lua
@@ -509,6 +509,8 @@ ScreenResources{
 		ButtonShareSeed = "Share Seed", -- NEEDS TRANSLATION
 		CheckboxShowPreEvolutions = "Show Pre Evolutions", -- NEEDS TRANSLATION
 		CheckboxCustomTrainerNames = "Custom Trainer Names", -- NEEDS TRANSLATION
+		CheckboxOpenBookMode = "Open Book Play Mode", -- NEEDS TRANSLATION
+		LabelExtraTimeWarning = "Adds 2 seconds to game load", -- NEEDS TRANSLATION
 		PromptShareSeedTitle = "Share Randomizer Seed", -- NEEDS TRANSLATION
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.", -- NEEDS TRANSLATION
 	},

--- a/ironmon_tracker/Languages/Italian.lua
+++ b/ironmon_tracker/Languages/Italian.lua
@@ -510,7 +510,7 @@ ScreenResources{
 		CheckboxShowPreEvolutions = "Show Pre Evolutions", -- NEEDS TRANSLATION
 		CheckboxCustomTrainerNames = "Custom Trainer Names", -- NEEDS TRANSLATION
 		CheckboxOpenBookMode = "Open Book Play Mode", -- NEEDS TRANSLATION
-		LabelExtraTimeWarning = "Adds 2 seconds to game load", -- NEEDS TRANSLATION
+		LabelExtraTimeWarning = "May add extra load time", -- NEEDS TRANSLATION
 		PromptShareSeedTitle = "Share Randomizer Seed", -- NEEDS TRANSLATION
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.", -- NEEDS TRANSLATION
 	},

--- a/ironmon_tracker/Languages/Italian.lua
+++ b/ironmon_tracker/Languages/Italian.lua
@@ -509,6 +509,8 @@ ScreenResources{
 		ButtonShareSeed = "Share Seed", -- NEEDS TRANSLATION
 		CheckboxShowPreEvolutions = "Show Pre Evolutions", -- NEEDS TRANSLATION
 		CheckboxCustomTrainerNames = "Custom Trainer Names", -- NEEDS TRANSLATION
+		CheckboxOpenBookMode = "Open Book Play Mode", -- NEEDS TRANSLATION
+		LabelExtraTimeWarning = "Adds 2 seconds to game load", -- NEEDS TRANSLATION
 		PromptShareSeedTitle = "Share Randomizer Seed", -- NEEDS TRANSLATION
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.", -- NEEDS TRANSLATION
 	},

--- a/ironmon_tracker/Languages/Japanese.lua
+++ b/ironmon_tracker/Languages/Japanese.lua
@@ -512,7 +512,7 @@ ScreenResources{
 		CheckboxShowPreEvolutions = "Show Pre Evolutions", -- NEEDS TRANSLATION
 		CheckboxCustomTrainerNames = "Custom Trainer Names", -- NEEDS TRANSLATION
 		CheckboxOpenBookMode = "Open Book Play Mode", -- NEEDS TRANSLATION
-		LabelExtraTimeWarning = "Adds 2 seconds to game load", -- NEEDS TRANSLATION
+		LabelExtraTimeWarning = "May add extra load time", -- NEEDS TRANSLATION
 		PromptShareSeedTitle = "Share Randomizer Seed", -- NEEDS TRANSLATION
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.", -- NEEDS TRANSLATION
 	},

--- a/ironmon_tracker/Languages/Japanese.lua
+++ b/ironmon_tracker/Languages/Japanese.lua
@@ -511,6 +511,8 @@ ScreenResources{
 		ButtonShareSeed = "Share Seed", -- NEEDS TRANSLATION
 		CheckboxShowPreEvolutions = "Show Pre Evolutions", -- NEEDS TRANSLATION
 		CheckboxCustomTrainerNames = "Custom Trainer Names", -- NEEDS TRANSLATION
+		CheckboxOpenBookMode = "Open Book Play Mode", -- NEEDS TRANSLATION
+		LabelExtraTimeWarning = "Adds 2 seconds to game load", -- NEEDS TRANSLATION
 		PromptShareSeedTitle = "Share Randomizer Seed", -- NEEDS TRANSLATION
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.", -- NEEDS TRANSLATION
 	},

--- a/ironmon_tracker/Languages/Spanish.lua
+++ b/ironmon_tracker/Languages/Spanish.lua
@@ -510,7 +510,7 @@ ScreenResources{
 		CheckboxShowPreEvolutions = "Show Pre Evolutions", -- NEEDS TRANSLATION
 		CheckboxCustomTrainerNames = "Custom Trainer Names", -- NEEDS TRANSLATION
 		CheckboxOpenBookMode = "Open Book Play Mode", -- NEEDS TRANSLATION
-		LabelExtraTimeWarning = "Adds 2 seconds to game load", -- NEEDS TRANSLATION
+		LabelExtraTimeWarning = "May add extra load time", -- NEEDS TRANSLATION
 		PromptShareSeedTitle = "Share Randomizer Seed", -- NEEDS TRANSLATION
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.", -- NEEDS TRANSLATION
 	},

--- a/ironmon_tracker/Languages/Spanish.lua
+++ b/ironmon_tracker/Languages/Spanish.lua
@@ -509,6 +509,8 @@ ScreenResources{
 		ButtonShareSeed = "Share Seed", -- NEEDS TRANSLATION
 		CheckboxShowPreEvolutions = "Show Pre Evolutions", -- NEEDS TRANSLATION
 		CheckboxCustomTrainerNames = "Custom Trainer Names", -- NEEDS TRANSLATION
+		CheckboxOpenBookMode = "Open Book Play Mode", -- NEEDS TRANSLATION
+		LabelExtraTimeWarning = "Adds 2 seconds to game load", -- NEEDS TRANSLATION
 		PromptShareSeedTitle = "Share Randomizer Seed", -- NEEDS TRANSLATION
 		PromptShareSeedDesc = "Copy/paste everything below to share. Load it through Randomizer --> Premade Seed.", -- NEEDS TRANSLATION
 	},

--- a/ironmon_tracker/Options.lua
+++ b/ironmon_tracker/Options.lua
@@ -44,6 +44,7 @@ Options = {
 	["Show Team View"] = false,
 	["Show Pre Evolutions"] = false,
 	["Use Custom Trainer Names"] = false,
+	["Open Book Play Mode"] = false,
 	CONTROLS = {
 		["Load next seed"] = "A, B, Start",
 		["Toggle view"] = "Start",

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -410,9 +410,7 @@ end
 
 -- If the viewed Pokemon has the move "Hidden Power" (id=237), return it's tracked type; otherwise default type value = NORMAL
 function Tracker.getHiddenPowerType()
-	-- Default to 'true' if not using open book setting
-	local useOpenBookInfo = not Options["Open Book Play Mode"] or Tracker.Data.isViewingOwn
-	local viewedPokemon = Battle.getViewedPokemon(useOpenBookInfo)
+	local viewedPokemon = Battle.getViewedPokemon(true)
 
 	if viewedPokemon ~= nil and Tracker.Data.hiddenPowers[viewedPokemon.personality] ~= nil then
 		return Tracker.Data.hiddenPowers[viewedPokemon.personality]

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -410,7 +410,9 @@ end
 
 -- If the viewed Pokemon has the move "Hidden Power" (id=237), return it's tracked type; otherwise default type value = NORMAL
 function Tracker.getHiddenPowerType()
-	local viewedPokemon = Battle.getViewedPokemon(true)
+	-- Default to 'true' if not using open book setting
+	local useOpenBookInfo = not Options["Open Book Play Mode"] or Tracker.Data.isViewingOwn
+	local viewedPokemon = Battle.getViewedPokemon(useOpenBookInfo)
 
 	if viewedPokemon ~= nil and Tracker.Data.hiddenPowers[viewedPokemon.personality] ~= nil then
 		return Tracker.Data.hiddenPowers[viewedPokemon.personality]

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -250,7 +250,7 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 
 		-- Update: Specific Moves
 		if move.id == 237 then -- 237 = Hidden Power
-			if data.x.viewingOwn or useOpenBookInfo then
+			if data.x.viewingOwn then
 				move.type = Tracker.getHiddenPowerType()
 			else
 				move.type = MoveData.HiddenPowerTypeList[1] -- Unknown type

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -99,6 +99,7 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 	local targetInfo = Battle.getDoublesCursorTargetInfo()
 	local viewedPokemon = Battle.getViewedPokemon(data.x.viewingOwn)
 	local opposingPokemon = Tracker.getPokemon(targetInfo.slot, targetInfo.isOwner) -- currently used exclusively for Low Kick weight calcs
+	local useOpenBookInfo = not data.x.viewingOwn and Options["Open Book Play Mode"]
 
 	if viewedPokemon == nil or viewedPokemon.pokemonID == 0 or not Program.isValidMapLocation() then
 		viewedPokemon = Tracker.getDefaultPokemon()
@@ -115,6 +116,11 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 		for key, value in pairs(PokemonData.Pokemon[viewedPokemon.pokemonID]) do
 			viewedPokemon[key] = value
 		end
+	end
+
+	local pokemonLog = {}
+	if RandomizerLog.Data.Pokemon then
+		pokemonLog = RandomizerLog.Data.Pokemon[viewedPokemon.pokemonID] or {}
 	end
 
 	-- POKEMON ITSELF (data.p)
@@ -137,7 +143,11 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 	data.p.negativestat = ""
 	data.p.stages = {}
 	for _, statKey in ipairs(Constants.OrderedLists.STATSTAGES) do
-		data.p[statKey] = viewedPokemon.stats[statKey] or Constants.BLANKLINE
+		if useOpenBookInfo then
+			data.p[statKey] = pokemonLog.BaseStats and pokemonLog.BaseStats[statKey] or Constants.BLANKLINE
+		else
+			data.p[statKey] = viewedPokemon.stats[statKey] or Constants.BLANKLINE
+		end
 		data.p.stages[statKey] = viewedPokemon.statStages[statKey] or 6
 
 		local natureMultiplier = Utils.getNatureMultiplier(statKey, data.p.nature)
@@ -175,6 +185,20 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 		if abilityId ~= nil and abilityId ~= 0 then
 			data.p.line2 = AbilityData.Abilities[abilityId].name
 		end
+	elseif useOpenBookInfo then
+		local abilityIds = {
+			PokemonData.getAbilityId(viewedPokemon.pokemonID, 0),
+			PokemonData.getAbilityId(viewedPokemon.pokemonID, 1),
+		}
+		if abilityIds[1] ~= nil and abilityIds[1] ~= 0 then
+			if abilityIds[2] ~= nil and abilityIds[2] ~= abilityIds[1] then
+				data.p.line1 = AbilityData.Abilities[abilityIds[1]].name .. " /"
+				data.p.line2 = AbilityData.Abilities[abilityIds[2]].name
+			else
+				data.p.line1 = AbilityData.Abilities[abilityIds[1]].name
+				data.p.line2 = Constants.BLANKLINE
+			end
+		end
 	else
 		local trackedAbilities = Tracker.getAbilities(viewedPokemon.pokemonID)
 		if trackedAbilities[1].id ~= nil and trackedAbilities[1].id ~= 0 then
@@ -193,7 +217,7 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 	data.m.moves = { {}, {}, {}, {}, } -- four empty move placeholders
 
 	local stars
-	if data.x.viewingOwn then
+	if data.x.viewingOwn or useOpenBookInfo then
 		stars = { "", "", "", "" }
 	else
 		stars = Utils.calculateMoveStars(viewedPokemon.pokemonID, viewedPokemon.level)
@@ -202,7 +226,7 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 	local trackedMoves = Tracker.getMoves(viewedPokemon.pokemonID)
 	for i = 1, 4, 1 do
 		local moveToCopy = MoveData.BlankMove
-		if data.x.viewingOwn then
+		if data.x.viewingOwn or useOpenBookInfo then
 			if viewedPokemon.moves[i] ~= nil and viewedPokemon.moves[i].id ~= 0 then
 				moveToCopy = MoveData.Moves[viewedPokemon.moves[i].id]
 			end
@@ -226,7 +250,7 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 
 		-- Update: Specific Moves
 		if move.id == 237 then -- 237 = Hidden Power
-			if data.x.viewingOwn then
+			if data.x.viewingOwn or useOpenBookInfo then
 				move.type = Tracker.getHiddenPowerType()
 			else
 				move.type = MoveData.HiddenPowerTypeList[1] -- Unknown type
@@ -275,7 +299,7 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 
 		-- Update: Actual PP Values
 		if move.name ~= MoveData.BlankMove.name then
-			if data.x.viewingOwn then
+			if data.x.viewingOwn or useOpenBookInfo then
 				move.pp = viewedPokemon.moves[i].pp
 			elseif Options["Count enemy PP usage"] then
 				-- Interate over tracked moves, since we don't know the full move list
@@ -294,7 +318,7 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 			move.showeffective = false
 		elseif not Options["Reveal info if randomized"] then
 			-- If move info is randomized and the user doesn't want to know about it, hide it
-			if data.x.viewingOwn then
+			if data.x.viewingOwn or useOpenBookInfo then
 				-- Don't show effectiveness of the player's moves if the enemy types are unknown
 				move.showeffective = not PokemonData.IsRand.pokemonTypes
 			else

--- a/ironmon_tracker/data/RandomizerLog.lua
+++ b/ironmon_tracker/data/RandomizerLog.lua
@@ -82,39 +82,55 @@ RandomizerLog.EncounterTypes = {
 	Trainers = {
 		-- Not used for wild encounters
 		logKey = "Trainers",
+		internalArea = RouteData.EncounterArea.TRAINER,
+		index = 1,
 	},
 	GrassCave = {
 		logKey = "Grass/Cave",
-		rates = { 0.20, 0.20, 0.10, 0.10, 0.10, 0.10, 0.05, 0.05, 0.04, 0.04, 0.01, 0.01, }
+		internalArea = RouteData.EncounterArea.LAND,
+		rates = { 0.20, 0.20, 0.10, 0.10, 0.10, 0.10, 0.05, 0.05, 0.04, 0.04, 0.01, 0.01, },
+		index = 2,
 	},
 	Surfing = {
 		logKey = "Surfing",
-		rates = { 0.60, 0.30, 0.05, 0.04, 0.01, }
+		internalArea = RouteData.EncounterArea.SURFING,
+		rates = { 0.60, 0.30, 0.05, 0.04, 0.01, },
+		index = 3,
 	},
 	RockSmash = {
 		logKey = "Rock Smash",
-		rates = { 0.60, 0.30, 0.05, 0.04, 0.01, }
+		internalArea = RouteData.EncounterArea.ROCKSMASH,
+		rates = { 0.60, 0.30, 0.05, 0.04, 0.01, },
+		index = 4,
 	},
 	OldRod = {
 		logKey = "Fishing",
-		rates = { 0.70, 0.30, }
+		internalArea = RouteData.EncounterArea.OLDROD,
+		rates = { 0.70, 0.30, },
+		index = 5,
 	},
 	GoodRod = {
 		logKey = "Fishing",
-		rates = { 0.60, 0.20, 0.20, }
+		internalArea = RouteData.EncounterArea.GOODROD,
+		rates = { 0.60, 0.20, 0.20, },
+		index = 6,
 	},
 	SuperRod = {
 		logKey = "Fishing",
-		rates = { 0.40, 0.40, 0.15, 0.04, 0.01, }
+		internalArea = RouteData.EncounterArea.SUPERROD,
+		rates = { 0.40, 0.40, 0.15, 0.04, 0.01, },
+		index = 7,
 	},
 }
+
+-- A table of parsed data from the log file: Settings, Pokemon, TMs, Trainers, PickupItems
+RandomizerLog.Data = {}
 
 function RandomizerLog.initialize()
 	-- Holds the path of the previously loaded log file. This is used to check if a new file needs to be parsed
 	RandomizerLog.loadedLogPath = nil
 
-	-- A table of parsed data from the log file: Settings, Pokemon, TMs, Trainers, PickupItems
-	RandomizerLog.Data = {}
+	RandomizerLog.initBlankData()
 end
 
 -- Parses the log file at 'filepath' into the data object RandomizerLog.Data

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -455,7 +455,8 @@ function InfoScreen.getPokemonButtonsForEncounterArea(mapId, encounterArea)
 			end
 		end
 		local routeLog = RandomizerLog.Data.Routes[mapId] or {}
-		local encArea = routeLog.EncountersAreas[selectedEncKey or false] or {}
+		local routeAreas = routeLog.EncountersAreas or {}
+		local encArea = routeAreas[selectedEncKey or false] or {}
 		for id, pokemon in pairs(encArea.pokemon or {}) do
 			table.insert(areaInfo, {
 				pokemonID = id,
@@ -468,19 +469,23 @@ function InfoScreen.getPokemonButtonsForEncounterArea(mapId, encounterArea)
 			return (a.rate or 0) > (b.rate or 0) or (a.rate == b.rate and a.pokemonID < b.pokemonID)
 		end)
 		totalPossible = #areaInfo
-	elseif InfoScreen.Buttons.ShowRoutePercentages.toggleState or InfoScreen.Buttons.ShowRouteLevels.toggleState then
-		areaInfo = RouteData.getEncounterAreaPokemon(mapId, encounterArea)
-		totalPossible = #areaInfo
-	else
-		local trackedPokemonIDs = Tracker.getRouteEncounters(mapId, encounterArea)
-		areaInfo = {}
-		for _, id in ipairs(trackedPokemonIDs) do
-			table.insert(areaInfo, {
-				pokemonID = id,
-				rate = nil,
-			})
+	end
+	-- If log info isn't available, revert back to using normal route display
+	if totalPossible == 0 then
+		if InfoScreen.Buttons.ShowRoutePercentages.toggleState or InfoScreen.Buttons.ShowRouteLevels.toggleState then
+			areaInfo = RouteData.getEncounterAreaPokemon(mapId, encounterArea)
+			totalPossible = #areaInfo
+		else
+			local trackedPokemonIDs = Tracker.getRouteEncounters(mapId, encounterArea)
+			areaInfo = {}
+			for _, id in ipairs(trackedPokemonIDs) do
+				table.insert(areaInfo, {
+					pokemonID = id,
+					rate = nil,
+				})
+			end
+			totalPossible = RouteData.countPokemonInArea(mapId, encounterArea)
 		end
-		totalPossible = RouteData.countPokemonInArea(mapId, encounterArea)
 	end
 
 	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 3

--- a/ironmon_tracker/screens/LogOverlay.lua
+++ b/ironmon_tracker/screens/LogOverlay.lua
@@ -43,6 +43,9 @@ LogOverlay.Windower = {
 	end,
 	changeTab = function(self, newTab, pageNum, totalPages, tabInfoId, filterGrid)
 		if newTab == nil then return end
+		if not LogOverlay.isDisplayed then
+			LogOverlay.isDisplayed = true
+		end
 
 		local prevTab = {
 			tab = self.currentTab,
@@ -255,6 +258,22 @@ function LogOverlay.initialize()
 			button.boxColors = { LogOverlay.Colors.headerBorder, LogOverlay.Colors.headerFill }
 		end
 	end
+
+	if Options["Open Book Play Mode"] then
+		local logpath = LogOverlay.getLogFileAutodetected() or LogOverlay.getLogFileFromPrompt()
+
+		if (logpath or "") ~= "" then
+			RandomizerLog.loadedLogPath = logpath
+			local success = RandomizerLog.parseLog(logpath)
+
+			if success then
+				LogOverlay.buildAllTabs()
+				LogOverlay.Windower.currentTab = LogTabPokemon
+				LogSearchScreen.resetSearchSortFilter()
+				LogOverlay.refreshActiveTabGrid()
+			end
+		end
+	end
 end
 
 function LogOverlay.refreshButtons()
@@ -332,7 +351,6 @@ function LogOverlay.buildAllTabs()
 	LogTabRoutes.buildPagedButtons()
 	-- TMs
 	LogTabTMs.buildPagedButtons(gymTMs)
-	LogTabTMs.buildGymTMButtons()
 end
 
 function LogOverlay.refreshActiveTabGrid()
@@ -438,7 +456,7 @@ function LogOverlay.viewLogFile(postfix)
 end
 
 --- Attempts to determine the log file that matches the currently loaded rom. If not match or can't find, returns nil
---- @param postFix string The file's postFix, most likely FileManager.PostFixes.AUTORANDOMIZED or FileManager.PostFixes.PREVIOUSATTEMPT
+--- @param postFix string|nil The file's postFix, most likely FileManager.PostFixes.AUTORANDOMIZED or FileManager.PostFixes.PREVIOUSATTEMPT
 --- @return string|nil
 function LogOverlay.getLogFileAutodetected(postFix)
 	postFix = postFix or FileManager.PostFixes.AUTORANDOMIZED

--- a/ironmon_tracker/screens/LogTabMisc.lua
+++ b/ironmon_tracker/screens/LogTabMisc.lua
@@ -20,7 +20,7 @@ LogTabMisc.Buttons = {
 		type = Constants.ButtonTypes.CHECKBOX,
 		optionKey = "Show Pre Evolutions",
 		getText = function(self) return Resources.LogOverlay.CheckboxShowPreEvolutions end,
-		clickableArea = { LogOverlay.TabBox.x + 4, LogOverlay.TabBox.y + 4, 90, 10, },
+		clickableArea = { LogOverlay.TabBox.x + 5, LogOverlay.TabBox.y + 5, 90, 10, },
 		box = { LogOverlay.TabBox.x + 5, LogOverlay.TabBox.y + 5, 8, 8, },
 		toggleState = Options["Show Pre Evolutions"],
 		updateSelf = function(self) self.toggleState = (Options[self.optionKey] == true) end,
@@ -33,9 +33,23 @@ LogTabMisc.Buttons = {
 		type = Constants.ButtonTypes.CHECKBOX,
 		optionKey = "Use Custom Trainer Names",
 		getText = function(self) return Resources.LogOverlay.CheckboxCustomTrainerNames end,
-		clickableArea = { LogOverlay.TabBox.x + 4, LogOverlay.TabBox.y + 17, 90, 10, },
+		clickableArea = { LogOverlay.TabBox.x + 5, LogOverlay.TabBox.y + 17, 90, 10, },
 		box = { LogOverlay.TabBox.x + 5, LogOverlay.TabBox.y + 17, 8, 8, },
 		toggleState = Options["Use Custom Trainer Names"],
+		updateSelf = function(self) self.toggleState = (Options[self.optionKey] == true) end,
+		onClick = function(self)
+			self.toggleState = Options.toggleSetting(self.optionKey)
+			Program.redraw(true)
+		end,
+	},
+	OpenBookMode = {
+		type = Constants.ButtonTypes.CHECKBOX,
+		optionKey = "Open Book Play Mode",
+		-- TODO: Update Resources
+		getText = function(self) return "Open Book Play Mode" or Resources.LogOverlay.CheckboxOpenBookMode end,
+		clickableArea = { LogOverlay.TabBox.x + 5, LogOverlay.TabBox.y + 29, 90, 10, },
+		box = { LogOverlay.TabBox.x + 5, LogOverlay.TabBox.y + 29, 8, 8, },
+		toggleState = Options["Open Book Play Mode"],
 		updateSelf = function(self) self.toggleState = (Options[self.optionKey] == true) end,
 		onClick = function(self)
 			self.toggleState = Options.toggleSetting(self.optionKey)
@@ -53,7 +67,7 @@ LogTabMisc.Buttons = {
 		getText = function(self) return Resources.LogOverlay.LabelPokemonGame .. ":" end,
 		getValue = function(self) return RandomizerLog.Data.Settings.Game or Constants.BLANKLINE end,
 		index = 1,
-		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 35, 100, 11 },
+		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 45, 100, 11 },
 		draw = function(self, shadowcolor)
 			Drawing.drawText(self.box[1] + columnOffsetX, self.box[2], self:getValue(), Theme.COLORS[self.textColor], shadowcolor)
 		end,
@@ -63,7 +77,7 @@ LogTabMisc.Buttons = {
 		getText = function(self) return Resources.LogOverlay.LabelRandomizerVersion .. ":" end,
 		getValue = function(self) return RandomizerLog.Data.Settings.Version or Constants.BLANKLINE end,
 		index = 2,
-		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 48, 100, 11 },
+		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 57, 100, 11 },
 		draw = function(self, shadowcolor)
 			Drawing.drawText(self.box[1] + columnOffsetX, self.box[2], self:getValue(), Theme.COLORS[self.textColor], shadowcolor)
 		end,
@@ -73,7 +87,7 @@ LogTabMisc.Buttons = {
 		getText = function(self) return Resources.LogOverlay.LabelRandomSeed .. ":" end,
 		getValue = function(self) return RandomizerLog.Data.Settings.RandomSeed or Constants.BLANKLINE end,
 		index = 3,
-		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 61, 100, 11 },
+		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 69, 100, 11 },
 		draw = function(self, shadowcolor)
 			Drawing.drawText(self.box[1] + columnOffsetX, self.box[2], self:getValue(), Theme.COLORS[self.textColor], shadowcolor)
 		end,
@@ -83,7 +97,7 @@ LogTabMisc.Buttons = {
 		getText = function(self) return Resources.LogOverlay.LabelSettingsString .. ":" end,
 		getValue = function(self) return RandomizerLog.Data.Settings.SettingsString or Constants.BLANKLINE end,
 		index = 4,
-		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 74, 100, 11 },
+		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 81, 100, 11 },
 		draw = function(self, shadowcolor)
 			local settingsString = self:getValue()
 			local offsetY = self.box[2] + Constants.SCREEN.LINESPACING

--- a/ironmon_tracker/screens/LogTabMisc.lua
+++ b/ironmon_tracker/screens/LogTabMisc.lua
@@ -45,12 +45,21 @@ LogTabMisc.Buttons = {
 	OpenBookMode = {
 		type = Constants.ButtonTypes.CHECKBOX,
 		optionKey = "Open Book Play Mode",
-		-- TODO: Update Resources
-		getText = function(self) return "Open Book Play Mode" or Resources.LogOverlay.CheckboxOpenBookMode end,
+		getText = function(self) return Resources.LogOverlay.CheckboxOpenBookMode end,
 		clickableArea = { LogOverlay.TabBox.x + 5, LogOverlay.TabBox.y + 29, 90, 10, },
 		box = { LogOverlay.TabBox.x + 5, LogOverlay.TabBox.y + 29, 8, 8, },
 		toggleState = Options["Open Book Play Mode"],
 		updateSelf = function(self) self.toggleState = (Options[self.optionKey] == true) end,
+		draw = function(self, shadowcolor)
+			if self.toggleState then
+				local color = Theme.COLORS[LogTabMisc.Colors.hightlight]
+				local x, y = self.box[1] + self.box[3], self.box[2] - 2
+				x = x + Utils.calcWordPixelLength(self:getText()) + 7
+				Drawing.drawImageAsPixels(Constants.PixelImages.WARNING, x, y + 1, color, shadowcolor)
+				local warningMsg = Resources.LogOverlay.LabelExtraTimeWarning
+				Drawing.drawText(x + 10, y, warningMsg, color, shadowcolor)
+			end
+		end,
 		onClick = function(self)
 			self.toggleState = Options.toggleSetting(self.optionKey)
 			Program.redraw(true)
@@ -67,7 +76,7 @@ LogTabMisc.Buttons = {
 		getText = function(self) return Resources.LogOverlay.LabelPokemonGame .. ":" end,
 		getValue = function(self) return RandomizerLog.Data.Settings.Game or Constants.BLANKLINE end,
 		index = 1,
-		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 45, 100, 11 },
+		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 50, 100, 11 },
 		draw = function(self, shadowcolor)
 			Drawing.drawText(self.box[1] + columnOffsetX, self.box[2], self:getValue(), Theme.COLORS[self.textColor], shadowcolor)
 		end,
@@ -77,7 +86,7 @@ LogTabMisc.Buttons = {
 		getText = function(self) return Resources.LogOverlay.LabelRandomizerVersion .. ":" end,
 		getValue = function(self) return RandomizerLog.Data.Settings.Version or Constants.BLANKLINE end,
 		index = 2,
-		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 57, 100, 11 },
+		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 62, 100, 11 },
 		draw = function(self, shadowcolor)
 			Drawing.drawText(self.box[1] + columnOffsetX, self.box[2], self:getValue(), Theme.COLORS[self.textColor], shadowcolor)
 		end,
@@ -87,7 +96,7 @@ LogTabMisc.Buttons = {
 		getText = function(self) return Resources.LogOverlay.LabelRandomSeed .. ":" end,
 		getValue = function(self) return RandomizerLog.Data.Settings.RandomSeed or Constants.BLANKLINE end,
 		index = 3,
-		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 69, 100, 11 },
+		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 74, 100, 11 },
 		draw = function(self, shadowcolor)
 			Drawing.drawText(self.box[1] + columnOffsetX, self.box[2], self:getValue(), Theme.COLORS[self.textColor], shadowcolor)
 		end,
@@ -97,7 +106,7 @@ LogTabMisc.Buttons = {
 		getText = function(self) return Resources.LogOverlay.LabelSettingsString .. ":" end,
 		getValue = function(self) return RandomizerLog.Data.Settings.SettingsString or Constants.BLANKLINE end,
 		index = 4,
-		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 81, 100, 11 },
+		box = { LogOverlay.TabBox.x + 3, LogOverlay.TabBox.y + 86, 100, 11 },
 		draw = function(self, shadowcolor)
 			local settingsString = self:getValue()
 			local offsetY = self.box[2] + Constants.SCREEN.LINESPACING

--- a/ironmon_tracker/screens/LogTabPokemon.lua
+++ b/ironmon_tracker/screens/LogTabPokemon.lua
@@ -150,16 +150,20 @@ function LogTabPokemon.buildPagedButtons()
 	end
 
 	-- First main page viewed by default is the Pokemon Window, so set that up now
-	LogTabPokemon.realignGrid()
+	if LogOverlay.isDisplayed then
+		LogTabPokemon.realignGrid()
+	end
 end
 
 function LogTabPokemon.realignGrid(gridFilter, sortFunc, startingPage)
 	-- Default grid to Pokédex number
 	gridFilter = gridFilter or "#"
-	sortFunc = sortFunc or LogSearchScreen.currentSortOrder.sortFunc --pokedexNumber
 	startingPage = startingPage or 1
 
-	table.sort(LogTabPokemon.PagedButtons, sortFunc)
+	if sortFunc or LogSearchScreen.currentSortOrder then
+		sortFunc = sortFunc or LogSearchScreen.currentSortOrder.sortFunc --pokedexNumber
+		table.sort(LogTabPokemon.PagedButtons, sortFunc)
+	end
 
 	local x = LogOverlay.TabBox.x + 19
 	local y = LogOverlay.TabBox.y + 1

--- a/ironmon_tracker/screens/LogTabRouteDetails.lua
+++ b/ironmon_tracker/screens/LogTabRouteDetails.lua
@@ -211,13 +211,11 @@ function LogTabRouteDetails.buildZoomButtons(mapId)
 				draw = function(self, shadowcolor)
 					local totalText = tostring(self.totalCount)
 					Drawing.drawText(self.box[1] + self.box[3] + 1, self.box[2] + 1, totalText, Theme.COLORS[self.textColor], shadowcolor)
-					-- Currently unused, unsure if I want to keep this or not
-					-- if self.isSelected then
-					-- 	-- Drawing.drawUnderline(self, Theme.COLORS[self.textColor])
-					-- 	local color = Theme.COLORS[LogTabRouteDetails.Colors.hightlight]
-					-- 	local textWidth = Utils.calcWordPixelLength(totalText) + 5
-					-- 	Drawing.drawSelectionIndicators(self.box[1] - 1, self.box[2] - 1, self.box[3] + textWidth, self.box[4] + 1, color, 1, 4, 1)
-					-- end
+					if self.isSelected then
+						local color = Theme.COLORS[LogTabRouteDetails.Colors.hightlight]
+						local textWidth = Utils.calcWordPixelLength(totalText) + 4
+						Drawing.drawSelectionIndicators(self.box[1] - 1, self.box[2] - 1, self.box[3] + textWidth, self.box[4] + 1, color, 1, 4, 1)
+					end
 				end,
 				onClick = function(self)
 					if self.isSelected then return end -- Don't change if already on this tab

--- a/ironmon_tracker/screens/LogTabRoutes.lua
+++ b/ironmon_tracker/screens/LogTabRoutes.lua
@@ -220,7 +220,24 @@ function LogTabRoutes.buildPagedButtons()
 			end,
 			onClick = function(self)
 				LogOverlay.Windower:changeTab(LogTabRouteDetails, 1, 1, self.id)
-				Program.redraw(true)
+				-- Find first available enoucnter area
+				local encounterArea
+				for _, encType in ipairs(Utils.getSortedList(RandomizerLog.EncounterTypes)) do
+					if encType.logKey ~= RandomizerLog.EncounterTypes.Trainers.logKey then
+						encounterArea = encType.internalArea
+						break
+					end
+				end
+				if route.numWilds > 0 and RouteData.hasRouteEncounterArea(self.id, encounterArea) then
+					local routeInfo = {
+						mapId = self.id,
+						encounterArea = encounterArea,
+					}
+					InfoScreen.changeScreenView(InfoScreen.Screens.ROUTE_INFO, routeInfo)
+				else
+					Program.redraw(true)
+				end
+
 			end,
 			draw = function(self, shadowcolor)
 				local x, y = self.box[1], self.box[2]

--- a/ironmon_tracker/screens/LogTabTMs.lua
+++ b/ironmon_tracker/screens/LogTabTMs.lua
@@ -16,6 +16,7 @@ LogTabTMs = {
 
 LogTabTMs.PagedButtons = {}
 LogTabTMs.NavFilterButtons = {}
+LogTabTMs.GymLabelButtons = {}
 
 function LogTabTMs.initialize()
 	LogTabTMs.buildNavigation()
@@ -23,6 +24,11 @@ end
 
 function LogTabTMs.refreshButtons()
 	for _, button in pairs(LogTabTMs.NavFilterButtons) do
+		if type(button.updateSelf) == "function" then
+			button:updateSelf()
+		end
+	end
+	for _, button in pairs(LogTabTMs.GymLabelButtons) do
 		if type(button.updateSelf) == "function" then
 			button:updateSelf()
 		end
@@ -126,6 +132,7 @@ function LogTabTMs.buildPagedButtons(gymTMs)
 end
 
 function LogTabTMs.buildGymTMButtons()
+	LogTabTMs.GymLabelButtons = {}
 	local gymTMNav = LogOverlay.NavFilters.TMs.GymTMs
 	LogTabTMs.realignGrid(gymTMNav.group, gymTMNav.sortFunc)
 
@@ -164,7 +171,7 @@ function LogTabTMs.buildGymTMButtons()
 					-- InfoScreen.changeScreenView(InfoScreen.Screens.TRAINER_INFO, self.trainerId) -- TODO: (future feature) implied redraw
 				end,
 			}
-			table.insert(LogTabTMs.NavFilterButtons, gymButton)
+			table.insert(LogTabTMs.GymLabelButtons, gymButton)
 		end
 	end
 end
@@ -201,6 +208,7 @@ end
 -- USER INPUT FUNCTIONS
 function LogTabTMs.checkInput(xmouse, ymouse)
 	Input.checkButtonsClicked(xmouse, ymouse, LogTabTMs.NavFilterButtons)
+	Input.checkButtonsClicked(xmouse, ymouse, LogTabTMs.GymLabelButtons)
 	Input.checkButtonsClicked(xmouse, ymouse, LogTabTMs.PagedButtons)
 end
 
@@ -221,6 +229,9 @@ function LogTabTMs.drawTab()
 
 	-- Draw the navigation
 	for _, button in pairs(LogTabTMs.NavFilterButtons) do
+		Drawing.drawButton(button, shadowcolor)
+	end
+	for _, button in pairs(LogTabTMs.GymLabelButtons) do
 		Drawing.drawButton(button, shadowcolor)
 	end
 

--- a/ironmon_tracker/screens/LogTabTrainers.lua
+++ b/ironmon_tracker/screens/LogTabTrainers.lua
@@ -157,6 +157,10 @@ function LogTabTrainers.buildPagedButtons()
 			group = trainerInternal.group or TrainerData.TrainerGroups.Other,
 			isVisible = function(self) return LogOverlay.Windower.currentPage == self.pageVisible end,
 			includeInGrid = function(self)
+				if not TrainerData.shouldUseTrainer(self.id) then
+					return false
+				end
+
 				-- If no search text entered, check any filter groups
 				if LogSearchScreen.searchText == "" then
 					if LogOverlay.Windower.filterGrid == self.group then

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -102,6 +102,16 @@ TrackerScreen.Buttons = {
 			Program.redraw(true)
 		end
 	},
+	LogViewerQuickAccess = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = Constants.PixelImages.MAGNIFYING_GLASS,
+		textColor = "Intermediate text",
+		box = { Constants.SCREEN.WIDTH + 84, 64, 10, 10 },
+		isVisible = function() return Tracker.Data.isViewingOwn and Options["Open Book Play Mode"] and not Options["Track PC Heals"] end,
+		onClick = function(self)
+			TrackerScreen.Buttons.PokemonIcon:onClick()
+		end
+	},
 	InvisibleStatsArea = {
 		type = Constants.ButtonTypes.NO_BORDER,
 		box = { Constants.SCREEN.WIDTH + 103, Constants.SCREEN.MARGIN, 44, 75 },
@@ -908,6 +918,8 @@ function TrackerScreen.drawPokemonInfoArea(data)
 
 			-- Auto-tracking PC Heals button
 			Drawing.drawButton(TrackerScreen.Buttons.PCHealAutoTracking, shadowcolor)
+		else
+			Drawing.drawButton(TrackerScreen.Buttons.LogViewerQuickAccess, shadowcolor)
 		end
 	elseif Battle.inBattle then
 		local encounterText, routeText, routeInfoX

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -17,12 +17,15 @@ TrackerScreen.Buttons = {
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN, -1, 32, 32 },
 		isVisible = function() return true end,
 		onClick = function(self)
-			local pokemon = Tracker.getViewedPokemon()
-			local pokemonID = 0
-			if pokemon ~= nil and PokemonData.isValid(pokemon.pokemonID) then
-				pokemonID = pokemon.pokemonID
+			local pokemon = Tracker.getViewedPokemon() or Tracker.getDefaultPokemon()
+			if not PokemonData.isValid(pokemon.pokemonID) then
+				return
 			end
-			InfoScreen.changeScreenView(InfoScreen.Screens.POKEMON_INFO, pokemonID)
+			if Options["Open Book Play Mode"] then
+				LogOverlay.Windower:changeTab(LogTabPokemon)
+				LogOverlay.Windower:changeTab(LogTabPokemonDetails, 1, 1, pokemon.pokemonID)
+			end
+			InfoScreen.changeScreenView(InfoScreen.Screens.POKEMON_INFO, pokemon.pokemonID)
 		end
 	},
 	TypeDefenses = {
@@ -99,6 +102,20 @@ TrackerScreen.Buttons = {
 			Program.redraw(true)
 		end
 	},
+	InvisibleStatsArea = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		box = { Constants.SCREEN.WIDTH + 103, Constants.SCREEN.MARGIN, 44, 75 },
+		isVisible = function() return Options["Open Book Play Mode"] and not Tracker.Data.isViewingOwn end,
+		onClick = function(self)
+			local pokemon = Tracker.getViewedPokemon() or Tracker.getDefaultPokemon()
+			if not PokemonData.isValid(pokemon.pokemonID) then
+				return
+			end
+			LogOverlay.Windower:changeTab(LogTabPokemon)
+			LogOverlay.Windower:changeTab(LogTabPokemonDetails, 1, 1, pokemon.pokemonID)
+			InfoScreen.changeScreenView(InfoScreen.Screens.POKEMON_INFO, pokemon.pokemonID)
+		end,
+	},
 	RouteDetails = {
 		type = Constants.ButtonTypes.PIXELIMAGE,
 		image = Constants.PixelImages.MAP_PINDROP,
@@ -126,8 +143,13 @@ TrackerScreen.Buttons = {
 		onClick = function(self)
 			local pokemon = Tracker.getViewedPokemon()
 			if pokemon ~= nil and PokemonData.isValid(pokemon.pokemonID) then
-				local trackedAbilities = Tracker.getAbilities(pokemon.pokemonID)
-				InfoScreen.changeScreenView(InfoScreen.Screens.ABILITY_INFO, trackedAbilities[1].id)
+				if Options["Open Book Play Mode"] then
+					local abilityId = PokemonData.getAbilityId(pokemon.pokemonID, 0) -- 0 is the first ability
+					InfoScreen.changeScreenView(InfoScreen.Screens.ABILITY_INFO, abilityId)
+				else
+					local trackedAbilities = Tracker.getAbilities(pokemon.pokemonID)
+					InfoScreen.changeScreenView(InfoScreen.Screens.ABILITY_INFO, trackedAbilities[1].id)
+				end
 			end
 		end
 	},
@@ -144,6 +166,8 @@ TrackerScreen.Buttons = {
 				local abilityId
 				if Tracker.Data.isViewingOwn then
 					abilityId = PokemonData.getAbilityId(pokemon.pokemonID, pokemon.abilityNum)
+				elseif Options["Open Book Play Mode"] then
+					abilityId = PokemonData.getAbilityId(pokemon.pokemonID, 1) -- 1 is the second ability
 				else
 					local trackedAbilities = Tracker.getAbilities(pokemon.pokemonID)
 					abilityId = trackedAbilities[2].id
@@ -328,18 +352,14 @@ function TrackerScreen.initialize()
 	for _, statKey in ipairs(Constants.OrderedLists.STATSTAGES) do
 		TrackerScreen.Buttons[statKey] = {
 			type = Constants.ButtonTypes.STAT_STAGE,
-			getText = function(self)
-				return Constants.STAT_STATES[self.statState].text
-			end,
+			getText = function(self) return Constants.STAT_STATES[self.statState].text end,
 			textColor = "Default text",
 			box = { Constants.SCREEN.WIDTH + 129, heightOffset, 8, 8 },
 			boxColors = { "Upper box border", "Upper box background" },
 			statStage = statKey,
 			statState = 0,
-			isVisible = function() return Battle.inBattle and not Tracker.Data.isViewingOwn end,
+			isVisible = function() return Battle.inBattle and not Tracker.Data.isViewingOwn and not Options["Open Book Play Mode"] end,
 			onClick = function(self)
-				if not self:isVisible() then return end
-
 				self.statState = ((self.statState + 1) % 4) -- 4 total possible markings for a stat state
 				self.textColor = Constants.STAT_STATES[self.statState].textColor
 
@@ -774,7 +794,12 @@ function TrackerScreen.drawPokemonInfoArea(data)
 		else
 			extraInfoText = Resources.TrackerScreen.BattleNewEncounter
 		end
-		extraInfoColor = Theme.COLORS["Intermediate text"]
+		-- Prioritize showing open book stuff with highlight color
+		if Options["Open Book Play Mode"] then
+			extraInfoColor = Theme.COLORS["Default text"]
+		else
+			extraInfoColor = Theme.COLORS["Intermediate text"]
+		end
 	end
 
 	local levelEvoText = string.format("%s.%s", Resources.TrackerScreen.LevelAbbreviation, data.p.level)
@@ -805,18 +830,14 @@ function TrackerScreen.drawPokemonInfoArea(data)
 		Drawing.drawText(Constants.SCREEN.WIDTH + offsetX, offsetY, levelEvoText, Theme.COLORS["Default text"], shadowcolor)
 		if data.p.evo ~= PokemonData.Evolutions.NONE and evoSpacing ~= nil then
 			-- Draw over the evo method in the new color to reflect if evo is possible/ready
+			local evoReadyFriendship = (Options["Determine friendship readiness"] and data.p.evo == PokemonData.Evolutions.FRIEND_READY)
+			local evoReadyLevel = Utils.isReadyToEvolveByLevel(data.p.evo, data.p.level)
+			local evoReadyStone = Utils.isReadyToEvolveByStone(data.p.evo)
 			local evoTextColor
-			if Tracker.Data.isViewingOwn then
-				local evoReadyFriendship = (Options["Determine friendship readiness"] and data.p.evo == PokemonData.Evolutions.FRIEND_READY)
-				local evoReadyLevel = Utils.isReadyToEvolveByLevel(data.p.evo, data.p.level)
-				local evoReadyStone = Utils.isReadyToEvolveByStone(data.p.evo)
-				if evoReadyFriendship or evoReadyLevel or evoReadyStone then
-					evoTextColor = Theme.COLORS["Positive text"]
-				else
-					evoTextColor = Theme.COLORS["Intermediate text"]
-				end
+			if evoReadyFriendship or evoReadyLevel or evoReadyStone then
+				evoTextColor = Theme.COLORS["Positive text"]
 			else
-				evoTextColor = Theme.COLORS["Default text"]
+				evoTextColor = Theme.COLORS["Intermediate text"]
 			end
 			-- Highlight some % of the evo text based on progress towards friendship requirement
 			if (data.p.evo == PokemonData.Evolutions.FRIEND) and Options["Determine friendship readiness"] and Tracker.Data.isViewingOwn then
@@ -843,7 +864,6 @@ function TrackerScreen.drawPokemonInfoArea(data)
 		offsetY = offsetY + 5
 	end
 
-	-- Tracker.Data.isViewingOwn and
 	if data.p.status ~= MiscData.StatusCodeMap[MiscData.StatusType.None] then
 		Drawing.drawStatusIcon(data.p.status, Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 30 - 16 + 1, Constants.SCREEN.MARGIN + 1)
 	end
@@ -960,7 +980,12 @@ function TrackerScreen.drawStatsArea(data)
 			local statValueText = Utils.inlineIf(data.p[statKey] == 0, Constants.BLANKLINE, data.p[statKey])
 			Drawing.drawNumber(statOffsetX + 25, statOffsetY, statValueText, 3, textColor, shadowcolor)
 		else
-			Drawing.drawButton(TrackerScreen.Buttons[statKey], shadowcolor)
+			if Options["Open Book Play Mode"] then
+				local bstSpread = Utils.inlineIf(data.p[statKey] == 0, Constants.BLANKLINE, data.p[statKey])
+				Drawing.drawNumber(statOffsetX + 25, statOffsetY, bstSpread, 3, Theme.COLORS["Intermediate text"], shadowcolor)
+			else
+				Drawing.drawButton(TrackerScreen.Buttons[statKey], shadowcolor)
+			end
 		end
 		statOffsetY = statOffsetY + 10
 	end


### PR DESCRIPTION
Added Open Book play mode. Enable this log feature to see log info while actively playing the game. The option lives in the Log Viewer's Misc tab option list, since it's more-or-less part of the log.

_(This feature requires the extended Log Viewer routes feature, that PR must be merged in first)_

### Info Revealed by Open Book
- Wild and Trainer Pokémon's stat boxes are replaced with base stats (the bst spread, not actual in-game stats)
   - These values are highlighted to help further indicate they are revealed log info, and not true in-game stats
- Pokémon abilities
- Pokémon moves
- The entire Pokémon moveset is shown in the Move History screen
- The Route info page that normally tracks wilds you encounter now just shows all wild encounters in that area, with their levels & percentages

### Quick Access to the Log
Added a magnifying glass button in the space where the survival PC heals get shown on the main Tracker screen. Clicking it opens the log viewer. Also, clicking on the Pokémon icon and/or stats area of an enemy Pokémon will opens the log viewer for that Pokémon, offering quick-access to the log.

![image](https://github.com/besteon/Ironmon-Tracker/assets/4258818/3265a071-b3ab-4da0-8948-0f6762f86f98)

### Feature Complications
To get this feature to work, I told the Tracker to parse the log file when it starts up. This adds a bit of time to startup, since parsing the log can take a second or two. Don't really see a way around this, since you need access to all that info in order to display it while actively playing. If no log is auto-detected (from Quickload settings) to be parsed, then it prompts the user to open it. Again, no good way around this. As a result of this, I added a "warning" to the Open Book option to help inform the player that some extra stuff has to happen in the backend, and on their part, to make this feature work.

![openbook-feature](https://github.com/besteon/Ironmon-Tracker/assets/4258818/c2b0358f-9079-412d-abc7-9a46f085114f)
