### PR TITLE
Fix for new quickload attempts

### DIFF
--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -783,7 +783,12 @@ function Main.SaveCurrentRom(filename)
 	return nil
 end
 
-function Main.GetAttemptsFile()
+--- Attempts to find an attempts file based off of the Quickload settings file, then off of the currently loaded ROM name
+--- @param forceUseSettingsFile boolean Force return of filepath of an attempts file to be created from the Quickload settings file
+--- @return string attemptsFilePath Filepath to an attempts file
+function Main.GetAttemptsFile(forceUseSettingsFile)
+	forceUseSettingsFile = forceUseSettingsFile or false
+
 	-- If temp quickload files are available, use those instead of spending resources to look them up
 	local quickloadFiles = Main.tempQuickloadFiles
 
@@ -805,6 +810,9 @@ function Main.GetAttemptsFile()
 		-- Return early if an attemptsFilePath has been found
 		if attemptsFilePath ~= nil then
 			return attemptsFilePath
+		elseif forceUseSettingsFile then
+			-- Force return a filepath to an attempts file to be created based off settings file
+			return FileManager.prependDir(attemptsFileName)
 		end
 	end
 
@@ -834,9 +842,13 @@ function Main.GetAttemptsFile()
 	return attemptsFilePath
 end
 
--- Determines what attempts # the play session is on, either from pre-existing file or from Bizhawk's ROM Name
-function Main.ReadAttemptsCount()
-	local filepath = Main.GetAttemptsFile()
+--- Determines what attempts # the play session is on, either from pre-existing file or from Bizhawk's ROM Name.
+--- Resulting attempts # is stored in Main.currentSeed
+--- @param forceUseSettingsFile boolean Force creation of new attempts # for the current Quickload settings file
+function Main.ReadAttemptsCount(forceUseSettingsFile)
+	forceUseSettingsFile = forceUseSettingsFile or false
+
+	local filepath = Main.GetAttemptsFile(forceUseSettingsFile)
 	local attemptsRead = io.open(filepath, "r")
 
 	-- First check if a matching "attempts file" already exists, if so read from that
@@ -859,6 +871,9 @@ function Main.ReadAttemptsCount()
 				Main.currentSeed = smallestSeedNumber
 			end
 		end
+	elseif Options["Generate ROM each time"] and forceUseSettingsFile then
+		-- Set a new attempts count for newly-set Settings file
+		Main.currentSeed = 0 -- 0 so that first quickload results in attempt 1
 	else
 		-- Otherwise, leave the attempts count as-is
 	end

--- a/ironmon_tracker/screens/QuickloadScreen.lua
+++ b/ironmon_tracker/screens/QuickloadScreen.lua
@@ -334,8 +334,8 @@ function QuickloadScreen.handleSetCustomSettings(button)
 		if extension == "rnqs" then
 			Options.FILES[button.optionKey] = file
 			button.isSet = true
-			-- After changing the setup, read-in any existing attempts counter for the new quickload choice
-			Main.ReadAttemptsCount()
+			-- After changing the setup, read-in any existing attempts counter for the new quickload choice or force-create a new one if it doesn't exist
+			Main.ReadAttemptsCount(true)
 			Main.SaveSettings(true)
 		else
 			Main.DisplayError("The file selected is not a Randomizer Settings file.\n\nPlease select an RNQS file: has the file extension \".rnqs\"")


### PR DESCRIPTION
When testing the quickload changes included in #412 (will want to merge this before that PR) I noticed consistently that swapping to a new settings file for quickload *while* a tracker-generated rom is currently loaded results in the tracker erroneously carrying over the attempts file from the previous quickload settings file into the new one

Example reproduction steps:
1. Set up tracker quickload for one particular settings file e.g. `RSE Kaizo`
2. Quickload a couple of roms / edit the attempts count to some arbitrary number > 1
3. Change the quickload settings file to another settings file e.g. `RSE Survival` while `RSE Kaizo AutoRandomized.gba` is still loaded in the emulator
4. Notice how the attempts counter from `RSE Kaizo Attempts.txt` carries over into `RSE Survival Attempts.txt`

Went with adding an optional (default false) parameter to force the attempts filepath to be based off the currently set settings file & create a new attempts counter for it if it does not exist. Seems to work fine for me in the above steps but definitely test in case there's a case I didn't catch / it broke elsewhere