### PR TITLE
Heals/Items In Bag Screen

### DIFF
--- a/ironmon_tracker/FileManager.lua
+++ b/ironmon_tracker/FileManager.lua
@@ -121,6 +121,7 @@ FileManager.LuaCode = {
 	{ name = "RandomEvosScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "RandomEvosScreen.lua", },
 	{ name = "MoveHistoryScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "MoveHistoryScreen.lua", },
 	{ name = "TypeDefensesScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "TypeDefensesScreen.lua", },
+	{ name = "HealsInBagScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "HealsInBagScreen.lua", },
 	{ name = "GameOverScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "GameOverScreen.lua", },
 	{ name = "StreamerScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "StreamerScreen.lua", },
 	{ name = "TimeMachineScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "TimeMachineScreen.lua", },

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -506,8 +506,14 @@ function GameSettings.setEwramAddresses()
 		-- FRLG: [SaveBlock1's flags offset] + [Badge flag offset: (SYSTEM_FLAGS + FLAG_BADGE01_GET) / 8]
 		badgeOffset = { 0x1220 + 0x100, 0x1270 + 0x10C, 0xEE0 + 0x104 },
 		bagPocket_Items_offset = { 0x560, 0x560, 0x310 },
-		bagPocket_Berries_offset = { 0x740, 0x790, 0x54c },
 		bagPocket_Items_Size = { 20, 30, 42 },
+		bagPocket_KeyItems_offset = { 0x5B0, 0x5D8, 0x3b8 },
+		bagPocket_KeyItems_Size = { 20, 30, 30 },
+		bagPocket_Balls_offset = { 0x600, 0x650, 0x430 },
+		bagPocket_Balls_Size = { 16, 16, 13 },
+		bagPocket_TmHm_offset = { 0x640, 0x690, 0x464 },
+		bagPocket_TmHm_Size = { 64, 64, 58 },
+		bagPocket_Berries_offset = { 0x740, 0x790, 0x54c },
 		bagPocket_Berries_Size = { 46, 46, 43 },
 		-- RS don't use an encryption key
 		EncryptionKeyOffset = { nil, 0xAC, 0xF20 },

--- a/ironmon_tracker/Languages/English.lua
+++ b/ironmon_tracker/Languages/English.lua
@@ -476,6 +476,13 @@ ScreenResources{
 		LabelRandomEvos = "Random Evos",
 		LabelEvoShort = "Evo",
 	},
+	HealsInBagScreen = {
+		TabAll = "All",
+		TabHP = "HP",
+		TabPP = "PP",
+		TabStatus = "Status",
+		TabBattle = "Battle",
+	},
 	MoveHistoryScreen = {
 		HeaderMoves = "Move seen at level",
 		HeaderMin = "Min",

--- a/ironmon_tracker/Languages/French.lua
+++ b/ironmon_tracker/Languages/French.lua
@@ -476,6 +476,13 @@ ScreenResources{
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION
 		LabelEvoShort = "Evo", -- NEEDS TRANSLATION
 	},
+	HealsInBagScreen = {
+		TabAll = "All", -- NEEDS TRANSLATION
+		TabHP = "HP", -- NEEDS TRANSLATION
+		TabPP = "PP", -- NEEDS TRANSLATION
+		TabStatus = "Status", -- NEEDS TRANSLATION
+		TabBattle = "Battle", -- NEEDS TRANSLATION
+	},
 	MoveHistoryScreen = {
 		HeaderMoves = "Move seen at level", -- NEEDS TRANSLATION
 		HeaderMin = "Min", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/German.lua
+++ b/ironmon_tracker/Languages/German.lua
@@ -476,6 +476,13 @@ ScreenResources{
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION
 		LabelEvoShort = "Evo", -- NEEDS TRANSLATION
 	},
+	HealsInBagScreen = {
+		TabAll = "All", -- NEEDS TRANSLATION
+		TabHP = "HP", -- NEEDS TRANSLATION
+		TabPP = "PP", -- NEEDS TRANSLATION
+		TabStatus = "Status", -- NEEDS TRANSLATION
+		TabBattle = "Battle", -- NEEDS TRANSLATION
+	},
 	MoveHistoryScreen = {
 		HeaderMoves = "Move seen at level", -- NEEDS TRANSLATION
 		HeaderMin = "Min", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Italian.lua
+++ b/ironmon_tracker/Languages/Italian.lua
@@ -476,6 +476,13 @@ ScreenResources{
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION
 		LabelEvoShort = "Evo", -- NEEDS TRANSLATION
 	},
+	HealsInBagScreen = {
+		TabAll = "All", -- NEEDS TRANSLATION
+		TabHP = "HP", -- NEEDS TRANSLATION
+		TabPP = "PP", -- NEEDS TRANSLATION
+		TabStatus = "Status", -- NEEDS TRANSLATION
+		TabBattle = "Battle", -- NEEDS TRANSLATION
+	},
 	MoveHistoryScreen = {
 		HeaderMoves = "Move seen at level", -- NEEDS TRANSLATION
 		HeaderMin = "Min", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Japanese.lua
+++ b/ironmon_tracker/Languages/Japanese.lua
@@ -478,6 +478,13 @@ ScreenResources{
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION
 		LabelEvoShort = "Evo", -- NEEDS TRANSLATION
 	},
+	HealsInBagScreen = {
+		TabAll = "All", -- NEEDS TRANSLATION
+		TabHP = "HP", -- NEEDS TRANSLATION
+		TabPP = "PP", -- NEEDS TRANSLATION
+		TabStatus = "Status", -- NEEDS TRANSLATION
+		TabBattle = "Battle", -- NEEDS TRANSLATION
+	},
 	MoveHistoryScreen = {
 		HeaderMoves = "Move seen at level", -- NEEDS TRANSLATION
 		HeaderMin = "Min", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Spanish.lua
+++ b/ironmon_tracker/Languages/Spanish.lua
@@ -476,6 +476,13 @@ ScreenResources{
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION
 		LabelEvoShort = "Evo", -- NEEDS TRANSLATION
 	},
+	HealsInBagScreen = {
+		TabAll = "All", -- NEEDS TRANSLATION
+		TabHP = "HP", -- NEEDS TRANSLATION
+		TabPP = "PP", -- NEEDS TRANSLATION
+		TabStatus = "Status", -- NEEDS TRANSLATION
+		TabBattle = "Battle", -- NEEDS TRANSLATION
+	},
 	MoveHistoryScreen = {
 		HeaderMoves = "Move seen at level", -- NEEDS TRANSLATION
 		HeaderMin = "Min", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -29,11 +29,12 @@ Program.GameData = {
 	Items = {
 		healingTotal = 0, -- A calculation of total HP heals
 		healingPercentage = 0, -- A calculation of percentage heals
-		HPHeals = {}, -- Map of [itemId] -> quanity of item
-		PPHeals = {}, -- Map of [itemId] -> quanity of item
-		StatusHeals = {}, -- Map of [itemId] -> quanity of item
-		EvoStones = {}, -- Map of [itemId] -> quanity of item
-		Other = {}, -- Map of [itemId] -> quanity of item
+		-- Each of the below: map of [itemId] -> quanity of item
+		HPHeals = {},
+		PPHeals = {},
+		StatusHeals = {},
+		EvoStones = {},
+		Other = {},
 	},
 }
 
@@ -1009,6 +1010,9 @@ function Program.updateBagItems()
 	local addressesToScan = {
 		[saveBlock1Addr + GameSettings.bagPocket_Items_offset] = GameSettings.bagPocket_Items_Size,
 		[saveBlock1Addr + GameSettings.bagPocket_Berries_offset] = GameSettings.bagPocket_Berries_Size,
+		-- Don't have a use for these yet, so not reading them from memory
+		-- [saveBlock1Addr + GameSettings.bagPocket_Balls_offset] = GameSettings.bagPocket_Balls_Size,
+		-- [saveBlock1Addr + GameSettings.bagPocket_TmHm_offset] = GameSettings.bagPocket_TmHm_Size,
 	}
 	for address, size in pairs(addressesToScan) do
 		for i = 0, (size - 1), 1 do

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -25,13 +25,15 @@ Program.GameData = {
 	wildBattles = -999, -- used to track differences in GAME STATS
 	trainerBattles = -999, -- used to track differences in GAME STATS
 	friendshipRequired = 220,
-	evolutionStones = { -- The evolution stones currently in bag
-			[93] = 0, -- Sun Stone
-			[94] = 0, -- Moon Stone
-			[95] = 0, -- Fire Stone
-			[96] = 0, -- Thunder Stone
-			[97] = 0, -- Water Stone
-			[98] = 0, -- Leaf Stone
+	-- All items currently found in the player's bag
+	Items = {
+		healingTotal = 0, -- A calculation of total HP heals
+		healingPercentage = 0, -- A calculation of percentage heals
+		HPHeals = {}, -- Map of [itemId] -> quanity of item
+		PPHeals = {}, -- Map of [itemId] -> quanity of item
+		StatusHeals = {}, -- Map of [itemId] -> quanity of item
+		EvoStones = {}, -- Map of [itemId] -> quanity of item
+		Other = {}, -- Map of [itemId] -> quanity of item
 	},
 }
 
@@ -991,69 +993,16 @@ function Program.validPokemonData(pokemonData)
 end
 
 function Program.updateBagItems()
-	if not Tracker.Data.isViewingOwn then return end
-
-	local leadPokemon = Battle.getViewedPokemon(true)
-	if leadPokemon ~= nil then
-		local healingItems, evolutionStones = Program.getBagItems()
-		if healingItems ~= nil then
-			Tracker.Data.healingItems = Program.calcBagHealingItems(leadPokemon.stats.hp, healingItems)
-		end
-		if evolutionStones ~= nil then
-			Program.GameData.evolutionStones = evolutionStones
-		end
-	end
-end
-
-function Program.calcBagHealingItems(pokemonMaxHP, healingItemsInBag)
-	local totals = {
-		healing = 0,
-		numHeals = 0,
+	Program.GameData.Items = {
+		healingTotal = 0,
+		healingPercentage = 0,
+		HPHeals = {},
+		PPHeals = {},
+		StatusHeals = {},
+		EvoStones = {},
+		Other = {},
 	}
-
-	-- Check for potential divide-by-zero errors
-	if pokemonMaxHP == nil or pokemonMaxHP == 0 then
-		return totals
-	end
-
-	-- Define some max values to prevent erroneous game data reads
-	local maxPossibleQuantity = 999
-	-- Formatted as: healingItemsInBag[itemID] = quantity
-	for itemID, quantity in pairs(healingItemsInBag) do
-		local healItemData = MiscData.HealingItems[itemID]
-		if healItemData ~= nil and quantity > 0 then
-			local healingPercentage = 0
-			if healItemData.type == MiscData.HealingType.Constant then
-				-- Healing is in a percentage compared to the mon's max HP
-				local percentage = healItemData.amount / pokemonMaxHP * 100
-				if percentage > 100 then
-					percentage = 100
-				end
-				healingPercentage = percentage * quantity
-			elseif healItemData.type == MiscData.HealingType.Percentage then
-				healingPercentage = healItemData.amount * quantity
-			end
-
-			if quantity > 0 and quantity <= maxPossibleQuantity then
-				totals.healing = totals.healing + healingPercentage
-				totals.numHeals = totals.numHeals + quantity
-			end
-		end
-	end
-
-	return totals
-end
-
-function Program.getBagItems()
-	local healingItems = {}
-	local evoStones = {
-		[93] = 0, -- Sun Stone
-		[94] = 0, -- Moon Stone
-		[95] = 0, -- Fire Stone
-		[96] = 0, -- Thunder Stone
-		[97] = 0, -- Water Stone
-		[98] = 0, -- Leaf Stone
-	}
+	local items = Program.GameData.Items
 
 	local key = Utils.getEncryptionKey(2) -- Want a 16-bit key
 	local saveBlock1Addr = Utils.getSaveBlock1Addr()
@@ -1063,21 +1012,60 @@ function Program.getBagItems()
 	}
 	for address, size in pairs(addressesToScan) do
 		for i = 0, (size - 1), 1 do
-			--read 4 bytes at once, should be less expensive than reading two sets of 2 bytes.
+			-- Read 4 bytes at once, should be less expensive than reading two sets of 2 bytes.
 			local itemid_and_quantity = Memory.readdword(address + i * 0x4)
 			local itemID = Utils.getbits(itemid_and_quantity, 0, 16)
-			if itemID ~= 0 then
+			-- Only add to items if the item exists
+			if MiscData.Items[itemID] then
 				local quantity = Utils.getbits(itemid_and_quantity, 16, 16)
-				if key ~= nil then quantity = Utils.bit_xor(quantity, key) end
-
-				if MiscData.HealingItems[itemID] ~= nil then
-					healingItems[itemID] = quantity
-				elseif MiscData.EvolutionStones[itemID] ~= nil then
-					evoStones[itemID] = quantity
+				if key ~= nil then
+					quantity = Utils.bit_xor(quantity, key)
+				end
+				if quantity > 0 then
+					if MiscData.HealingItems[itemID] then
+						items.HPHeals[itemID] = quantity
+					elseif MiscData.PPItems[itemID] then
+						items.PPHeals[itemID] = quantity
+					elseif MiscData.StatusItems[itemID] then
+						items.StatusHeals[itemID] = quantity
+					elseif MiscData.EvolutionStones[itemID] then
+						items.EvoStones[itemID] = quantity
+					else
+						items.Other[itemID] = quantity
+					end
 				end
 			end
 		end
 	end
 
-	return healingItems, evoStones
+	-- After updating items in bag, recalculate lead mon heals info
+	Program.calcLeadPokemonHealingInfo()
+end
+
+function Program.calcLeadPokemonHealingInfo()
+	local leadPokemon = Battle.getViewedPokemon(true) or Tracker.getDefaultPokemon()
+	local maxHP = leadPokemon.stats.hp or 0
+	if not Tracker.Data.isViewingOwn or maxHP == 0 then
+		return
+	end
+
+	local items = Program.GameData.Items
+	items.healingTotal = 0
+	items.healingPercentage = 0
+
+	for itemID, quantity in pairs(items.HPHeals or {}) do
+		-- An arbitrary max value to prevent erroneous game data reads
+		if quantity <= 999 then
+			local healItemData = MiscData.HealingItems[itemID] or {}
+			local percentageAmt = 0
+			if healItemData.type == MiscData.HealingType.Constant then
+				-- Healing is in a percentage compared to the mon's max HP
+				percentageAmt = quantity * math.min(healItemData.amount / maxHP * 100, 100) -- max of 100
+			elseif healItemData.type == MiscData.HealingType.Percentage then
+				percentageAmt = quantity * healItemData.amount
+			end
+			items.healingTotal = items.healingTotal + quantity
+			items.healingPercentage = items.healingPercentage + percentageAmt
+		end
+	end
 end

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -511,10 +511,10 @@ function Tracker.resetData()
 		gameStatsHeals = 0, -- Tally of auto-tracked heals, separate to allow manual adjusting of centerHeals
 		centerHeals = Utils.inlineIf(Options["PC heals count downward"], 10, 0),
 		-- items = {}, -- Currently unused. If plans to use, this would instead be stored under allPokemon tracked data
-		healingItems = {
-			healing = 0,
-			numHeals = 0,
-		},
+		-- healingItems = { -- No longer in use, moved to Program.GameData.Items
+		-- 	healing = 0,
+		-- 	numHeals = 0,
+		-- },
 		hiddenPowers = { -- Track hidden power types for each of your own Pokemon [personality] = [type]
 			[0] = MoveData.HiddenPowerTypeList[1],
 		},

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -845,14 +845,13 @@ end
 -- Checks if the player has a usable stone in their bag to evolve the pokémon
 function Utils.isReadyToEvolveByStone(evoMethod)
 	evoMethod = evoMethod or PokemonData.Evolutions.NONE
-
 	if evoMethod.evoItemIds == nil then
 		return false
 	end
 
 	-- Check through the possible evolutions with the stones available
-	for itemID, quantity in pairs(Program.GameData.evolutionStones) do
-		if quantity > 0 and evoMethod.evoItemIds[itemID] then
+	for itemID, quantity in pairs(Program.GameData.Items.EvoStones or {}) do
+		if evoMethod.evoItemIds[itemID] then
 			return true
 		end
 	end

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -845,17 +845,12 @@ end
 -- Checks if the player has a usable stone in their bag to evolve the pokémon
 function Utils.isReadyToEvolveByStone(evoMethod)
 	evoMethod = evoMethod or PokemonData.Evolutions.NONE
-	if evoMethod.evoItemIds == nil then
-		return false
-	end
-
 	-- Check through the possible evolutions with the stones available
-	for itemID, quantity in pairs(Program.GameData.Items.EvoStones or {}) do
-		if evoMethod.evoItemIds[itemID] then
+	for _, itemID in pairs(evoMethod.evoItemIds or {}) do
+		if Program.GameData.Items.EvoStones[itemID] then
 			return true
 		end
 	end
-
 	return false
 end
 

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -349,8 +349,8 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 	end
 
 	-- MISC DATA (data.x)
-	data.x.healperc = math.min(9999, Tracker.Data.healingItems.healing or 0)
-	data.x.healnum = math.min(99, Tracker.Data.healingItems.numHeals or 0)
+	data.x.healperc = math.min(9999, Program.GameData.Items.healingPercentage or 0) -- Max of 9999
+	data.x.healnum = math.min(99, Program.GameData.Items.healingTotal or 0) -- Max of 99
 	data.x.pcheals = Tracker.Data.centerHeals
 
 	data.x.route = Constants.BLANKLINE

--- a/ironmon_tracker/data/MiscData.lua
+++ b/ironmon_tracker/data/MiscData.lua
@@ -17,8 +17,8 @@ MiscData.BagPocket = {
 }
 
 MiscData.HealingType = {
-	Constant = 0,
-	Percentage = 1,
+	Constant = "Constant",
+	Percentage = "Percentage",
 }
 
 -- Currently unused data
@@ -77,6 +77,20 @@ end
 -- Ordered lists that are populated from Resources
 MiscData.Natures = {}
 MiscData.Items = {}
+
+-- Don't have a use for these yet
+-- MiscData.PokeBalls = {}
+-- MiscData.TMs = {}
+-- MiscData.HMs = {}
+-- for i=1, 12, 1 do
+-- 	MiscData.PokeBalls[i] = true
+-- end
+-- for i=289, 338, 1 do
+-- 	MiscData.TMs[i] = true
+-- end
+-- for i=339, 346, 1 do
+-- 	MiscData.HMs[i] = true
+-- end
 
 MiscData.HealingItems = {
 	[13] = {

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -62,70 +62,70 @@ PokemonData.Evolutions = {
 		abbreviation = "STONE",
 		short = { "Thunder", "Water", "Fire", "Sun", "Moon", },
 		detailed = { "5 Diff. Stones", },
-		evoItemIds = { [93] = true, [94] = true, [95] = true, [96] = true, [97] = true, },
+		evoItemIds = { 93, 94, 95, 96, 97 },
 	},
 	-- Thunder stone item
 	THUNDER = {
 		abbreviation = "THUNDER",
 		short = { "Thunder", },
 		detailed = { "Thunder Stone", },
-		evoItemIds = { [96] = true, },
+		evoItemIds = { 96 },
 	},
 	-- Fire stone item
 	FIRE = {
 		abbreviation = "FIRE",
 		short = { "Fire", },
 		detailed = { "Fire Stone", },
-		evoItemIds = { [95] = true, },
+		evoItemIds = { 95 },
 	},
 	-- Water stone item
 	WATER = {
 		abbreviation = "WATER",
 		short = { "Water", },
 		detailed = { "Water Stone", },
-		evoItemIds = { [97] = true, },
+		evoItemIds = { 97 },
 	},
 	-- Moon stone item
 	MOON = {
 		abbreviation = "MOON",
 		short = { "Moon", },
 		detailed = { "Moon Stone", },
-		evoItemIds = { [94] = true, },
+		evoItemIds = { 94 },
 	},
 	-- Leaf stone item
 	LEAF = {
 		abbreviation = "LEAF",
 		short = { "Leaf", },
 		detailed = { "Leaf Stone", },
-		evoItemIds = { [98] = true, },
+		evoItemIds = { 98 },
 	},
 	-- Sun stone item
 	SUN = {
 		abbreviation = "SUN",
 		short = { "Sun", },
 		detailed = { "Sun Stone", },
-		evoItemIds = { [93] = true, },
+		evoItemIds = { 93 },
 	},
 	-- Leaf or Sun stone items
 	LEAF_SUN = {
 		abbreviation = "LF/SN",
 		short = { "Leaf", "Sun", },
 		detailed = { "Leaf Stone", "Sun Stone", },
-		evoItemIds = { [93] = true, [98] = true, },
+		evoItemIds = { 93, 98, },
 	},
 	-- Water stone item or at level 30
 	WATER30 = {
 		abbreviation = "30/WTR",
 		short = { "Lv.30", "Water", },
 		detailed = { "Level 30", "Water Stone", },
-		evoItemIds = { [97] = true, },
+		evoItemIds = { 97 },
 	},
 	-- Water stone item or at level 37
 	WATER37 = {
 		abbreviation = "37/WTR",
 		short = { "Lv.37", "Water", },
 		detailed = { "Level 37", "Water Stone", },
-		evoItemIds = { [97] = true, },
+		evoItemIds = { 97 },
 	},
 }
 

--- a/ironmon_tracker/screens/HealsInBagScreen.lua
+++ b/ironmon_tracker/screens/HealsInBagScreen.lua
@@ -1,0 +1,320 @@
+HealsInBagScreen = {
+	Colors = {
+		text = "Default text",
+		highlight = "Intermediate text",
+		border = "Upper box border",
+		boxFill = "Upper box background",
+	},
+	Tabs = {
+		All = {
+			index = 1,
+			tabKey = "All",
+			resourceKey = "TabAll",
+		},
+		HP = {
+			index = 2,
+			tabKey = "HP",
+			resourceKey = "TabHP",
+		},
+		PP = {
+			index = 3,
+			tabKey = "PP",
+			resourceKey = "TabPP",
+		},
+		Status = {
+			index = 4,
+			tabKey = "Status",
+			resourceKey = "TabStatus",
+		},
+		Battle = {
+			index = 5,
+			tabKey = "Battle",
+			resourceKey = "TabBattle",
+		},
+	},
+	currentView = 1,
+	currentTab = nil,
+}
+local SCREEN = HealsInBagScreen
+local TAB_HEIGHT = 12
+local BATTLE_ITEM_IDS = {}
+for i=39, 41, 1 do -- Flutes
+	BATTLE_ITEM_IDS[i] = true
+end
+for i=73, 79, 1 do -- X Items, Dire Hit, Guard Spec.
+	BATTLE_ITEM_IDS[i] = true
+end
+
+SCREEN.Buttons = {
+	CurrentPage = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		getText = function(self) return SCREEN.Pager:getPageText() end,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 56, Constants.SCREEN.MARGIN + 136, 50, 10, },
+		isVisible = function() return SCREEN.Pager.totalPages > 1 end,
+	},
+	PrevPage = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = Constants.PixelImages.LEFT_ARROW,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 44, Constants.SCREEN.MARGIN + 137, 10, 10, },
+		isVisible = function() return SCREEN.Pager.totalPages > 1 end,
+		onClick = function(self)
+			SCREEN.Pager:prevPage()
+		end
+	},
+	NextPage = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = Constants.PixelImages.RIGHT_ARROW,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 87, Constants.SCREEN.MARGIN + 137, 10, 10, },
+		isVisible = function() return SCREEN.Pager.totalPages > 1 end,
+		onClick = function(self)
+			SCREEN.Pager:nextPage()
+		end
+	},
+	Back = Drawing.createUIElementBackButton(function()
+		Program.changeScreenView(TrackerScreen)
+	end),
+}
+
+SCREEN.Pager = {
+	Buttons = {},
+	currentPage = 0,
+	totalPages = 0,
+	defaultSort = function(a, b) return (a.sortValue or 0) > (b.sortValue or 0) or (a.sortValue == b.sortValue and a.id < b.id) end,
+	realignButtonsToGrid = function(self)
+		table.sort(self.Buttons, self.defaultSort)
+		local x = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 26
+		local y = Constants.SCREEN.MARGIN + 17
+		local cutoffX = Constants.SCREEN.WIDTH + Constants.SCREEN.RIGHT_GAP - Constants.SCREEN.MARGIN
+		local cutoffY = Constants.SCREEN.HEIGHT - Constants.SCREEN.MARGIN - 10
+		local totalPages = Utils.gridAlign(self.Buttons, x, y, 2, 2, true, cutoffX, cutoffY)
+		self.currentPage = 1
+		self.totalPages = totalPages or 1
+	end,
+	getPageText = function(self)
+		if self.totalPages <= 1 then return Resources.AllScreens.Page end
+		local buffer = Utils.inlineIf(self.currentPage > 9, "", " ") .. Utils.inlineIf(self.totalPages > 9, "", " ")
+		return buffer .. string.format("%s/%s", self.currentPage, self.totalPages)
+	end,
+	prevPage = function(self)
+		if self.totalPages <= 1 then return end
+		self.currentPage = ((self.currentPage - 2 + self.totalPages) % self.totalPages) + 1
+		Program.redraw(true)
+	end,
+	nextPage = function(self)
+		if self.totalPages <= 1 then return end
+		self.currentPage = (self.currentPage % self.totalPages) + 1
+		Program.redraw(true)
+	end,
+}
+
+function HealsInBagScreen.initialize()
+	SCREEN.currentView = 1
+	SCREEN.currentTab = SCREEN.Tabs.HP
+	SCREEN.createButtons()
+
+	for _, button in pairs(SCREEN.Buttons) do
+		if button.textColor == nil then
+			button.textColor = SCREEN.Colors.text
+		end
+		if button.boxColors == nil then
+			button.boxColors = { SCREEN.Colors.border, SCREEN.Colors.boxFill }
+		end
+	end
+
+	SCREEN.refreshButtons()
+end
+
+function HealsInBagScreen.refreshButtons()
+	for _, button in pairs(SCREEN.Buttons) do
+		if button.updateSelf ~= nil then
+			button:updateSelf()
+		end
+	end
+	for _, button in pairs(SCREEN.Pager.Buttons) do
+		if button.updateSelf ~= nil then
+			button:updateSelf()
+		end
+	end
+end
+
+function HealsInBagScreen.createButtons()
+	local startX = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN
+	local startY = Constants.SCREEN.MARGIN
+	local tabPadding = 5
+
+	-- TABS
+	for _, tab in ipairs(Utils.getSortedList(SCREEN.Tabs)) do
+		local tabText = Resources.HealsInBagScreen[tab.resourceKey]
+		local tabWidth = (tabPadding * 2) + Utils.calcWordPixelLength(tabText)
+		SCREEN.Buttons["Tab" .. tab.tabKey] = {
+			type = Constants.ButtonTypes.NO_BORDER,
+			getText = function(self) return tabText end,
+			tab = SCREEN.Tabs[tab.tabKey],
+			isSelected = false,
+			box = {	startX, startY, tabWidth, TAB_HEIGHT },
+			-- isVisible = function(self) return true end,
+			updateSelf = function(self)
+				self.isSelected = (self.tab == SCREEN.currentTab)
+				self.textColor = self.isSelected and SCREEN.Colors.highlight or SCREEN.Colors.text
+			end,
+			draw = function(self, shadowcolor)
+				local x, y = self.box[1], self.box[2]
+				local w, h = self.box[3], self.box[4]
+				local color = Theme.COLORS[self.boxColors[1]]
+				local bgColor = Theme.COLORS[self.boxColors[2]]
+				gui.drawRectangle(x + 1, y + 1, w - 1, h - 2, bgColor, bgColor) -- Box fill
+				if not self.isSelected then
+					gui.drawRectangle(x + 1, y + 1, w - 1, h - 2, Drawing.ColorEffects.DARKEN, Drawing.ColorEffects.DARKEN)
+				end
+				gui.drawLine(x + 1, y, x + w - 1, y, color) -- Top edge
+				gui.drawLine(x, y + 1, x, y + h - 1, color) -- Left edge
+				gui.drawLine(x + w, y + 1, x + w, y + h - 1, color) -- Right edge
+				if self.isSelected then
+					gui.drawLine(x + 1, y + h, x + w - 1, y + h, bgColor) -- Remove bottom edge
+				end
+				local centeredOffsetX = Utils.getCenteredTextX(self:getText(), w) - 2
+				Drawing.drawText(x + centeredOffsetX, y, self:getText(), Theme.COLORS[self.textColor], shadowcolor)
+			end,
+			onClick = function(self) SCREEN.changeTab(self.tab) end,
+		}
+		startX = startX + tabWidth
+	end
+end
+
+function HealsInBagScreen.buildPagedButtons(tab)
+	tab = tab or SCREEN.currentTab
+	SCREEN.Pager.Buttons = {}
+
+	-- Calculate a sorting value for a given item based on the amount it "heals"
+	local function calcSortValue(itemID)
+		local value = 0
+		local itemData = MiscData.HealingItems[itemID] or MiscData.PPItems[itemID] or MiscData.StatusItems[itemID] or {}
+		if MiscData.HealingItems[itemID] then
+			value = 50000
+		elseif MiscData.StatusItems[itemID] then
+			value = 40000
+		elseif MiscData.PPItems[itemID] then
+			value = 30000
+		elseif BATTLE_ITEM_IDS[itemID] then
+			value = 20000
+		end
+		if itemData.type == MiscData.HealingType.Percentage then
+			value = value + (itemData.amount or 0) + 1000
+		elseif itemData.type == MiscData.HealingType.Constant then
+			value = value + (itemData.amount or 0)
+		elseif itemData.type == MiscData.StatusType.All then -- The really good status items
+			value = value + 2
+		elseif MiscData.StatusItems[itemID] then -- All other status items
+			value = value + 1
+		end
+		return value
+	end
+
+	local tabContents = {}
+	if tab == SCREEN.Tabs.HP then
+		for itemID, _ in pairs(Program.GameData.Items.HPHeals or {}) do
+			local sortValue = calcSortValue(itemID)
+			table.insert(tabContents, { id = itemID, bagKey = "HPHeals", sortValue = sortValue })
+		end
+	elseif tab == SCREEN.Tabs.PP then
+		for itemID, _ in pairs(Program.GameData.Items.PPHeals or {}) do
+			local sortValue = calcSortValue(itemID)
+			table.insert(tabContents, { id = itemID, bagKey = "PPHeals", sortValue = sortValue })
+		end
+	elseif tab == SCREEN.Tabs.Status then
+		for itemID, _ in pairs(Program.GameData.Items.StatusHeals or {}) do
+			local sortValue = calcSortValue(itemID)
+			table.insert(tabContents, { id = itemID, bagKey = "StatusHeals", sortValue = sortValue })
+		end
+	elseif tab == SCREEN.Tabs.Battle then
+		for itemID, _ in pairs(Program.GameData.Items.Other or {}) do
+			if BATTLE_ITEM_IDS[itemID] then
+				table.insert(tabContents, { id = itemID, bagKey = "Other", sortValue = 20000 })
+			end
+		end
+	elseif tab == SCREEN.Tabs.All then
+		for bagKey, itemGroup in pairs(Program.GameData.Items) do
+			if type(itemGroup) == "table" then
+				for itemID, _ in pairs(itemGroup) do
+					local sortValue = calcSortValue(itemID)
+					table.insert(tabContents, { id = itemID, bagKey = bagKey, sortValue = sortValue })
+				end
+			end
+		end
+	end
+
+	for _, item in ipairs(tabContents) do
+		local button = {
+			type = Constants.ButtonTypes.NO_BORDER,
+			getText = function(self) return MiscData.Items[item.id] or Constants.BLANKLINE end,
+			tab = tab,
+			id = item.id,
+			sortValue = item.sortValue,
+			dimensions = { width = 85, height = 11, },
+			textColor = SCREEN.Colors.text,
+			boxColors = { SCREEN.Colors.border, SCREEN.Colors.boxFill },
+			isVisible = function(self) return SCREEN.Pager.currentPage == self.pageVisible end,
+			includeInGrid = function(self) return SCREEN.currentTab == self.tab end,
+			-- onClick = function(self)
+			-- 	InfoScreen.changeScreenView(InfoScreen.Screens.ITEM_INFO, self.id) -- implied redraw
+			-- end,
+			draw = function(self, shadowcolor)
+				local x, y = self.box[1], self.box[2]
+				local w, h = self.box[3], self.box[4]
+				local textColor = Theme.COLORS[self.textColor]
+				local bag = Program.GameData.Items[item.bagKey] or {}
+				local quantity = bag[item.id] or 0
+				if quantity == 69 then -- Nice
+					textColor = Theme.COLORS["Positive text"]
+				end
+				-- Draw the quantity off to the right
+				local quantityText = string.format("x%s", quantity)
+				local extraWidth = Utils.calcWordPixelLength(quantityText)
+				Drawing.drawText(x + w - extraWidth, y, quantityText, textColor, shadowcolor)
+			end,
+		}
+		table.insert(SCREEN.Pager.Buttons, button)
+	end
+	SCREEN.Pager:realignButtonsToGrid()
+end
+
+function HealsInBagScreen.changeTab(tab)
+	SCREEN.currentTab = tab
+	SCREEN.buildPagedButtons(tab)
+	SCREEN.refreshButtons()
+	Program.redraw(true)
+end
+
+-- USER INPUT FUNCTIONS
+function HealsInBagScreen.checkInput(xmouse, ymouse)
+	Input.checkButtonsClicked(xmouse, ymouse, SCREEN.Buttons)
+	Input.checkButtonsClicked(xmouse, ymouse, SCREEN.Pager.Buttons)
+end
+
+-- DRAWING FUNCTIONS
+function HealsInBagScreen.drawScreen()
+	Drawing.drawBackgroundAndMargins()
+
+	local canvas = {
+		x = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN,
+		y = Constants.SCREEN.MARGIN + TAB_HEIGHT,
+		width = Constants.SCREEN.RIGHT_GAP - (Constants.SCREEN.MARGIN * 2),
+		height = Constants.SCREEN.HEIGHT - (Constants.SCREEN.MARGIN * 2) - TAB_HEIGHT,
+		text = Theme.COLORS[SCREEN.Colors.text],
+		border = Theme.COLORS[SCREEN.Colors.border],
+		fill = Theme.COLORS[SCREEN.Colors.boxFill],
+		shadow = Utils.calcShadowColor(Theme.COLORS[SCREEN.Colors.boxFill]),
+	}
+
+	-- Draw top border box
+	gui.defaultTextBackground(canvas.fill)
+	gui.drawRectangle(canvas.x, canvas.y, canvas.width, canvas.height, canvas.border, canvas.fill)
+
+	-- Draw all buttons
+	for _, button in pairs(SCREEN.Buttons) do
+		Drawing.drawButton(button, canvas.shadow)
+	end
+	for _, button in pairs(SCREEN.Pager.Buttons) do
+		Drawing.drawButton(button, canvas.shadow)
+	end
+end

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -188,6 +188,16 @@ TrackerScreen.Buttons = {
 			end
 		end
 	},
+	HealsInBag = {
+		-- Invisible clickable button
+		type = Constants.ButtonTypes.NO_BORDER,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN, Constants.SCREEN.MARGIN + 54, 55, 21 },
+		isVisible = function() return Tracker.Data.isViewingOwn end,
+		onClick = function(self)
+			HealsInBagScreen.changeTab(HealsInBagScreen.Tabs.HP)
+			Program.changeScreenView(HealsInBagScreen)
+		end
+	},
 	MovesHistory = {
 		-- Invisible clickable button
 		type = Constants.ButtonTypes.NO_BORDER,


### PR DESCRIPTION
This feature adds an easily accessible screen for viewing what items are in your bag. Primarily useful for seeing what heals (hp, status, pp) and battle items are available.

To get to the screen, simply click on the "Heals:" box area on the main Tracker Screen (Defaults to showing the "HP" tab).

![image](https://github.com/besteon/Ironmon-Tracker/assets/4258818/1cde57bf-bed2-41f0-838f-8b7ea7c0ab41)

Also added in memory address offsets for Poké Balls and TMs/HMs, but not currently using them yet.