### PR TITLE
Battle started flag

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -150,8 +150,6 @@ function Battle.updateBattleStatus()
 			},
 			[false] = {
 				[GameSettings.BattleIntroOpponentSendsOutMonAnimation] = true, -- trainer encounter
-				[GameSettings.BattleIntroOpponent2SendsOutMonAnimation] = true,
-				[GameSettings.BattleIntroRecordMonsToDex] = true,
 				[GameSettings.HandleTurnActionSelectionState] = true,
 			},
 		},

--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -150,6 +150,8 @@ function Battle.updateBattleStatus()
 			},
 			[false] = {
 				[GameSettings.BattleIntroOpponentSendsOutMonAnimation] = true, -- trainer encounter
+				[GameSettings.BattleIntroOpponent2SendsOutMonAnimation] = true,
+				[GameSettings.BattleIntroRecordMonsToDex] = true,
 				[GameSettings.HandleTurnActionSelectionState] = true,
 			},
 		},

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -661,24 +661,9 @@ function GameSettings.setRomAddresses(gameIndex, versionIndex)
 		BattleIntroOpponentSendsOutMonAnimation = {
 			{ 0x080118C5, 0x080118C5, 0x080118C5 }, --bc_801362C
 			{ 0x080118C5, 0x080118C5, 0x080118C5 },
-			{ 0x0803b25d },
+			{ 0x0803b315 }, --BattleIntroRecordMonsToDex for Emerald
 			{ 0x0801359d, 0x080135b1, 0x0801359D, 0x080135B1, 0x0801359D, 0x080135B1, 0x08012E59 },
 			{ 0x0801359d, 0x080135b1 },
-		},
-		--Only exists for Emerald
-		BattleIntroOpponent2SendsOutMonAnimation = {
-			{ nil, nil, nil },
-			{ nil, nil, nil },
-			{ 0x0803b1dd },
-			{ nil, nil, nil, nil, nil, nil, nil },
-			{ nil, nil },
-		},
-		BattleIntroRecordMonsToDex = {
-			{ 0x08011a69, 0x08011a69, 0x08011a69 }, --unref_sub_8011A68
-			{ 0x08011a69, 0x08011a69, 0x08011a69 },
-			{ 0x0803b315 },
-			{ 0x0801362d, 0x08013641, 0x0801359D, 0x080135B1, 0x0801359D, 0x080135B1, 0x08012E59 },
-			{ 0x0801362d, 0x08013641 },
 		},
 		HandleTurnActionSelectionState = {
 			{ 0x08012325, 0x08012325, 0x08012325 }, --sub_8012324

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -665,6 +665,21 @@ function GameSettings.setRomAddresses(gameIndex, versionIndex)
 			{ 0x0801359d, 0x080135b1, 0x0801359D, 0x080135B1, 0x0801359D, 0x080135B1, 0x08012E59 },
 			{ 0x0801359d, 0x080135b1 },
 		},
+		--Only exists for Emerald
+		BattleIntroOpponent2SendsOutMonAnimation = {
+			{ nil, nil, nil },
+			{ nil, nil, nil },
+			{ 0x0803b1dd },
+			{ nil, nil, nil, nil, nil, nil, nil },
+			{ nil, nil },
+		},
+		BattleIntroRecordMonsToDex = {
+			{ 0x08011a69, 0x08011a69, 0x08011a69 }, --unref_sub_8011A68
+			{ 0x08011a69, 0x08011a69, 0x08011a69 },
+			{ 0x0803b315 },
+			{ 0x0801362d, 0x08013641, 0x0801359D, 0x080135B1, 0x0801359D, 0x080135B1, 0x08012E59 },
+			{ 0x0801362d, 0x08013641 },
+		},
 		HandleTurnActionSelectionState = {
 			{ 0x08012325, 0x08012325, 0x08012325 }, --sub_8012324
 			{ 0x08012325, 0x08012325, 0x08012325 },


### PR DESCRIPTION
- Emerald works a little differently due to how many "artificial" double battles can take place, and actually spends the bulk of its time in the BattleIntroRecordMonsToDex script. Previous address caused unreliable battle start times for some trainers since the script addresses from other games were only present for a few frames in Emerald.