### PR TITLE
Patch 8.3.9

### DIFF
--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "8", minor = "3", patch = "8" }
+Main.Version = { major = "8", minor = "3", patch = "9" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -194,7 +194,6 @@ Program.Pedometer = {
 
 Program.AutoSaver = {
 	knownSaveCount = 0,
-	framesUntilNextSave = -1,
 	updateSaveCount = function(self) -- returns true if the savecount has been updated
 		local currentSaveCount = Utils.getGameStat(Constants.GAME_STATS.SAVED_GAME) or 0
 		local saveSuccessCountdown = Memory.readbyte(GameSettings.sSaveDialogDelay) or 0
@@ -228,7 +227,26 @@ function Program.initialize()
 
 	if Main.IsOnBizhawk() then
 		Program.clientFpsMultiplier = math.max(client.get_approx_framerate() / 60, 1) -- minimum of 1
+	else
+		Program.clientFpsMultiplier = 1
 	end
+
+	-- Reset variables when a new game is loaded
+	Program.inStartMenu = false
+	Program.inCatchingTutorial = false
+	Program.hasCompletedTutorial = false
+	Program.activeFormId = 0
+	Program.lastActiveTimestamp = os.time()
+	Program.Frames.waitToDraw = 1
+	Program.Frames.highAccuracyUpdate = 0
+	Program.Frames.lowAccuracyUpdate = 0
+	Program.Frames.three_sec_update = 0
+	Program.Frames.saveData = 3600
+	Program.Frames.carouselActive = 0
+	Program.Frames.Others = {}
+
+	Program.GameData.PlayerTeam = {}
+	Program.GameData.EnemyTeam = {}
 
 	-- Check if requirement for Friendship evos has changed (Default:219, MakeEvolutionsFaster:159)
 	local friendshipRequired = Memory.readbyte(GameSettings.FriendshipRequiredToEvo) + 1
@@ -237,19 +255,8 @@ function Program.initialize()
 	end
 
 	Program.Pedometer:initialize()
-	Program.AutoSaver:updateSaveCount()
 	Program.GameTimer:initialize()
-	Program.lastActiveTimestamp = os.time()
-
-	Program.GameData.PlayerTeam = {}
-	Program.GameData.EnemyTeam = {}
-
-	-- Update data asap
-	Program.Frames.highAccuracyUpdate = 0
-	Program.Frames.lowAccuracyUpdate = 0
-	Program.Frames.three_sec_update = 0
-	Program.Frames.waitToDraw = 1
-	Program.Frames.Others = {}
+	Program.AutoSaver:updateSaveCount()
 end
 
 function Program.mainLoop()

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -177,7 +177,14 @@ Program.Pedometer = {
 	totalSteps = 0, -- updated from GAME_STATS
 	lastResetCount = 0, -- num steps since last "reset", for counting new steps
 	goalSteps = 0, -- num steps that is set by the user as a milestone goal to reach, 0 to disable
-	getCurrentStepcount = function(self) return math.max(self.totalSteps - self.lastResetCount, 0) end,
+	initialize = function(self)
+		self.totalSteps = 0
+		self.lastResetCount = 0
+		self.goalSteps = 0
+	end,
+	getCurrentStepcount = function(self)
+		return math.max(self.totalSteps - self.lastResetCount, 0)
+	end,
 	isInUse = function(self)
 		local enabledAndAllowed = Options["Display pedometer"] and Program.isValidMapLocation()
 		local hasConflict = Battle.inActiveBattle() or LogOverlay.isDisplayed or GameOverScreen.status ~= GameOverScreen.Statuses.STILL_PLAYING
@@ -229,6 +236,7 @@ function Program.initialize()
 		Program.GameData.friendshipRequired = friendshipRequired
 	end
 
+	Program.Pedometer:initialize()
 	Program.AutoSaver:updateSaveCount()
 	Program.GameTimer:initialize()
 	Program.lastActiveTimestamp = os.time()

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -204,7 +204,7 @@ function PokemonData.buildPokemonData()
 			local typeTwo = Utils.getbits(typesData, 8, 8)
 			pokemon.types = {
 				PokemonData.TypeIndexMap[typeOne],
-				PokemonData.TypeIndexMap[typeTwo],
+				typeOne ~= typeTwo and PokemonData.TypeIndexMap[typeTwo] or PokemonData.Types.EMPTY,
 			}
 
 			-- Exp Yield (1 byte)

--- a/ironmon_tracker/screens/CoverageCalcScreen.lua
+++ b/ironmon_tracker/screens/CoverageCalcScreen.lua
@@ -521,7 +521,9 @@ function CoverageCalcScreen.calculateCoverageTable(moveTypes, onlyFullyEvolved)
 			local eff = MoveData.TypeToEffectiveness[moveType] or {}
 			local moveEff = 1
 			moveEff = moveEff * (eff[type1] or 1)
-			moveEff = moveEff * (eff[type2] or 1)
+			if type1 ~= type2 then -- Don't check twice against mono-type Pokémon
+				moveEff = moveEff * (eff[type2] or 1)
+			end
 			if moveEff > highestEff then
 				highestEff = moveEff
 			end


### PR DESCRIPTION
### Release Notes
- [8.3.9] Fixed an issue with the Coverage Calculator incorrectly counting single-typed Pokémon as dual-type.
- [8.3.9] Fixed an issue where the step counter could get stuck at 0 steps at the beginning of a new game.

A note about the variables being reset: because they are defined outside of a function, Bizhawk does *not* properly reset them when a new game is started while the script is still running. They must be set in the init function to properly reset to default values.