### PR TITLE
Revert FileManager Utils changes

### DIFF
--- a/ironmon_tracker/FileManager.lua
+++ b/ironmon_tracker/FileManager.lua
@@ -617,7 +617,7 @@ function FileManager.readTableFromFile(filepath)
 
 	if file ~= nil then
 		local dataString = file:read("*a")
-		if not Utils.isNilOrEmpty(dataString) then
+		if dataString ~= nil and dataString ~= "" then
 			tableData = Pickle.unpickle(dataString)
 		end
 		file:close()
@@ -641,7 +641,7 @@ function FileManager.readLinesFromFile(filename)
 	end
 
 	local fileContents = file:read("*a")
-	if not Utils.isNilOrEmpty(fileContents) then
+	if fileContents ~= nil and fileContents ~= "" then
 		for line in fileContents:gmatch("([^\r\n]+)[\r\n]*") do
 			if line ~= nil then
 				table.insert(lines, line)

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "8", minor = "4", patch = "0" }
+Main.Version = { major = "8", minor = "4", patch = "1" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",


### PR DESCRIPTION
Tracker broke because of attempting to use Utils funcs before Utils is actually loaded, reverting use of funcs just in case