### PR TITLE
Retry Battle bugfix

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -784,8 +784,6 @@ function Battle.endCurrentBattle()
 	}
 
 	Program.recalcLeadPokemonHealingInfo()
-	-- While the below clears our currently stored enemy pokemon data, most gets read back in from memory anyway
-	Program.GameData.EnemyTeam = {}
 
 	-- Reset stat stage changes for the owner's pokemon team
 	for i=1, 6, 1 do


### PR DESCRIPTION
Fixing a bug where when resetting a battle, enemy pokemon were not being read so moves/abilities were not tracked post-mortem