### PR TITLE
Add Extensions support to MGBA

### DIFF
--- a/ironmon_tracker/Languages/English.lua
+++ b/ironmon_tracker/Languages/English.lua
@@ -692,6 +692,7 @@ ScreenResources{
 		MenuCheckForUpdates = "Check for Updates",
 		MenuNewUpdateVailable = "New Update Available",
 		MenuLanguage = "Language",
+		MenuExtensions = "Extensions",
 		MenuCommands = "Commands",
 		MenuBasicCommands = "Basic Commands",
 		MenuOtherCommands = "Other Commands",
@@ -745,6 +746,7 @@ ScreenResources{
 		OptionRandomizerJar = "Randomizer JAR",
 		OptionSourceRom = "Source ROM",
 		OptionSettingsFile = "Settings File",
+		OptionAllowCustomCode = "Allow custom code to run",
 		AnimatedPopoutRequired = "The Animated Pokemon popout add-on must be installed separately.\n Refer to the Tracker Wiki for more details on setting this up.",
 		JarFileRequired = "A '.jar' file is required; please enter the full file path to your Randomizer JAR file.",
 		GbaFileRequired = "A '.gba' file is required; please enter the full file path to your GBA ROM file.",
@@ -797,6 +799,10 @@ ScreenResources{
 		LanguageChangeWith = "Change your language with",
 		LanguageHeaderTag = "Tag",
 		LanguageHeaderLang = "Language",
+		ExtensionsInstallNewWith = "Install new extensions with",
+		ExtensionsInstalledExtensions = "Installed Extensions",
+		ExtensionsEnableDisable = "Enable/disable with",
+
 		CommandsDesc = "To use, type into below textbox. Example command",
 		CommandsUsageSyntax = "Usage Syntax",
 		CommandsExampleUsage = "Example Usage",
@@ -919,6 +925,9 @@ ScreenResources{
 		LanguageError1 = "Where 'language' is the name or # of a language. Check the Language sidebar menu.",
 		LanguageError2 = "Unable to find language",
 		LanguageSuccess = "The Tracker's display language has been updated.",
+		InstallExtDesc = "Installs new Extension files from the Tracker's extensions folder.",
+		InstallExtSuccess1 = "New extensions have been installed!",
+		InstallExtSuccess2 = "No new extension files found in the Tracker's extensions folder.",
 	},
 }
 

--- a/ironmon_tracker/Languages/French.lua
+++ b/ironmon_tracker/Languages/French.lua
@@ -694,6 +694,7 @@ ScreenResources{
 		MenuCheckForUpdates = "Check for Updates", -- NEEDS TRANSLATION
 		MenuNewUpdateVailable = "New Update Available", -- NEEDS TRANSLATION
 		MenuLanguage = "Language", -- NEEDS TRANSLATION
+		MenuExtensions = "Extensions", -- NEEDS TRANSLATION
 		MenuCommands = "Commands", -- NEEDS TRANSLATION
 		MenuBasicCommands = "Basic Commands", -- NEEDS TRANSLATION
 		MenuOtherCommands = "Other Commands", -- NEEDS TRANSLATION
@@ -747,6 +748,7 @@ ScreenResources{
 		OptionRandomizerJar = "Randomizer JAR", -- NEEDS TRANSLATION
 		OptionSourceRom = "Source ROM", -- NEEDS TRANSLATION
 		OptionSettingsFile = "Settings File", -- NEEDS TRANSLATION
+		OptionAllowCustomCode = "Allow custom code to run", -- NEEDS TRANSLATION
 		AnimatedPopoutRequired = "The Animated Pokemon popout add-on must be installed separately.\n Refer to the Tracker Wiki for more details on setting this up.", -- NEEDS TRANSLATION
 		JarFileRequired = "A '.jar' file is required; please enter the full file path to your Randomizer JAR file.", -- NEEDS TRANSLATION
 		GbaFileRequired = "A '.gba' file is required; please enter the full file path to your GBA ROM file.", -- NEEDS TRANSLATION
@@ -799,6 +801,9 @@ ScreenResources{
 		LanguageChangeWith = "Change your language with", -- NEEDS TRANSLATION
 		LanguageHeaderTag = "Tag", -- NEEDS TRANSLATION
 		LanguageHeaderLang = "Language", -- NEEDS TRANSLATION
+		ExtensionsInstallNewWith = "Install new extensions with", -- NEEDS TRANSLATION
+		ExtensionsInstalledExtensions = "Installed Extensions", -- NEEDS TRANSLATION
+		ExtensionsEnableDisable = "Enable/disable with", -- NEEDS TRANSLATION
 		CommandsDesc = "To use, type into below textbox. Example command", -- NEEDS TRANSLATION
 		CommandsUsageSyntax = "Usage Syntax", -- NEEDS TRANSLATION
 		CommandsExampleUsage = "Example Usage", -- NEEDS TRANSLATION
@@ -921,6 +926,9 @@ ScreenResources{
 		LanguageError1 = "Where 'language' is the name or # of a language. Check the Language sidebar menu.", -- NEEDS TRANSLATION
 		LanguageError2 = "Unable to find language", -- NEEDS TRANSLATION
 		LanguageSuccess = "The Tracker's display language has been updated.", -- NEEDS TRANSLATION
+		InstallExtDesc = "Installs new Extension files from the Tracker's extensions folder.", -- NEEDS TRANSLATION
+		InstallExtSuccess1 = "New extensions have been installed!", -- NEEDS TRANSLATION
+		InstallExtSuccess2 = "No new extension files found in the Tracker's extensions folder.", -- NEEDS TRANSLATION
 	},
 }
 

--- a/ironmon_tracker/Languages/German.lua
+++ b/ironmon_tracker/Languages/German.lua
@@ -694,6 +694,7 @@ ScreenResources{
 		MenuCheckForUpdates = "Check for Updates", -- NEEDS TRANSLATION
 		MenuNewUpdateVailable = "New Update Available", -- NEEDS TRANSLATION
 		MenuLanguage = "Language", -- NEEDS TRANSLATION
+		MenuExtensions = "Extensions", -- NEEDS TRANSLATION
 		MenuCommands = "Commands", -- NEEDS TRANSLATION
 		MenuBasicCommands = "Basic Commands", -- NEEDS TRANSLATION
 		MenuOtherCommands = "Other Commands", -- NEEDS TRANSLATION
@@ -747,6 +748,7 @@ ScreenResources{
 		OptionRandomizerJar = "Randomizer JAR", -- NEEDS TRANSLATION
 		OptionSourceRom = "Source ROM", -- NEEDS TRANSLATION
 		OptionSettingsFile = "Settings File", -- NEEDS TRANSLATION
+		OptionAllowCustomCode = "Allow custom code to run", -- NEEDS TRANSLATION
 		AnimatedPopoutRequired = "The Animated Pokemon popout add-on must be installed separately.\n Refer to the Tracker Wiki for more details on setting this up.", -- NEEDS TRANSLATION
 		JarFileRequired = "A '.jar' file is required; please enter the full file path to your Randomizer JAR file.", -- NEEDS TRANSLATION
 		GbaFileRequired = "A '.gba' file is required; please enter the full file path to your GBA ROM file.", -- NEEDS TRANSLATION
@@ -799,6 +801,9 @@ ScreenResources{
 		LanguageChangeWith = "Change your language with", -- NEEDS TRANSLATION
 		LanguageHeaderTag = "Tag", -- NEEDS TRANSLATION
 		LanguageHeaderLang = "Language", -- NEEDS TRANSLATION
+		ExtensionsInstallNewWith = "Install new extensions with", -- NEEDS TRANSLATION
+		ExtensionsInstalledExtensions = "Installed Extensions", -- NEEDS TRANSLATION
+		ExtensionsEnableDisable = "Enable/disable with", -- NEEDS TRANSLATION
 		CommandsDesc = "To use, type into below textbox. Example command", -- NEEDS TRANSLATION
 		CommandsUsageSyntax = "Usage Syntax", -- NEEDS TRANSLATION
 		CommandsExampleUsage = "Example Usage", -- NEEDS TRANSLATION
@@ -921,6 +926,9 @@ ScreenResources{
 		LanguageError1 = "Where 'language' is the name or # of a language. Check the Language sidebar menu.", -- NEEDS TRANSLATION
 		LanguageError2 = "Unable to find language", -- NEEDS TRANSLATION
 		LanguageSuccess = "The Tracker's display language has been updated.", -- NEEDS TRANSLATION
+		InstallExtDesc = "Installs new Extension files from the Tracker's extensions folder.", -- NEEDS TRANSLATION
+		InstallExtSuccess1 = "New extensions have been installed!", -- NEEDS TRANSLATION
+		InstallExtSuccess2 = "No new extension files found in the Tracker's extensions folder.", -- NEEDS TRANSLATION
 	},
 }
 

--- a/ironmon_tracker/Languages/Italian.lua
+++ b/ironmon_tracker/Languages/Italian.lua
@@ -694,6 +694,7 @@ ScreenResources{
 		MenuCheckForUpdates = "Check for Updates", -- NEEDS TRANSLATION
 		MenuNewUpdateVailable = "New Update Available", -- NEEDS TRANSLATION
 		MenuLanguage = "Language", -- NEEDS TRANSLATION
+		MenuExtensions = "Extensions", -- NEEDS TRANSLATION
 		MenuCommands = "Commands", -- NEEDS TRANSLATION
 		MenuBasicCommands = "Basic Commands", -- NEEDS TRANSLATION
 		MenuOtherCommands = "Other Commands", -- NEEDS TRANSLATION
@@ -747,6 +748,7 @@ ScreenResources{
 		OptionRandomizerJar = "Randomizer JAR", -- NEEDS TRANSLATION
 		OptionSourceRom = "Source ROM", -- NEEDS TRANSLATION
 		OptionSettingsFile = "Settings File", -- NEEDS TRANSLATION
+		OptionAllowCustomCode = "Allow custom code to run", -- NEEDS TRANSLATION
 		AnimatedPopoutRequired = "The Animated Pokemon popout add-on must be installed separately.\n Refer to the Tracker Wiki for more details on setting this up.", -- NEEDS TRANSLATION
 		JarFileRequired = "A '.jar' file is required; please enter the full file path to your Randomizer JAR file.", -- NEEDS TRANSLATION
 		GbaFileRequired = "A '.gba' file is required; please enter the full file path to your GBA ROM file.", -- NEEDS TRANSLATION
@@ -799,6 +801,9 @@ ScreenResources{
 		LanguageChangeWith = "Change your language with", -- NEEDS TRANSLATION
 		LanguageHeaderTag = "Tag", -- NEEDS TRANSLATION
 		LanguageHeaderLang = "Language", -- NEEDS TRANSLATION
+		ExtensionsInstallNewWith = "Install new extensions with", -- NEEDS TRANSLATION
+		ExtensionsInstalledExtensions = "Installed Extensions", -- NEEDS TRANSLATION
+		ExtensionsEnableDisable = "Enable/disable with", -- NEEDS TRANSLATION
 		CommandsDesc = "To use, type into below textbox. Example command", -- NEEDS TRANSLATION
 		CommandsUsageSyntax = "Usage Syntax", -- NEEDS TRANSLATION
 		CommandsExampleUsage = "Example Usage", -- NEEDS TRANSLATION
@@ -921,6 +926,9 @@ ScreenResources{
 		LanguageError1 = "Where 'language' is the name or # of a language. Check the Language sidebar menu.", -- NEEDS TRANSLATION
 		LanguageError2 = "Unable to find language", -- NEEDS TRANSLATION
 		LanguageSuccess = "The Tracker's display language has been updated.", -- NEEDS TRANSLATION
+		InstallExtDesc = "Installs new Extension files from the Tracker's extensions folder.", -- NEEDS TRANSLATION
+		InstallExtSuccess1 = "New extensions have been installed!", -- NEEDS TRANSLATION
+		InstallExtSuccess2 = "No new extension files found in the Tracker's extensions folder.", -- NEEDS TRANSLATION
 	},
 }
 

--- a/ironmon_tracker/Languages/Japanese.lua
+++ b/ironmon_tracker/Languages/Japanese.lua
@@ -696,6 +696,7 @@ ScreenResources{
 		MenuCheckForUpdates = "Check for Updates", -- NEEDS TRANSLATION
 		MenuNewUpdateVailable = "New Update Available", -- NEEDS TRANSLATION
 		MenuLanguage = "Language", -- NEEDS TRANSLATION
+		MenuExtensions = "Extensions", -- NEEDS TRANSLATION
 		MenuCommands = "Commands", -- NEEDS TRANSLATION
 		MenuBasicCommands = "Basic Commands", -- NEEDS TRANSLATION
 		MenuOtherCommands = "Other Commands", -- NEEDS TRANSLATION
@@ -749,6 +750,7 @@ ScreenResources{
 		OptionRandomizerJar = "Randomizer JAR", -- NEEDS TRANSLATION
 		OptionSourceRom = "Source ROM", -- NEEDS TRANSLATION
 		OptionSettingsFile = "Settings File", -- NEEDS TRANSLATION
+		OptionAllowCustomCode = "Allow custom code to run", -- NEEDS TRANSLATION
 		AnimatedPopoutRequired = "The Animated Pokemon popout add-on must be installed separately.\n Refer to the Tracker Wiki for more details on setting this up.", -- NEEDS TRANSLATION
 		JarFileRequired = "A '.jar' file is required; please enter the full file path to your Randomizer JAR file.", -- NEEDS TRANSLATION
 		GbaFileRequired = "A '.gba' file is required; please enter the full file path to your GBA ROM file.", -- NEEDS TRANSLATION
@@ -801,6 +803,9 @@ ScreenResources{
 		LanguageChangeWith = "Change your language with", -- NEEDS TRANSLATION
 		LanguageHeaderTag = "Tag", -- NEEDS TRANSLATION
 		LanguageHeaderLang = "Language", -- NEEDS TRANSLATION
+		ExtensionsInstallNewWith = "Install new extensions with", -- NEEDS TRANSLATION
+		ExtensionsInstalledExtensions = "Installed Extensions", -- NEEDS TRANSLATION
+		ExtensionsEnableDisable = "Enable/disable with", -- NEEDS TRANSLATION
 		CommandsDesc = "To use, type into below textbox. Example command", -- NEEDS TRANSLATION
 		CommandsUsageSyntax = "Usage Syntax", -- NEEDS TRANSLATION
 		CommandsExampleUsage = "Example Usage", -- NEEDS TRANSLATION
@@ -923,6 +928,9 @@ ScreenResources{
 		LanguageError1 = "Where 'language' is the name or # of a language. Check the Language sidebar menu.", -- NEEDS TRANSLATION
 		LanguageError2 = "Unable to find language", -- NEEDS TRANSLATION
 		LanguageSuccess = "The Tracker's display language has been updated.", -- NEEDS TRANSLATION
+		InstallExtDesc = "Installs new Extension files from the Tracker's extensions folder.", -- NEEDS TRANSLATION
+		InstallExtSuccess1 = "New extensions have been installed!", -- NEEDS TRANSLATION
+		InstallExtSuccess2 = "No new extension files found in the Tracker's extensions folder.", -- NEEDS TRANSLATION
 	},
 }
 

--- a/ironmon_tracker/Languages/Spanish.lua
+++ b/ironmon_tracker/Languages/Spanish.lua
@@ -694,6 +694,7 @@ ScreenResources{
 		MenuCheckForUpdates = "Check for Updates", -- NEEDS TRANSLATION
 		MenuNewUpdateVailable = "New Update Available", -- NEEDS TRANSLATION
 		MenuLanguage = "Language", -- NEEDS TRANSLATION
+		MenuExtensions = "Extensions", -- NEEDS TRANSLATION
 		MenuCommands = "Commands", -- NEEDS TRANSLATION
 		MenuBasicCommands = "Basic Commands", -- NEEDS TRANSLATION
 		MenuOtherCommands = "Other Commands", -- NEEDS TRANSLATION
@@ -747,6 +748,7 @@ ScreenResources{
 		OptionRandomizerJar = "Randomizer JAR", -- NEEDS TRANSLATION
 		OptionSourceRom = "Source ROM", -- NEEDS TRANSLATION
 		OptionSettingsFile = "Settings File", -- NEEDS TRANSLATION
+		OptionAllowCustomCode = "Allow custom code to run", -- NEEDS TRANSLATION
 		AnimatedPopoutRequired = "The Animated Pokemon popout add-on must be installed separately.\n Refer to the Tracker Wiki for more details on setting this up.", -- NEEDS TRANSLATION
 		JarFileRequired = "A '.jar' file is required; please enter the full file path to your Randomizer JAR file.", -- NEEDS TRANSLATION
 		GbaFileRequired = "A '.gba' file is required; please enter the full file path to your GBA ROM file.", -- NEEDS TRANSLATION
@@ -799,6 +801,9 @@ ScreenResources{
 		LanguageChangeWith = "Change your language with", -- NEEDS TRANSLATION
 		LanguageHeaderTag = "Tag", -- NEEDS TRANSLATION
 		LanguageHeaderLang = "Language", -- NEEDS TRANSLATION
+		ExtensionsInstallNewWith = "Install new extensions with", -- NEEDS TRANSLATION
+		ExtensionsInstalledExtensions = "Installed Extensions", -- NEEDS TRANSLATION
+		ExtensionsEnableDisable = "Enable/disable with", -- NEEDS TRANSLATION
 		CommandsDesc = "To use, type into below textbox. Example command", -- NEEDS TRANSLATION
 		CommandsUsageSyntax = "Usage Syntax", -- NEEDS TRANSLATION
 		CommandsExampleUsage = "Example Usage", -- NEEDS TRANSLATION
@@ -921,6 +926,9 @@ ScreenResources{
 		LanguageError1 = "Where 'language' is the name or # of a language. Check the Language sidebar menu.", -- NEEDS TRANSLATION
 		LanguageError2 = "Unable to find language", -- NEEDS TRANSLATION
 		LanguageSuccess = "The Tracker's display language has been updated.", -- NEEDS TRANSLATION
+		InstallExtDesc = "Installs new Extension files from the Tracker's extensions folder.", -- NEEDS TRANSLATION
+		InstallExtSuccess1 = "New extensions have been installed!", -- NEEDS TRANSLATION
+		InstallExtSuccess2 = "No new extension files found in the Tracker's extensions folder.", -- NEEDS TRANSLATION
 	},
 }
 

--- a/ironmon_tracker/MGBADisplay.lua
+++ b/ironmon_tracker/MGBADisplay.lua
@@ -1,4 +1,13 @@
-MGBADisplay = {}
+MGBADisplay = {
+	OptionValues = {
+		GENERAL_SETUP = 1,
+		CONTROLS = 11,
+		GAMEPLAY = 20,
+		NEW_RUNS = 30,
+		LANGUAGE = 40,
+		EXTENSIONS = 50,
+	},
+}
 
 MGBADisplay.Symbols = {
 	EmptyLine = "",
@@ -254,7 +263,7 @@ MGBADisplay.LineBuilder = {
 		table.insert(lines, Utils.formatUTF8("%s: %s", Resources.MGBAScreens.LabelToggleOption, MGBA.CommandMap["OPTION"].usageSyntax))
 
 		table.insert(lines, Utils.formatUTF8("%-2s %-20s [%s]", "#", Utils.toUpperUTF8(Resources.MGBAScreens.LabelOption), Utils.toUpperUTF8(Resources.MGBAScreens.LabelEnabled)))
-		for i = 1, 9, 1 do
+		for i = MGBADisplay.OptionValues.GENERAL_SETUP, MGBADisplay.OptionValues.CONTROLS - 1, 1 do
 			local opt = MGBA.OptionMap[i]
 			if opt ~= nil then
 				table.insert(lines, Utils.formatUTF8(optionBar, i, opt:getText(), opt:getValue()))
@@ -264,13 +273,13 @@ MGBADisplay.LineBuilder = {
 		table.insert(lines, MGBADisplay.Symbols.DividerLine)
 		table.insert(lines, Utils.formatUTF8("%s: OPTION \"# %s\"", Resources.MGBAScreens.GeneralSetupChange, Resources.MGBAScreens.GeneralSetupButtons))
 		table.insert(lines, Utils.formatUTF8("%-2s %-13s %16s", "#", Utils.toUpperUTF8(Resources.MGBAScreens.GeneralSetupControls), Utils.toUpperUTF8(Resources.MGBAScreens.GeneralSetupGBAButtons)))
-		for i = 10, 12, 1 do
+		for i = MGBADisplay.OptionValues.CONTROLS, MGBADisplay.OptionValues.CONTROLS + 3, 1 do
 			local opt = MGBA.OptionMap[i]
 			if opt ~= nil then
 				table.insert(lines, Utils.formatUTF8(controlBar, i, opt:getText(), opt:getValue()))
 			end
 		end
-		local qid = 13 -- "Quickload"
+		local qid = MGBADisplay.OptionValues.CONTROLS + 3 -- "Quickload"
 		if MGBA.OptionMap[qid] ~= nil then
 			table.insert(lines, Utils.formatUTF8("%-2s %-13s %16s", qid, MGBA.OptionMap[qid]:getText(), MGBA.OptionMap[qid]:getValue()))
 		end
@@ -288,7 +297,7 @@ MGBADisplay.LineBuilder = {
 		table.insert(lines, Utils.formatUTF8("%s: %s", Resources.MGBAScreens.LabelToggleOption, MGBA.CommandMap["OPTION"].usageSyntax))
 
 		table.insert(lines, Utils.formatUTF8("%-2s %-20s [%s]", "#", Utils.toUpperUTF8(Resources.MGBAScreens.LabelOption), Utils.toUpperUTF8(Resources.MGBAScreens.LabelEnabled)))
-		for i = 20, 28, 1 do
+		for i = MGBADisplay.OptionValues.GAMEPLAY, MGBADisplay.OptionValues.GAMEPLAY + 8, 1 do
 			local opt = MGBA.OptionMap[i]
 			if opt ~= nil then
 				table.insert(lines, Utils.formatUTF8(optionBar, i, opt:getText(), opt:getValue()))
@@ -315,7 +324,7 @@ MGBADisplay.LineBuilder = {
 		table.insert(lines, Utils.formatUTF8('%s: %s', Resources.MGBAScreens.QuickloadChooseMode, MGBA.CommandMap["OPTION"].usageSyntax))
 		table.insert(lines, Utils.formatUTF8("%-2s %-19s [%s]", "#", Utils.toUpperUTF8(Resources.MGBAScreens.QuickloadMode), Utils.toUpperUTF8(Resources.MGBAScreens.QuickloadSelected)))
 
-		for i = 30, 31, 1 do
+		for i = MGBADisplay.OptionValues.NEW_RUNS, MGBADisplay.OptionValues.NEW_RUNS + 1, 1 do
 			local opt = MGBA.OptionMap[i]
 			if opt ~= nil then
 				table.insert(lines, Utils.formatUTF8(optionBar, i, opt:getText(), opt:getValue()))
@@ -323,8 +332,12 @@ MGBADisplay.LineBuilder = {
 		end
 		table.insert(lines, MGBADisplay.Symbols.EmptyLine)
 
+		local batchOptionId = MGBADisplay.OptionValues.NEW_RUNS
+		local generateOptionId = MGBADisplay.OptionValues.NEW_RUNS + 1
+
 		-- local fileBar = "%-2s %-30s"
-		if MGBA.OptionMap[30] ~= nil and MGBA.OptionMap[30]:getValue() == MGBADisplay.Symbols.OptionEnabled then
+		if MGBA.OptionMap[batchOptionId] ~= nil and MGBA.OptionMap[batchOptionId]:getValue() == MGBADisplay.Symbols.OptionEnabled then
+			-- NOTE: If you UNCOMMON THIS CODE, don't use hardcoded option values like "32"
 			-- local romFolderId = 32
 			-- local opt = MGBA.OptionMap[romFolderId]
 			-- if opt ~= nil then
@@ -342,7 +355,8 @@ MGBADisplay.LineBuilder = {
 			table.insert(lines, Utils.formatUTF8("- %s", Resources.MGBAScreens.QuickloadMultipleRoms))
 			table.insert(lines, MGBADisplay.Symbols.EmptyLine)
 			table.insert(lines, MGBADisplay.Symbols.EmptyLine)
-		elseif MGBA.OptionMap[31] ~= nil and MGBA.OptionMap[31]:getValue() == MGBADisplay.Symbols.OptionEnabled then
+		elseif MGBA.OptionMap[generateOptionId] ~= nil and MGBA.OptionMap[generateOptionId]:getValue() == MGBADisplay.Symbols.OptionEnabled then
+			-- NOTE: If you UNCOMMON THIS CODE, don't use hardcoded option values like "33"
 			-- for i = 33, 35, 1 do
 			-- 	local opt = MGBA.OptionMap[i]
 			-- 	if opt ~= nil then
@@ -436,10 +450,36 @@ MGBADisplay.LineBuilder = {
 		table.insert(lines, Utils.formatUTF8("%s: %s", Resources.MGBAScreens.LabelToggleOption, MGBA.CommandMap["OPTION"].usageSyntax))
 		table.insert(lines, Utils.formatUTF8("%-2s %-20s [%s]", "#", Utils.toUpperUTF8(Resources.MGBAScreens.LabelOption), Utils.toUpperUTF8(Resources.MGBAScreens.LabelEnabled)))
 
-		local optionAutodetectId = 29
+		local optionAutodetectId = MGBADisplay.OptionValues.LANGUAGE
 		local opt = MGBA.OptionMap[optionAutodetectId]
 		if opt ~= nil then
 			table.insert(lines, Utils.formatUTF8(optionBar, optionAutodetectId, opt:getText(), opt:getValue()))
+		end
+
+		table.insert(lines, MGBADisplay.Symbols.DividerLine)
+
+		return lines
+	end,
+	buildExtensions = function()
+		local lines = {}
+
+		local optionBar = "%-2s %-26s [%s]"
+		table.insert(lines, Utils.toUpperUTF8(MGBA.Screens.Extensions:getTitle()))
+		table.insert(lines, MGBADisplay.Symbols.DividerLine)
+		table.insert(lines, Utils.formatUTF8("%s:", Resources.MGBAScreens.ExtensionsInstallNewWith))
+		table.insert(lines, Utils.formatUTF8(" %s", "INSTALLEXT()"))
+		table.insert(lines, MGBADisplay.Symbols.DividerLine)
+		table.insert(lines, Utils.formatUTF8("%s:", Resources.MGBAScreens.ExtensionsInstalledExtensions))
+		table.insert(lines, "")
+		table.insert(lines, Utils.formatUTF8("%s: OPTION \"#\"", Resources.MGBAScreens.ExtensionsEnableDisable))
+		table.insert(lines, Utils.formatUTF8("%-2s %-20s [%s]", "#", Utils.toUpperUTF8(Resources.MGBAScreens.LabelOption), Utils.toUpperUTF8(Resources.MGBAScreens.LabelEnabled)))
+
+		for i = 1, CustomCode.ExtensionCount, 1 do
+			local optId = MGBADisplay.OptionValues.EXTENSIONS + i
+			local opt = MGBA.OptionMap[optId]
+			if opt ~= nil then
+				table.insert(lines, Utils.formatUTF8(optionBar, optId, opt:getText(), opt:getValue()))
+			end
 		end
 
 		table.insert(lines, MGBADisplay.Symbols.DividerLine)


### PR DESCRIPTION
MGBA was already allowed to use Extensions, however there was no way to install them or enable/disable them through the Scripting Tool UI screens.

This PR adds that screen to MGBA to allow users to install and enable new extensions.

![image](https://github.com/besteon/Ironmon-Tracker/assets/4258818/53582ea3-ffb2-4a12-8be8-17abb7972be1)
