### PR TITLE
Better External UI framework

### DIFF
--- a/ironmon_tracker/ColorPicker.lua
+++ b/ironmon_tracker/ColorPicker.lua
@@ -7,8 +7,8 @@ function ColorPicker.new(colorkey)
 	self.width = 220
 	self.height = 330
 
-	self.xPos = client.xpos() + client.screenwidth() / 2 - self.width / 2
-	self.yPos = client.ypos() + client.screenheight() / 2 - self.height / 2
+	self.xPos = 150
+	self.yPos = 10
 
 	self.circleRadius = 75
 	self.circleCenter = {85,85}
@@ -21,11 +21,8 @@ function ColorPicker.new(colorkey)
 	self.green = 0
 	self.blue = 0
 
-	self.mainForm = nil
 	self.mainCanvas = nil
 	self.colorTextBox = nil
-	self.saveButton = nil
-	self.cancelButton = nil
 
 	self.valueSliderY = 10
 	self.ellipsesPos = {85,85}
@@ -163,14 +160,15 @@ function ColorPicker:show()
 	local tryClose = function()
 		self:onClose()
 	end
-	local form = ExternalUI.BizForms.createForm(Resources.ThemeScreen.PromptColorPickerTitle, self.width, self.height, self.xPos, self.yPos, tryClose)
+	local title = Resources.ThemeScreen.PromptColorPickerTitle
+	local form = ExternalUI.BizForms.createForm(title, self.width, self.height, self.xPos, self.yPos, tryClose)
 	self.colorTextBox = form:createTextBox("", 90, 218, 65, 10, "HEX", false, true)
 	local saveAndClose = string.format("%s && %s", Resources.AllScreens.Save, Resources.AllScreens.Close)
-	self.saveButton = form:createButton(saveAndClose, 15, 250, function()
+	form:createButton(saveAndClose, 15, 250, function()
 		self:onSave()
 		form:destroy()
 	end)
-	self.cancelButton = form:createButton(Resources.AllScreens.Cancel, 125, 250, function()
+	form:createButton(Resources.AllScreens.Cancel, 125, 250, function()
 		self:onClose()
 		form:destroy()
 	end)

--- a/ironmon_tracker/ColorPicker.lua
+++ b/ironmon_tracker/ColorPicker.lua
@@ -57,7 +57,7 @@ function ColorPicker:initializeColorWheelSlider()
 	self:HEX_to_RGB(colorText)
 	self:RGB_to_HSL()
 	self:convertHSVtoColorPicker()
-	forms.settext(self.colorTextBox,string.sub(colorText,3))
+	ExternalUI.BizForms.setText(self.colorTextBox, string.sub(colorText, 3))
 end
 
 function ColorPicker:setColor()
@@ -79,7 +79,7 @@ end
 
 function ColorPicker:updateCirclePreview()
 	local circleCenter = self.circleCenter
-	local clickPos = {forms.getMouseX(self.mainCanvas),forms.getMouseY(self.mainCanvas)}
+	local clickPos = {forms.getMouseX(self.mainCanvas), forms.getMouseY(self.mainCanvas)}
 	local x,y = clickPos[1],clickPos[2]
 	local distanceToRadius = ColorPicker.distance(clickPos,circleCenter)
 	if distanceToRadius > self.circleRadius then
@@ -103,14 +103,14 @@ function ColorPicker:updateCirclePreview()
 			self.val = 50
 		end
 		self:setColor()
-		forms.settext(self.colorTextBox,string.sub(self.color,5))
+		ExternalUI.BizForms.setText(self.colorTextBox, string.sub(self.color, 5))
 		self.ellipsesPos = {x,y}
 		self:drawMainCanvas()
 	end
 end
 
 function ColorPicker:updateVSlider()
-	local clickPos = {forms.getMouseX(self.mainCanvas),forms.getMouseY(self.mainCanvas)}
+	local clickPos = {forms.getMouseX(self.mainCanvas), forms.getMouseY(self.mainCanvas)}
 	local y = clickPos[2]
 	y = math.min(160,y)
 	y = math.max(10,y)
@@ -118,7 +118,7 @@ function ColorPicker:updateVSlider()
 	local val = 100-((y-10)/150 * 100)
 	self.val = val
 	self:setColor()
-	forms.settext(self.colorTextBox,string.sub(self.color,5))
+	ExternalUI.BizForms.setText(self.colorTextBox, string.sub(self.color, 5))
 	self:drawMainCanvas()
 end
 
@@ -133,7 +133,6 @@ function ColorPicker:drawMainCanvas()
 	local sliderX = 178
 	local sliderY = self.valueSliderY
 	forms.drawRectangle(self.mainCanvas,sliderX,sliderY,14,4,nil,nil)
-
 	forms.drawRectangle(self.mainCanvas,15,173,30,30,nil,tonumber(self.color))
 
 	local colorResourceKeys = {
@@ -152,7 +151,6 @@ function ColorPicker:drawMainCanvas()
 
 	local colorKeyLabel = Resources.ThemeScreen[colorResourceKeys[self.colorkey] or ""] or "???"
 	forms.drawText(self.mainCanvas,50,179,colorKeyLabel,Drawing.Colors.WHITE,0x00000000,14,"Arial")
-
 	local hexLabel = string.format("%s:", Resources.ThemeScreen.PromptColorPickerHexColor)
 	forms.drawText(self.mainCanvas,14,221,hexLabel,Drawing.Colors.WHITE,0x00000000,14,"Arial")
 
@@ -162,23 +160,29 @@ end
 function ColorPicker:show()
 	if self.colorkey == nil then return end
 
-	local closeFormFunc = function()
-		Utils.closeBizhawkForm(self.mainForm)
+	local tryClose = function()
 		self:onClose()
 	end
-	self.mainForm = Utils.createBizhawkForm(Resources.ThemeScreen.PromptColorPickerTitle, self.width, self.height, 0, 0, closeFormFunc)
-	self.colorTextBox = forms.textbox(self.mainForm,"",65,10,"HEX",90,218)
+	local form = ExternalUI.BizForms.createForm(Resources.ThemeScreen.PromptColorPickerTitle, self.width, self.height, self.xPos, self.yPos, tryClose)
+	self.colorTextBox = form:createTextBox("", 90, 218, 65, 10, "HEX", false, true)
 	local saveAndClose = string.format("%s && %s", Resources.AllScreens.Save, Resources.AllScreens.Close)
-	self.saveButton = forms.button(self.mainForm,saveAndClose, function() self:onSave() end,15,250,95,30)
-	self.cancelButton = forms.button(self.mainForm,Resources.AllScreens.Cancel, closeFormFunc,125,250,65,30)
-	self.mainCanvas = forms.pictureBox(self.mainForm,0,0,250,300)
-	forms.setlocation(self.mainForm,self.xPos,self.yPos)
+	self.saveButton = form:createButton(saveAndClose, 15, 250, function()
+		self:onSave()
+		form:destroy()
+	end)
+	self.cancelButton = form:createButton(Resources.AllScreens.Cancel, 125, 250, function()
+		self:onClose()
+		form:destroy()
+	end)
+	self.mainCanvas = form:createPictureBox(0, 0, 250, 300)
 
 	self:initializeColorWheelSlider()
 	self:drawMainCanvas()
 
 	-- Required when Bizhawk configuration is set to pause the game when any menu opens, blocks mouse inputs
-	client.unpause()
+	if Main.IsOnBizhawk() then
+		client.unpause()
+	end
 
 	-- Changes the tracker screen back to the main screen so you can see theme updates live
 	Program.changeScreenView(TrackerScreen)
@@ -191,8 +195,6 @@ end
 function ColorPicker:onSave()
 	-- Save the color from the colorpicker over the theme's original color, then close then window
 	self.originalColor = self.color
-	Utils.closeBizhawkForm(self.mainForm)
-	self:onClose()
 end
 
 function ColorPicker:onClose()
@@ -204,7 +206,7 @@ end
 
 function ColorPicker:handleInput()
 	if not self.draggingColor and not self.draggingValueSlider then
-		local colorText = forms.gettext(self.colorTextBox)
+		local colorText = ExternalUI.BizForms.getText(self.colorTextBox)
 		if #colorText == 6 then
 			self.color = "0xFF"..colorText
 			self:HEX_to_RGB(colorText)
@@ -220,7 +222,7 @@ function ColorPicker:handleInput()
 		elseif self.draggingValueSlider then
 			self:updateVSlider()
 		else
-			local clickPos = {forms.getMouseX(self.mainCanvas),forms.getMouseY(self.mainCanvas)}
+			local clickPos = {forms.getMouseX(self.mainCanvas), forms.getMouseY(self.mainCanvas)}
 			if not self.draggingColor then
 				local distanceToCenter = ColorPicker.distance(clickPos,self.circleCenter)
 				if distanceToCenter >= 0 and distanceToCenter <= self.circleRadius then

--- a/ironmon_tracker/ExternalUI.lua
+++ b/ironmon_tracker/ExternalUI.lua
@@ -67,8 +67,9 @@ function _helper.formToId(formOrId)
 end
 function _helper.tryAutoSize(controlId, width, height)
 	if not Main.IsOnBizhawk() then return end
+	-- Only auto size the control if the width and height were not specified
 	if ExternalUI.BizForms.AUTO_SIZE_CONTROLS and not width and not height then
-		_forms.setproperty(controlId, ExternalUI.BizForms.Properties.AUTO_SIZE, true)
+		ExternalUI.BizForms.setProperty(controlId, ExternalUI.BizForms.Properties.AUTO_SIZE, true)
 	end
 end
 
@@ -249,6 +250,16 @@ function ExternalUI.BizForms.setProperty(controlId, property, value)
 	_forms.setproperty(controlId, property, value)
 end
 
+---Adds a click event to a form Control element
+---@param controlId number
+---@param clickFunc? function
+function ExternalUI.BizForms.addOnClick(controlId, clickFunc)
+	if (controlId or 0) == 0 or type(clickFunc) ~= "function" or not Main.IsOnBizhawk() then
+		return
+	end
+	_forms.addclick(controlId, clickFunc)
+end
+
 --- BIZHAWK FORM OBJECT
 
 --- An object representing a Bizhawk form popup. Contains useful Bizhawk Lua functions to create controls:
@@ -315,9 +326,7 @@ function ExternalUI.IBizhawkForm:createCheckbox(text, x, y, clickFunc)
 	if not Main.IsOnBizhawk() then return 0 end
 	local controlId = _forms.checkbox(self.ControlId, text, x, y)
 	_helper.tryAutoSize(controlId)
-	if type(clickFunc) == "function" then
-		_forms.addclick(controlId, clickFunc)
-	end
+	ExternalUI.BizForms.addOnClick(controlId, clickFunc)
 	self.CreatedControls[controlId] = ExternalUI.BizForms.ControlTypes.Checkbox
 	return controlId
 end
@@ -337,15 +346,13 @@ function ExternalUI.IBizhawkForm:createDropdown(itemList, x, y, width, height, s
 	sortAlphabetically = (sortAlphabetically ~= false) -- default to true
 	local controlId = _forms.dropdown(self.ControlId, {["Init"]="..."}, x, y, width, height)
 	_forms.setdropdownitems(controlId, itemList, sortAlphabetically)
-	_forms.setproperty(controlId, ExternalUI.BizForms.Properties.AUTO_COMPLETE_SOURCE, "ListItems")
-	_forms.setproperty(controlId, ExternalUI.BizForms.Properties.AUTO_COMPLETE_MODE, "Append")
+	ExternalUI.BizForms.setProperty(controlId, ExternalUI.BizForms.Properties.AUTO_COMPLETE_SOURCE, "ListItems")
+	ExternalUI.BizForms.setProperty(controlId, ExternalUI.BizForms.Properties.AUTO_COMPLETE_MODE, "Append")
 	if startItem then
-		_forms.settext(controlId, startItem)
+		ExternalUI.BizForms.setText(controlId, startItem)
 	end
 	_helper.tryAutoSize(controlId, width, height)
-	if type(clickFunc) == "function" then
-		_forms.addclick(controlId, clickFunc)
-	end
+	ExternalUI.BizForms.addOnClick(controlId, clickFunc)
 	self.CreatedControls[controlId] = ExternalUI.BizForms.ControlTypes.Dropdown
 	return controlId
 end
@@ -363,9 +370,7 @@ function ExternalUI.IBizhawkForm:createLabel(text, x, y, width, height, monospac
 	if not Main.IsOnBizhawk() then return 0 end
 	local controlId = _forms.label(self.ControlId, text, x, y, width, height, monospaced)
 	_helper.tryAutoSize(controlId, width, height)
-	if type(clickFunc) == "function" then
-		_forms.addclick(controlId, clickFunc)
-	end
+	ExternalUI.BizForms.addOnClick(controlId, clickFunc)
 	self.CreatedControls[controlId] = ExternalUI.BizForms.ControlTypes.Label
 	return controlId
 end
@@ -387,9 +392,7 @@ function ExternalUI.IBizhawkForm:createTextBox(text, x, y, width, height, boxtyp
 	boxtype = boxtype or ""
 	local controlId = _forms.textbox(self.ControlId, text, width, height, boxtype, x, y, multiline, monospaced, scrollbars)
 	_helper.tryAutoSize(controlId, width, height)
-	if type(clickFunc) == "function" then
-		_forms.addclick(controlId, clickFunc)
-	end
+	ExternalUI.BizForms.addOnClick(controlId, clickFunc)
 	self.CreatedControls[controlId] = ExternalUI.BizForms.ControlTypes.TextBox
 	return controlId
 end
@@ -405,9 +408,7 @@ function ExternalUI.IBizhawkForm:createPictureBox(x, y, width, height, clickFunc
 	if not Main.IsOnBizhawk() then return 0 end
 	local controlId = _forms.pictureBox(self.ControlId, x, y, width, height)
 	_helper.tryAutoSize(controlId, width, height)
-	if type(clickFunc) == "function" then
-		_forms.addclick(controlId, clickFunc)
-	end
+	ExternalUI.BizForms.addOnClick(controlId, clickFunc)
 	self.CreatedControls[controlId] = ExternalUI.BizForms.ControlTypes.PictureBox
 	return controlId
 end

--- a/ironmon_tracker/ExternalUI.lua
+++ b/ironmon_tracker/ExternalUI.lua
@@ -1,0 +1,186 @@
+-- Defines all ways to interact with an emulator's external UI components, such as form popups
+ExternalUI = {}
+
+ExternalUI.BizForms = {
+	-- The current active form popup window; only 1 can be open at any given time
+	ActiveFormId = 0,
+
+	-- Options to modify form control elements; usually these values remain unmodified
+	AUTO_SIZE_CONTROLS = true,
+
+	Properties = {
+		AUTO_SIZE = "AutoSize", -- For most form elements
+		BLOCK_INPUT = "BlocksInputWhenFocused", -- For the main form popup
+		AUTO_COMPLETE_SOURCE = "AutoCompleteSource", -- For dropdown boxes
+		AUTO_COMPLETE_MODE = "AutoCompleteMode", -- For dropdown boxes
+	},
+}
+
+---Creates a form popup through Bizhawk Lua function
+---@param title string?
+---@param width number?
+---@param height number?
+---@param x number?
+---@param y number?
+---@param onCloseFunc function?
+---@param blockInput boolean?
+---@return table|nil form An IBizhawkForm object representing the created form; or nil if can't create
+function ExternalUI.createBizhawkForm(title, width, height, x, y, onCloseFunc, blockInput)
+	if not Main.IsOnBizhawk() then
+		return nil
+	end
+
+	-- Close the active form popup that's currently open, if any (only one at a time allowed to be open)
+	ExternalUI.closeBizhawkForm()
+
+	-- Disable mouse inputs on the emulator window until the form is closed
+	Input.allowMouse = false
+	Input.resumeMouse = false
+
+	-- Prepare the form to be created, defining defaults
+	local form = ExternalUI.IBizhawkForm:new({
+		Title = title, Width = width, Height = height, X = x, Y = y,
+		BlockInput = (blockInput ~= false),
+		OnCloseFunc = onCloseFunc,
+	})
+
+	local function safelyCloseForm()
+		Input.resumeMouse = true
+		client.unpause()
+		if not form then
+			return
+		end
+		if type(form.OnCloseFunc) == "function" then
+			form:OnCloseFunc()
+		end
+		ExternalUI.closeBizhawkForm(form)
+		if form.ControlId then
+			forms.destroy(form.ControlId)
+			if ExternalUI.BizForms.ActiveFormId == form.ControlId then
+				ExternalUI.BizForms.ActiveFormId = 0
+			end
+		end
+	end
+
+	-- Create the form through Bizhawk
+	form.ControlId = forms.newform(form.Width, form.Height, form.Title, safelyCloseForm)
+
+	-- Remember this form, and apply any other adjustments like screen centering
+	ExternalUI.BizForms.ActiveFormId = form.ControlId
+	Utils.setFormLocation(form.ControlId, form.X, form.Y)
+
+	-- A workaround for a bug for release candidate builds of Bizhawk 2.9
+	if Main.emulator == Main.EMU.BIZHAWK29 or Main.emulator == Main.EMU.BIZHAWK_FUTURE then
+		local currentPropVal = forms.getproperty(form.ControlId, ExternalUI.BizForms.Properties.BLOCK_INPUT)
+		if not Utils.isNilOrEmpty(currentPropVal) then
+			forms.setproperty(form.ControlId, ExternalUI.BizForms.Properties.BLOCK_INPUT, form.BlockInput)
+		end
+	end
+
+	return form
+end
+
+---Safely closes a specific form, or the active open form popup if none provided
+---@param formOrId table|number|nil
+function ExternalUI.closeBizhawkForm(formOrId)
+	if not Main.IsOnBizhawk() then return end
+	formOrId = formOrId or {}
+	local controlId = (type(formOrId) == "table" and formOrId.ControlId) or formOrId or ExternalUI.BizForms.ActiveFormId
+	Input.resumeMouse = true
+	client.unpause()
+	if (controlId or 0) ~= 0 then
+		forms.destroy(controlId)
+	end
+	ExternalUI.BizForms.ActiveFormId = 0
+end
+
+--- HELPER FUNCTIONS
+local _helper = {}
+
+function _helper.tryAutoSize(controlId, width, height)
+	if ExternalUI.BizForms.AUTO_SIZE_CONTROLS and not width and not height then
+		forms.setproperty(controlId, ExternalUI.BizForms.Properties.AUTO_SIZE, true)
+	end
+end
+
+--- BIZHAWK FORM OBJECT
+
+ExternalUI.IBizhawkForm = {
+	-- This value is set after the form is created; do not define it yourself
+	ControlId = 0,
+	-- Optional code to run when the form is closed
+	OnCloseFunc = function() end,
+
+	-- After the Bizhawk form itself is created, the following attributes cannot be changed
+	Title = "Tracker Form",
+	X = 100,
+	Y = 50,
+	Width = 600,
+	Height = 600,
+	BlockInput = true, -- Disable mouse inputs on the emulator window until the form is closed
+
+	---Creates a Button Control element for a Bizhawk form, returning the id of the created control
+	---@param text string
+	---@param clickFunc function
+	---@param x number
+	---@param y number
+	---@param width number? Optional
+	---@param height number? Optional
+	---@return number|nil controlId
+	createButton = function(self, text, clickFunc, x, y, width, height)
+		local controlId = forms.button(self.ControlId, text, clickFunc, x, y, width, height)
+		_helper.tryAutoSize(controlId, width, height)
+		return controlId
+	end,
+
+	---Creates a Checkbox Control element for a Bizhawk form, returning the id of the created control
+	---@param text string
+	---@param x number
+	---@param y number
+	---@param clickFunc function? Optional, note that most checkboxes do not need a click func
+	---@return number|nil controlId
+	createCheckbox = function(self, text, x, y, clickFunc)
+		local controlId = forms.checkbox(self.ControlId, text, x, y)
+		_helper.tryAutoSize(controlId)
+		if type(clickFunc) == "function" then
+			forms.addclick(controlId, clickFunc)
+		end
+		return controlId
+	end,
+
+	---Creates a Dropdown Control element for a Bizhawk form, returning the id of the created control
+	---@param itemList table An ordered list of values (ideally strings)
+	---@param x number
+	---@param y number
+	---@param width number?
+	---@param height number?
+	---@param startItem string?
+	---@param sortAlphabetically boolean?
+	---@return number|nil controlId
+	createDropdown = function(self, itemList, x, y, width, height, startItem, sortAlphabetically)
+		sortAlphabetically = (sortAlphabetically ~= false) -- default to true
+		local controlId = forms.dropdown(self.ControlId, {["Init"]="..."}, x, y, width, height)
+		forms.setdropdownitems(controlId, itemList, sortAlphabetically)
+		forms.setproperty(controlId, ExternalUI.BizForms.Properties.AUTO_COMPLETE_SOURCE, "ListItems")
+		forms.setproperty(controlId, ExternalUI.BizForms.Properties.AUTO_COMPLETE_MODE, "Append")
+		if startItem then
+			forms.settext(controlId, startItem)
+		end
+		_helper.tryAutoSize(controlId, width, height)
+		return controlId
+	end,
+}
+---Creates and returns a new IBizhawkForm object; use UIControls.createBizhawkForm instead of calling this directly
+---@param o? table Optional initial object table
+---@return table form An IBizhawkForm object
+function ExternalUI.IBizhawkForm:new(o)
+	o = o or {}
+	for k, v in pairs(ExternalUI.IBizhawkForm) do
+		if o[k] == nil then
+			o[k] = v
+		end
+	end
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end

--- a/ironmon_tracker/FileManager.lua
+++ b/ironmon_tracker/FileManager.lua
@@ -101,6 +101,7 @@ FileManager.LuaCode = {
 	-- Second set of core files
 	{ name = "Options", filepath = "Options.lua", },
 	{ name = "Drawing", filepath = "Drawing.lua", },
+	{ name = "ExternalUI", filepath = "ExternalUI.lua", },
 	{ name = "Theme", filepath = "Theme.lua", },
 	{ name = "ColorPicker", filepath = "ColorPicker.lua", },
 	{ name = "Input", filepath = "Input.lua", },

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -311,6 +311,7 @@ function Main.DisplayError(errMessage, moreInfoBtnLabel, moreInfoFunc)
 
 	client.pause()
 	local formTitle = string.format("[v%s] Woops, there's been an issue!", Main.TrackerVersion)
+	-- Create the form directly through Bizhawk and not ExternalUI, as it's possible that UI has not been loaded yet
 	local form = forms.newform(400, 150, formTitle, function() client.unpause() end)
 	local actualLocation = client.transformPoint(100, 50)
 	forms.setproperty(form, "Left", client.xpos() + actualLocation['x'] )

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -275,7 +275,6 @@ function Program.initialize()
 	Program.inStartMenu = false
 	Program.inCatchingTutorial = false
 	Program.hasCompletedTutorial = false
-	Program.activeFormId = 0
 	Program.lastActiveTimestamp = os.time()
 	Program.Frames.waitToDraw = 1
 	Program.Frames.highAccuracyUpdate = 0
@@ -379,7 +378,7 @@ end
 
 -- Deprecated
 function Program.destroyActiveForm()
-	ExternalUI.closeBizhawkForm()
+	ExternalUI.BizForms.destroyForm()
 end
 
 function Program.update()

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -377,10 +377,9 @@ function Program.goBackToPreviousScreen()
 	Program.redraw(true)
 end
 
+-- Deprecated
 function Program.destroyActiveForm()
-	if Program.activeFormId ~= nil and Program.activeFormId ~= 0 then
-		Utils.closeBizhawkForm(Program.activeFormId)
-	end
+	ExternalUI.closeBizhawkForm()
 end
 
 function Program.update()

--- a/ironmon_tracker/Theme.lua
+++ b/ironmon_tracker/Theme.lua
@@ -518,25 +518,27 @@ function Theme.openColorPickerWindow(colorkey)
 end
 
 function Theme.openImportWindow()
-	local form = Utils.createBizhawkForm(Resources.ThemeScreen.ButtonImport, 515, 125)
+	local form = ExternalUI.BizForms.createForm(Resources.ThemeScreen.ButtonImport, 515, 125)
+	if not form then return end
 
-	forms.label(form, Resources.ThemeScreen.PromptEnterThemeCode .. ":", 9, 10, 300, 20)
-	local importTextBox = forms.textbox(form, "", 480, 20, nil, 10, 30)
-	forms.button(form, Resources.AllScreens.Import, function()
+	form:createLabel(Resources.ThemeScreen.PromptEnterThemeCode .. ":", 9, 10)
+	local importTextBox = form:createTextBox("", 10, 30, 480, 20)
+	form:createButton(Resources.AllScreens.Import, 212, 55, function()
 		local formInput = forms.gettext(importTextBox)
-		if formInput ~= nil then
-			-- Check if the import was successful
-			local success = Theme.importThemeFromText(formInput, true)
-			if success then
-				Theme.refreshThemePreview()
-			else
-				print("Error importing Theme Config string:")
-				print(">> " .. formInput)
-				Main.DisplayError("The theme config string you entered is invalid.\n\nPlease enter a valid theme config string.")
-			end
+		if Utils.isNilOrEmpty(formInput) then
+			return
 		end
-		Utils.closeBizhawkForm(form)
-	end, 212, 55)
+		-- Check if the import was successful
+		local success = Theme.importThemeFromText(formInput, true)
+		if success then
+			Theme.refreshThemePreview()
+			Utils.closeBizhawkForm(form)
+		else
+			print("Error importing Theme Config string:")
+			print(">> " .. formInput)
+			Main.DisplayError("The theme config string you entered is invalid.\n\nPlease enter a valid theme config string.")
+		end
+	end)
 end
 
 function Theme.openExportWindow()

--- a/ironmon_tracker/Theme.lua
+++ b/ironmon_tracker/Theme.lua
@@ -519,12 +519,11 @@ end
 
 function Theme.openImportWindow()
 	local form = ExternalUI.BizForms.createForm(Resources.ThemeScreen.ButtonImport, 515, 125)
-	if not form then return end
 
 	form:createLabel(Resources.ThemeScreen.PromptEnterThemeCode .. ":", 9, 10)
 	local importTextBox = form:createTextBox("", 10, 30, 480, 20)
 	form:createButton(Resources.AllScreens.Import, 212, 55, function()
-		local formInput = forms.gettext(importTextBox)
+		local formInput = ExternalUI.BizForms.getText(importTextBox)
 		if Utils.isNilOrEmpty(formInput) then
 			return
 		end
@@ -532,7 +531,7 @@ function Theme.openImportWindow()
 		local success = Theme.importThemeFromText(formInput, true)
 		if success then
 			Theme.refreshThemePreview()
-			Utils.closeBizhawkForm(form)
+			form:destroy()
 		else
 			print("Error importing Theme Config string:")
 			print(">> " .. formInput)
@@ -542,67 +541,57 @@ function Theme.openImportWindow()
 end
 
 function Theme.openExportWindow()
-	local form = Utils.createBizhawkForm(Resources.ThemeScreen.ButtonExport, 515, 150)
-
+	local form = ExternalUI.BizForms.createForm(Resources.ThemeScreen.ButtonExport, 515, 150)
 	local themePreset = Theme.Presets[Theme.Screen.currentPreviewIndex]
-
 	local themeLabel = string.format("%s: %s", Resources.ThemeScreen.PromptThemeFor, themePreset:getText())
-	forms.label(form, themeLabel, 9, 10, 300, 20)
-	forms.label(form, Resources.ThemeScreen.PromptCopyThemeCode .. ":", 9, 30, 300, 20)
-	forms.textbox(form, themePreset.code or "", 480, 20, nil, 10, 55)
-	forms.button(form, Resources.AllScreens.Close, function()
-		Utils.closeBizhawkForm(form)
-	end, 212, 80)
+	form:createLabel(themeLabel, 9, 10)
+	form:createLabel(Resources.ThemeScreen.PromptCopyThemeCode .. ":", 9, 30)
+	form:createTextBox(themePreset.code or "", 10, 55, 480, 20)
+	form:createButton(Resources.AllScreens.Close, 212, 80, function()
+		form:destroy()
+	end)
 end
 
 function Theme.openPresetsWindow()
-	local form = Utils.createBizhawkForm(Resources.ThemeScreen.Title, 360, 105)
-
+	local form = ExternalUI.BizForms.createForm(Resources.ThemeScreen.Title, 360, 105)
 	local themeNameList = {}
 	for _, themePreset in ipairs(Theme.Presets) do
 		table.insert(themeNameList, themePreset:getText())
 	end
 
-	forms.label(form, Resources.ThemeScreen.PromptSelectPreset .. ":", 49, 10, 250, 20)
-	local presetDropdown = forms.dropdown(form, {["Init"]="Loading Presets"}, 50, 30, 145, 30)
-	forms.setdropdownitems(presetDropdown, themeNameList, false) -- Required to prevent alphabetizing the list
-	forms.setproperty(presetDropdown, "AutoCompleteSource", "ListItems")
-	forms.setproperty(presetDropdown, "AutoCompleteMode", "Append")
-
-	forms.button(form, Resources.AllScreens.Preview, function()
-		local themeName = forms.gettext(presetDropdown)
-
+	form:createLabel(Resources.ThemeScreen.PromptSelectPreset .. ":", 49, 10)
+	local dropdown = form:createDropdown(themeNameList, 50, 30, 145, 30, nil, false)
+	form:createButton(Resources.AllScreens.Preview, 212, 29, function()
+		local themeName = ExternalUI.BizForms.getText(dropdown)
 		for index, themePreset in ipairs(Theme.Presets) do
 			if themePreset:getText() == themeName then
 				Theme.Screen.currentPreviewIndex = index
 				break
 			end
 		end
-
 		local themePreset = Theme.Presets[Theme.Screen.currentPreviewIndex or Theme.PresetsIndex.ACTIVE]
 		Theme.refreshButtons()
 		Theme.Buttons.RemoveTheme:resetButtonToDefault()
 		Theme.importThemeFromText(themePreset.code, false)
-
-		Utils.closeBizhawkForm(form)
-	end, 212, 29)
+		form:destroy()
+	end)
 end
 
 function Theme.openSaveCurrentThemeWindow()
-	local form = Utils.createBizhawkForm(Resources.ThemeScreen.PromptSaveAsTitle, 350, 145)
+	local form = ExternalUI.BizForms.createForm(Resources.ThemeScreen.PromptSaveAsTitle, 350, 145)
 
-	forms.label(form, Resources.ThemeScreen.PromptEnterNameForTheme .. ":", 18, 10, 330, 20)
-	local saveTextBox = forms.textbox(form, "", 290, 30, nil, 20, 30)
-	forms.setproperty(saveTextBox, "MaxLength", 80)
+	form:createLabel(Resources.ThemeScreen.PromptEnterNameForTheme .. ":", 18, 10)
+	local nameTextbox = form:createTextBox("", 20, 30, 290, 30)
+	ExternalUI.BizForms.setProperty(nameTextbox, ExternalUI.BizForms.Properties.MAX_LENGTH, 80)
 
-	Theme.Manager.SaveNewWarning = forms.label(form, "", 18, 55, 330, 20)
-	forms.setproperty(Theme.Manager.SaveNewWarning, "ForeColor", "Red")
+	Theme.Manager.SaveNewWarning = form:createLabel("", 18, 55, 330, 20)
+	ExternalUI.BizForms.setProperty(Theme.Manager.SaveNewWarning, ExternalUI.BizForms.Properties.FORE_COLOR, "Red")
 
-	Theme.Manager.SaveNewConfirm = forms.button(form, Resources.AllScreens.Save, function()
+	Theme.Manager.SaveNewConfirm = form:createButton(Resources.AllScreens.Save, 91, 75, function()
 		-- Clear out warning texts
-		forms.settext(Theme.Manager.SaveNewWarning, "")
+		ExternalUI.BizForms.setText(Theme.Manager.SaveNewWarning, "")
 
-		local themeName = forms.gettext(saveTextBox)
+		local themeName = ExternalUI.BizForms.getText(nameTextbox)
 		if Utils.isNilOrEmpty(themeName) then
 			return
 		end
@@ -620,18 +609,18 @@ function Theme.openSaveCurrentThemeWindow()
 		-- Check a few conditions that would prevent the user from using a particular Theme name
 		if existingPresetIndex == Theme.PresetsIndex.ACTIVE or existingPresetIndex == Theme.PresetsIndex.DEFAULT then
 			-- Don't allow importing "Active Theme (Custom)" or "Default Theme" as that is reserved
-			forms.settext(Theme.Manager.SaveNewWarning, "Cannot use a reserved Theme name")
-			forms.settext(Theme.Manager.SaveNewConfirm, Resources.AllScreens.Save)
+			ExternalUI.BizForms.setText(Theme.Manager.SaveNewWarning, "Cannot use a reserved Theme name")
+			ExternalUI.BizForms.setText(Theme.Manager.SaveNewConfirm, Resources.AllScreens.Save)
 			return
 		elseif themeName:find("%x%x%x%x%x%x") then
 			-- Don't allow six consectuive hexcode characters, as this screws with parsing it later
-			forms.settext(Theme.Manager.SaveNewWarning, "Name cannot have 6 consectuive hexcode characters (0-9A-F)")
-			forms.settext(Theme.Manager.SaveNewConfirm, Resources.AllScreens.Save)
+			ExternalUI.BizForms.setText(Theme.Manager.SaveNewWarning, "Name cannot have 6 consectuive hexcode characters (0-9A-F)")
+			ExternalUI.BizForms.setText(Theme.Manager.SaveNewConfirm, Resources.AllScreens.Save)
 			return
-		elseif existingPreset ~= nil and forms.gettext(Theme.Manager.SaveNewConfirm) ~= Resources.AllScreens.Yes then
+		elseif existingPreset ~= nil and ExternalUI.BizForms.getText(Theme.Manager.SaveNewConfirm) ~= Resources.AllScreens.Yes then
 			-- If the Theme name is already in use, warn the user first
-			forms.settext(Theme.Manager.SaveNewWarning, "A Theme with that name already exists. Overwrite?")
-			forms.settext(Theme.Manager.SaveNewConfirm, Resources.AllScreens.Yes)
+			ExternalUI.BizForms.setText(Theme.Manager.SaveNewWarning, "A Theme with that name already exists. Overwrite?")
+			ExternalUI.BizForms.setText(Theme.Manager.SaveNewConfirm, Resources.AllScreens.Yes)
 			return
 		end
 		Theme.Manager.SaveNewWarning = nil
@@ -657,12 +646,11 @@ function Theme.openSaveCurrentThemeWindow()
 		-- Add the saved theme to the presets file and refresh
 		FileManager.addCustomThemeToFile(themeName, themeCode)
 		Theme.refreshThemePreview()
-
-		Utils.closeBizhawkForm(form)
-	end, 91, 75)
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 176, 75)
+		form:destroy()
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 176, 75, function()
+		form:destroy()
+	end)
 end
 
 -- Preloaded Theme Presets are added to the Theme Presets file only if that file doesn't already exist

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -355,35 +355,10 @@ function Utils.getClosestWord(word, wordlist, threshold)
 	end
 end
 
--- Creates a popup Bizhawk form at optional relative location (x,y); returns the created form handle id
+-- Deprecated
 function Utils.createBizhawkForm(title, width, height, x, y, onCloseFunc, blockInput)
-	title = title or "Form"
-	width = width or 600
-	height = height or 600
-	x = x or 100
-	y = y or 50
-	blockInput = (blockInput == nil) or (blockInput == true) -- default to true
-
-	-- By default, disable mouse inputs and resume them when the prompt closes
-	-- If a close func is provided, the caller needs to manage disabling/enabling mouse inputs instead
-	if onCloseFunc == nil then
-		Input.allowMouse = false
-		onCloseFunc = Utils.closeBizhawkForm
-	end
-
-	ExternalUI.BizForms.destroyForm()
-	Input.resumeMouse = false -- closing any active form resumes inputs, which we don't want yet
-	local form = forms.newform(width, height, title, onCloseFunc)
-	ExternalUI.BizForms.ActiveFormId = form
-	Utils.setFormLocation(form, x, y)
-	if Main.emulator == Main.EMU.BIZHAWK29 or Main.emulator == Main.EMU.BIZHAWK_FUTURE then
-		local property = "BlocksInputWhenFocused"
-		if not Utils.isNilOrEmpty(forms.getproperty(form, property)) then
-			forms.setproperty(form, property, blockInput)
-		end
-	end
-
-	return form
+	local form = ExternalUI.BizForms.createForm(title, width, height, x, y, onCloseFunc, blockInput)
+	return form.ControlId
 end
 
 -- Deprecated
@@ -943,15 +918,9 @@ function Utils.getWordWrapLines(str, limit)
 	return lines
 end
 
---sets the form location relative to the game window
---this function does what the built in forms.setlocation function supposed to do
---currently that function is bugged and should be fixed in 2.9
+-- Deprecated
 function Utils.setFormLocation(handle, x, y)
-	if handle == nil then return end
-	local ribbonHight = 64 -- so we are below the ribbon menu
-	local actualLocation = client.transformPoint(x,y)
-	forms.setproperty(handle, "Left", client.xpos() + actualLocation['x'] )
-	forms.setproperty(handle, "Top", client.ypos() + actualLocation['y'] + ribbonHight)
+	ExternalUI.BizForms.setWindowLocation(handle, x, y)
 end
 
 function Utils.getSaveBlock1Addr()

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -371,10 +371,10 @@ function Utils.createBizhawkForm(title, width, height, x, y, onCloseFunc, blockI
 		onCloseFunc = Utils.closeBizhawkForm
 	end
 
-	ExternalUI.closeBizhawkForm()
+	ExternalUI.BizForms.destroyForm()
 	Input.resumeMouse = false -- closing any active form resumes inputs, which we don't want yet
 	local form = forms.newform(width, height, title, onCloseFunc)
-	Program.activeFormId = form
+	ExternalUI.BizForms.ActiveFormId = form
 	Utils.setFormLocation(form, x, y)
 	if Main.emulator == Main.EMU.BIZHAWK29 or Main.emulator == Main.EMU.BIZHAWK_FUTURE then
 		local property = "BlocksInputWhenFocused"
@@ -386,12 +386,9 @@ function Utils.createBizhawkForm(title, width, height, x, y, onCloseFunc, blockI
 	return form
 end
 
+-- Deprecated
 function Utils.closeBizhawkForm(form)
-	form = form or Program.activeFormId
-	client.unpause()
-	forms.destroy(form)
-	Program.activeFormId = 0
-	Input.resumeMouse = true
+	ExternalUI.BizForms.destroyForm(form)
 end
 
 function Utils.randomPokemonID()

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -371,7 +371,7 @@ function Utils.createBizhawkForm(title, width, height, x, y, onCloseFunc, blockI
 		onCloseFunc = Utils.closeBizhawkForm
 	end
 
-	Program.destroyActiveForm()
+	ExternalUI.closeBizhawkForm()
 	Input.resumeMouse = false -- closing any active form resumes inputs, which we don't want yet
 	local form = forms.newform(width, height, title, onCloseFunc)
 	Program.activeFormId = form

--- a/ironmon_tracker/network/Network.lua
+++ b/ironmon_tracker/network/Network.lua
@@ -326,24 +326,24 @@ function Network.getStreamerbotCode()
 end
 
 function Network.openUpdateRequiredPrompt()
-	local form = Utils.createBizhawkForm("Streamerbot Update Required", 350, 150, 100, 50)
+	local form = ExternalUI.BizForms.createForm("Streamerbot Update Required", 350, 150)
 	local x, y, lineHeight = 20, 20, 20
-	forms.label(form, string.format("Streamerbot Tracker Integration code requires an update."), x, y, 330, 20)
+	form:createLabel(string.format("Streamerbot Tracker Integration code requires an update."), x, y)
 	y = y + lineHeight
-	forms.label(form, string.format("You must re-import the code to continue using Stream Connect."), x, y, 330, 20)
+	form:createLabel(string.format("You must re-import the code to continue using Stream Connect."), x, y)
 	y = y + lineHeight
 	-- Bottom row buttons
 	y = y + 10
-	forms.button(form, Resources.StreamConnect.PromptNetworkShowMe, function()
-		Utils.closeBizhawkForm(form)
+	form:createButton(Resources.StreamConnect.PromptNetworkShowMe, 40, y, function()
+		form:destroy()
 		StreamConnectOverlay.openGetCodeWindow()
-	end, 40, y, 80, lineHeight + 5)
-	forms.button(form, Resources.StreamConnect.PromptNetworkTurnOff, function()
+	end)
+	form:createButton(Resources.StreamConnect.PromptNetworkTurnOff, 150, y, function()
 		Network.Options["AutoConnectStartup"] = false
 		Main.SaveSettings(true)
 		Network.closeConnections()
-		Utils.closeBizhawkForm(form)
-	end, 150, y, 150, lineHeight + 5)
+		form:destroy()
+	end)
 end
 
 -- Not supported

--- a/ironmon_tracker/screens/ExtrasScreen.lua
+++ b/ironmon_tracker/screens/ExtrasScreen.lua
@@ -271,38 +271,37 @@ function ExtrasScreen.openEditTimerPrompt()
 	if not wasPaused then
 		Program.GameTimer:pause()
 	end
-	local closeAndUnpauseTimer = function()
+	local tryUnpauseTimer = function()
 		if not wasPaused then
 			Program.GameTimer:unpause()
 		end
-		Utils.closeBizhawkForm()
 	end
-	Input.allowMouse = false
 
-	local form = Utils.createBizhawkForm(Resources.ExtrasScreen.LabelTimer, 320, 130, nil, nil, closeAndUnpauseTimer)
-
+	local form = ExternalUI.BizForms.createForm(Resources.ExtrasScreen.LabelTimer, 320, 130, nil, nil, tryUnpauseTimer)
 	local hour = math.floor(Tracker.Data.playtime / 3600) % 10000
 	local min = math.floor(Tracker.Data.playtime / 60) % 60
 	local sec = Tracker.Data.playtime % 60
-	forms.label(form, "H", 60, 10, 15, 18)
-	forms.label(form, "M", 130, 10, 15, 18)
-	forms.label(form, "S", 200, 10, 15, 18)
-	local hourBox = forms.textbox(form, hour, 40, 30, "SIGNED", 50, 30)
-	local minBox = forms.textbox(form, min, 40, 30, "SIGNED", 120, 30)
-	local secBox = forms.textbox(form, sec, 40, 30, "SIGNED", 190, 30)
-	forms.button(form, Resources.AllScreens.Save, function()
-		hour = tonumber(forms.gettext(hourBox) or "") or 0
-		min = tonumber(forms.gettext(minBox) or "") or 0
-		sec = tonumber(forms.gettext(secBox) or "") or 0
+	form:createLabel("H", 60, 10)
+	form:createLabel("M", 130, 10)
+	form:createLabel("S", 200, 10)
+	local hourBox = form:createTextBox(tostring(hour), 50, 30, 40, 30, "SIGNED", nil, true)
+	local minBox = form:createTextBox(tostring(min), 120, 30, 40, 30, "SIGNED", nil, true)
+	local secBox = form:createTextBox(tostring(sec), 190, 30, 40, 30, "SIGNED", nil, true)
+	form:createButton(Resources.AllScreens.Save, 72, 60, function()
+		hour = tonumber(ExternalUI.BizForms.getText(hourBox)) or 0
+		min = tonumber(ExternalUI.BizForms.getText(minBox)) or 0
+		sec = tonumber(ExternalUI.BizForms.getText(secBox)) or 0
 		-- Update total play time
 		Tracker.Data.playtime = hour * 3600 + min * 60 + sec
 		Program.GameTimer:update()
-		closeAndUnpauseTimer()
+		tryUnpauseTimer()
+		form:destroy()
 		Program.redraw(true)
-	end, 72, 60)
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		closeAndUnpauseTimer()
-	end, 157, 60)
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 157, 60, function()
+		tryUnpauseTimer()
+		form:destroy()
+	end)
 end
 
 function ExtrasScreen.relocateTimer()

--- a/ironmon_tracker/screens/ExtrasScreen.lua
+++ b/ironmon_tracker/screens/ExtrasScreen.lua
@@ -284,9 +284,9 @@ function ExtrasScreen.openEditTimerPrompt()
 	form:createLabel("H", 60, 10)
 	form:createLabel("M", 130, 10)
 	form:createLabel("S", 200, 10)
-	local hourBox = form:createTextBox(tostring(hour), 50, 30, 40, 30, "SIGNED", nil, true)
-	local minBox = form:createTextBox(tostring(min), 120, 30, 40, 30, "SIGNED", nil, true)
-	local secBox = form:createTextBox(tostring(sec), 190, 30, 40, 30, "SIGNED", nil, true)
+	local hourBox = form:createTextBox(tostring(hour), 50, 30, 40, 30, "SIGNED", false, true)
+	local minBox = form:createTextBox(tostring(min), 120, 30, 40, 30, "SIGNED", false, true)
+	local secBox = form:createTextBox(tostring(sec), 190, 30, 40, 30, "SIGNED", false, true)
 	form:createButton(Resources.AllScreens.Save, 72, 60, function()
 		hour = tonumber(ExternalUI.BizForms.getText(hourBox)) or 0
 		min = tonumber(ExternalUI.BizForms.getText(minBox)) or 0

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -434,7 +434,7 @@ function InfoScreen.openRouteInfoWindow()
 	routeName = Utils.formatSpecialCharacters(routeName)
 
 	form:createLabel(Resources.InfoScreen.PromptLookupRoute .. ":", 49, 10)
-	local routeDropdown = form:createDropdown(RouteData.AvailableRoutes, 50, 30, 145, 30, routeName)
+	local routeDropdown = form:createDropdown(RouteData.AvailableRoutes, 50, 30, 145, 30, routeName, false)
 	form:createButton(Resources.AllScreens.Lookup, 212, 29, function()
 		local dropdownSelection = ExternalUI.BizForms.getText(routeDropdown)
 		local mapId

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -338,7 +338,7 @@ function InfoScreen.showNextPokemon(delta)
 end
 
 function InfoScreen.openMoveInfoWindow()
-	local form = Utils.createBizhawkForm(Resources.AllScreens.Lookup, 360, 105)
+	local form = ExternalUI.BizForms.createForm(Resources.AllScreens.Lookup, 360, 105)
 
 	local moveName = MoveData.Moves[InfoScreen.infoLookup].name -- infoLookup = moveId
 	local allmovesData = {}
@@ -348,15 +348,10 @@ function InfoScreen.openMoveInfoWindow()
 		end
 	end
 
-	forms.label(form, Resources.InfoScreen.PromptLookupMove .. ":", 49, 10, 250, 20)
-	local moveDropdown = forms.dropdown(form, {["Init"]="Loading Move Data"}, 50, 30, 145, 30)
-	forms.setdropdownitems(moveDropdown, allmovesData, true) -- true = alphabetize the list
-	forms.setproperty(moveDropdown, "AutoCompleteSource", "ListItems")
-	forms.setproperty(moveDropdown, "AutoCompleteMode", "Append")
-	forms.settext(moveDropdown, moveName)
-
-	forms.button(form, Resources.AllScreens.Lookup, function()
-		local moveNameFromForm = forms.gettext(moveDropdown)
+	form:createLabel(Resources.InfoScreen.PromptLookupMove .. ":", 49, 10)
+	local moveDropdown = form:createDropdown(allmovesData, 50, 30, 145, 30, moveName)
+	form:createButton(Resources.AllScreens.Lookup, 212, 29, function()
+		local moveNameFromForm = ExternalUI.BizForms.getText(moveDropdown)
 		local moveId
 
 		for id, data in pairs(MoveData.Moves) do
@@ -370,12 +365,12 @@ function InfoScreen.openMoveInfoWindow()
 			InfoScreen.infoLookup = moveId
 			Program.redraw(true)
 		end
-		Utils.closeBizhawkForm(form)
-	end, 212, 29)
+		form:destroy()
+	end)
 end
 
 function InfoScreen.openAbilityInfoWindow()
-	local form = Utils.createBizhawkForm(Resources.AllScreens.Lookup, 360, 105)
+	local form = ExternalUI.BizForms.createForm(Resources.AllScreens.Lookup, 360, 105)
 
 	local abilityName
 	if not AbilityData.isValid(InfoScreen.infoLookup) then -- infoLookup = abilityId
@@ -386,15 +381,10 @@ function InfoScreen.openAbilityInfoWindow()
 	local allAbilitiesData = {}
 	allAbilitiesData = AbilityData.populateAbilityDropdown(allAbilitiesData)
 
-	forms.label(form, Resources.InfoScreen.PromptLookupAbility .. ":", 49, 10, 250, 20)
-	local abilityDropdown = forms.dropdown(form, {["Init"]="Loading Ability Data"}, 50, 30, 145, 30)
-	forms.setdropdownitems(abilityDropdown, allAbilitiesData, true) -- true = alphabetize the list
-	forms.setproperty(abilityDropdown, "AutoCompleteSource", "ListItems")
-	forms.setproperty(abilityDropdown, "AutoCompleteMode", "Append")
-	forms.settext(abilityDropdown, abilityName)
-
-	forms.button(form, Resources.AllScreens.Lookup, function()
-		local abilityNameFromForm = forms.gettext(abilityDropdown)
+	form:createLabel(Resources.InfoScreen.PromptLookupAbility .. ":", 49, 10)
+	local abilityDropdown = form:createDropdown(allAbilitiesData, 50, 30, 145, 30, abilityName)
+	form:createButton(Resources.AllScreens.Lookup, 212, 29, function()
+		local abilityNameFromForm = ExternalUI.BizForms.getText(abilityDropdown)
 		local abilityId
 
 		for id, data in pairs(AbilityData.Abilities) do
@@ -408,12 +398,12 @@ function InfoScreen.openAbilityInfoWindow()
 			InfoScreen.infoLookup = abilityId
 			Program.redraw(true)
 		end
-		Utils.closeBizhawkForm(form)
-	end, 212, 29)
+		form:destroy()
+	end)
 end
 
 function InfoScreen.openPokemonInfoWindow()
-	local form = Utils.createBizhawkForm(Resources.AllScreens.Lookup, 360, 105)
+	local form = ExternalUI.BizForms.createForm(Resources.AllScreens.Lookup, 360, 105)
 
 	local pokemonName
 	if PokemonData.isValid(InfoScreen.infoLookup) then -- infoLookup = pokemonID
@@ -423,15 +413,10 @@ function InfoScreen.openPokemonInfoWindow()
 	end
 	local pokedexData = PokemonData.namesToList()
 
-	forms.label(form, Resources.InfoScreen.PromptLookupPokemon .. ":", 49, 10, 250, 20)
-	local pokedexDropdown = forms.dropdown(form, {["Init"]="Loading Pokedex"}, 50, 30, 145, 30)
-	forms.setdropdownitems(pokedexDropdown, pokedexData, true) -- true = alphabetize the list
-	forms.setproperty(pokedexDropdown, "AutoCompleteSource", "ListItems")
-	forms.setproperty(pokedexDropdown, "AutoCompleteMode", "Append")
-	forms.settext(pokedexDropdown, pokemonName)
-
-	forms.button(form, Resources.AllScreens.Lookup, function()
-		local pokemonNameFromForm = forms.gettext(pokedexDropdown)
+	form:createLabel(Resources.InfoScreen.PromptLookupPokemon .. ":", 49, 10)
+	local pokedexDropdown = form:createDropdown(pokedexData, 50, 30, 145, 30, pokemonName)
+	form:createButton(Resources.AllScreens.Lookup, 212, 29, function()
+		local pokemonNameFromForm = ExternalUI.BizForms.getText(pokedexDropdown)
 		local pokemonId = PokemonData.getIdFromName(pokemonNameFromForm)
 
 		if pokemonId ~= nil and pokemonId ~= 0 then
@@ -439,24 +424,19 @@ function InfoScreen.openPokemonInfoWindow()
 			Program.redraw(true)
 		end
 		Utils.closeBizhawkForm(form)
-	end, 212, 29)
+	end)
 end
 
 function InfoScreen.openRouteInfoWindow()
-	local form = Utils.createBizhawkForm(Resources.AllScreens.Lookup, 360, 105)
+	local form = ExternalUI.BizForms.createForm(Resources.AllScreens.Lookup, 360, 105)
 
 	local routeName = RouteData.Info[InfoScreen.infoLookup.mapId].name -- infoLookup = {mapId, encounterArea}
 	routeName = Utils.formatSpecialCharacters(routeName)
 
-	forms.label(form, Resources.InfoScreen.PromptLookupRoute .. ":", 49, 10, 250, 20)
-	local routeDropdown = forms.dropdown(form, {["Init"]="Loading Route Data"}, 50, 30, 145, 30)
-	forms.setdropdownitems(routeDropdown, RouteData.AvailableRoutes, false) -- true = alphabetize the list
-	forms.setproperty(routeDropdown, "AutoCompleteSource", "ListItems")
-	forms.setproperty(routeDropdown, "AutoCompleteMode", "Append")
-	forms.settext(routeDropdown, routeName)
-
-	forms.button(form, Resources.AllScreens.Lookup, function()
-		local dropdownSelection = forms.gettext(routeDropdown)
+	form:createLabel(Resources.InfoScreen.PromptLookupRoute .. ":", 49, 10)
+	local routeDropdown = form:createDropdown(RouteData.AvailableRoutes, 50, 30, 145, 30, routeName)
+	form:createButton(Resources.AllScreens.Lookup, 212, 29, function()
+		local dropdownSelection = ExternalUI.BizForms.getText(routeDropdown)
 		local mapId
 
 		for id, data in pairs(RouteData.Info) do
@@ -479,8 +459,8 @@ function InfoScreen.openRouteInfoWindow()
 			InfoScreen.Buttons.ShowRouteLevels.toggleState = (Options["Open Book Play Mode"] or LogOverlay.isDisplayed)
 			Program.redraw(true)
 		end
-		Utils.closeBizhawkForm(form)
-	end, 212, 29)
+		form:destroy()
+	end)
 end
 
 function InfoScreen.getPokemonButtonsForEncounterArea(mapId, encounterArea)

--- a/ironmon_tracker/screens/InfoScreen.lua
+++ b/ironmon_tracker/screens/InfoScreen.lua
@@ -423,7 +423,7 @@ function InfoScreen.openPokemonInfoWindow()
 			InfoScreen.infoLookup = pokemonId
 			Program.redraw(true)
 		end
-		Utils.closeBizhawkForm(form)
+		form:destroy()
 	end)
 end
 

--- a/ironmon_tracker/screens/LogOverlay.lua
+++ b/ironmon_tracker/screens/LogOverlay.lua
@@ -525,13 +525,10 @@ function LogOverlay.getLogFileFromPrompt()
 		workingDir = workingDir:sub(1, -2) -- remove trailing slash
 	end
 
-	Utils.tempDisableBizhawkSound()
-	local filepath = forms.openfile(suggestedFileName, workingDir, filterOptions)
-	if Utils.isNilOrEmpty(filepath) then
-		filepath = nil
+	local filepath, success = ExternalUI.BizForms.openFilePrompt(suggestedFileName, workingDir, filterOptions)
+	if not success then
+		return nil
 	end
-	Utils.tempEnableBizhawkSound()
-
 	return filepath
 end
 

--- a/ironmon_tracker/screens/LogTabMisc.lua
+++ b/ironmon_tracker/screens/LogTabMisc.lua
@@ -162,7 +162,7 @@ function LogTabMisc.openRandomizerShareWindow()
 	local multilineOutput = table.concat(shareExport, " " .. newline)
 
 	form:createLabel(Resources.LogOverlay.PromptShareSeedDesc, 9, 10)
-	form:createTextBox(multilineOutput, 10, 35, 480, 120, nil, true, false, "Vertical")
+	form:createTextBox(multilineOutput, 10, 35, 480, 120, "", true, false, "Vertical")
 	form:createButton(Resources.AllScreens.Close, 212, 165, function()
 		form:destroy()
 	end)

--- a/ironmon_tracker/screens/LogTabMisc.lua
+++ b/ironmon_tracker/screens/LogTabMisc.lua
@@ -149,10 +149,8 @@ function LogTabMisc.refreshButtons()
 end
 
 function LogTabMisc.openRandomizerShareWindow()
-	local form = Utils.createBizhawkForm(Resources.LogOverlay.PromptShareSeedTitle, 515, 235)
-
+	local form = ExternalUI.BizForms.createForm(Resources.LogOverlay.PromptShareSeedTitle, 515, 235)
 	local newline = "\r\n"
-
 	local shareExport = {}
 	for _, button in ipairs(Utils.getSortedList(LogTabMisc.Buttons)) do
 		local infoString = string.format("%s %s", button:getText(), button:getValue())
@@ -161,12 +159,13 @@ function LogTabMisc.openRandomizerShareWindow()
 		end
 		table.insert(shareExport, infoString)
 	end
+	local multilineOutput = table.concat(shareExport, " " .. newline)
 
-	forms.label(form, Resources.LogOverlay.PromptShareSeedDesc, 9, 10, 495, 20)
-	forms.textbox(form, table.concat(shareExport, " " .. newline), 480, 120, nil, 10, 35, true, false, "Vertical")
-	forms.button(form, Resources.AllScreens.Close, function()
-		Utils.closeBizhawkForm(form)
-	end, 212, 165)
+	form:createLabel(Resources.LogOverlay.PromptShareSeedDesc, 9, 10)
+	form:createTextBox(multilineOutput, 10, 35, 480, 120, nil, true, false, "Vertical")
+	form:createButton(Resources.AllScreens.Close, 212, 165, function()
+		form:destroy()
+	end)
 end
 
 -- USER INPUT FUNCTIONS

--- a/ironmon_tracker/screens/MoveHistoryScreen.lua
+++ b/ironmon_tracker/screens/MoveHistoryScreen.lua
@@ -152,7 +152,7 @@ function MoveHistoryScreen.buildOutHistory(pokemonID, startingLevel)
 end
 
 function MoveHistoryScreen.openPokemonInfoWindow()
-	local form = Utils.createBizhawkForm(Resources.MoveHistoryScreen.PromptPokemonTitle, 360, 105)
+	local form = ExternalUI.BizForms.createForm(Resources.MoveHistoryScreen.PromptPokemonTitle, 360, 105)
 
 	local pokemonName
 	if PokemonData.isValid(MoveHistoryScreen.pokemonID) then
@@ -162,24 +162,19 @@ function MoveHistoryScreen.openPokemonInfoWindow()
 	end
 	local pokedexData = PokemonData.namesToList()
 
-	forms.label(form, Resources.MoveHistoryScreen.PromptPokemonDesc .. ":", 49, 10, 250, 20)
-	local pokedexDropdown = forms.dropdown(form, {["Init"]="Loading Pokedex"}, 50, 30, 145, 30)
-	forms.setdropdownitems(pokedexDropdown, pokedexData, true) -- true = alphabetize the list
-	forms.setproperty(pokedexDropdown, "AutoCompleteSource", "ListItems")
-	forms.setproperty(pokedexDropdown, "AutoCompleteMode", "Append")
-	forms.settext(pokedexDropdown, pokemonName)
+	form:createLabel(Resources.MoveHistoryScreen.PromptPokemonDesc .. ":", 49, 10)
+	local pokedexDropdown = form:createDropdown(pokedexData, 50, 30, 145, 30, pokemonName)
 
-	forms.button(form, Resources.AllScreens.Lookup, function()
-		local pokemonNameFromForm = forms.gettext(pokedexDropdown)
+	form:createButton(Resources.AllScreens.Lookup, 212, 29, function()
+		local pokemonNameFromForm = ExternalUI.BizForms.getText(pokedexDropdown)
 		local pokemonId = PokemonData.getIdFromName(pokemonNameFromForm)
-
 		if pokemonId ~= nil and pokemonId ~= 0 then
 			if MoveHistoryScreen.buildOutHistory(pokemonId) then
 				Program.redraw(true)
 			end
 		end
-		Utils.closeBizhawkForm(form)
-	end, 212, 29)
+		form:destroy()
+	end)
 end
 
 -- USER INPUT FUNCTIONS

--- a/ironmon_tracker/screens/QuickloadScreen.lua
+++ b/ironmon_tracker/screens/QuickloadScreen.lua
@@ -258,22 +258,19 @@ function QuickloadScreen.verifyOptions()
 end
 
 function QuickloadScreen.handleSetRomFolder(button)
-	local path = Options.FILES[button.optionKey]
+	local knownpath = Options.FILES[button.optionKey]
 	local filterOptions = "ROM File (*.GBA)|*.gba|All files (*.*)|*.*"
-
-	Utils.tempDisableBizhawkSound()
-
-	local file = forms.openfile("SELECT A ROM", path, filterOptions)
-	if not Utils.isNilOrEmpty(file) then
+	local filepath, success = ExternalUI.BizForms.openFilePrompt("SELECT A ROM", knownpath, filterOptions)
+	if success then
 		-- Since the user had to pick a file, strip out the file name to just get the folder path
 		local pattern = "^.*()" .. FileManager.slash
-		file = file:sub(0, (file:match(pattern) or 1) - 1)
+		filepath = filepath:sub(0, (filepath:match(pattern) or 1) - 1)
 
-		if Utils.isNilOrEmpty(file) then
+		if Utils.isNilOrEmpty(filepath) then
 			Options.FILES[button.optionKey] = ""
 			button.isSet = false
 		else
-			Options.FILES[button.optionKey] = file
+			Options.FILES[button.optionKey] = filepath
 			button.isSet = true
 			-- After changing the setup, read-in any existing attempts counter for the new quickload choice
 			Main.ReadAttemptsCount()
@@ -281,74 +278,60 @@ function QuickloadScreen.handleSetRomFolder(button)
 
 		Main.SaveSettings(true)
 	end
-
 	QuickloadScreen.refreshButtons()
 	Program.redraw(true)
-	Utils.tempEnableBizhawkSound()
 end
 
 function QuickloadScreen.handleSetRandomizerJar(button)
-	local path = Options.FILES[button.optionKey]
+	local knownpath = Options.FILES[button.optionKey]
 	local filterOptions = "JAR File (*.JAR)|*.jar|All files (*.*)|*.*"
-
-	Utils.tempDisableBizhawkSound()
-
-	local file = forms.openfile("SELECT JAR", path, filterOptions)
-	if not Utils.isNilOrEmpty(file) then
-		local extension = FileManager.extractFileExtensionFromPath(file)
+	local filepath, success = ExternalUI.BizForms.openFilePrompt("SELECT JAR", knownpath, filterOptions)
+	if success then
+		local extension = FileManager.extractFileExtensionFromPath(filepath)
 		if extension == "jar" then
-			Options.FILES[button.optionKey] = file
+			Options.FILES[button.optionKey] = filepath
 			button.isSet = true
 			Main.SaveSettings(true)
 		else
 			Main.DisplayError("The file selected is not the Randomizer JAR file.\n\nPlease select the JAR file in the Randomizer ZX folder.")
 		end
 	end
-
 	QuickloadScreen.refreshButtons()
 	Program.redraw(true)
-	Utils.tempEnableBizhawkSound()
 end
 
 function QuickloadScreen.handleSetSourceRom(button)
-	local path = Options.FILES[button.optionKey]
+	local knownpath = Options.FILES[button.optionKey]
 	local filterOptions = "GBA File (*.GBA)|*.gba|All files (*.*)|*.*"
-
-	Utils.tempDisableBizhawkSound()
-
-	local file = forms.openfile("SELECT A ROM", path, filterOptions)
-	if not Utils.isNilOrEmpty(file) then
-		local extension = FileManager.extractFileExtensionFromPath(file)
+	local filepath, success = ExternalUI.BizForms.openFilePrompt("SELECT A ROM", knownpath, filterOptions)
+	if success then
+		local extension = FileManager.extractFileExtensionFromPath(filepath)
 		if extension == "gba" then
-			Options.FILES[button.optionKey] = file
+			Options.FILES[button.optionKey] = filepath
 			button.isSet = true
 			Main.SaveSettings(true)
 		else
 			Main.DisplayError("The file selected is not a GBA ROM file.\n\nPlease select a GBA file: has the file extension \".gba\"")
 		end
 	end
-
 	QuickloadScreen.refreshButtons()
 	Program.redraw(true)
-	Utils.tempEnableBizhawkSound()
 end
 
 function QuickloadScreen.handleSetCustomSettings(button)
-	local path = Options.FILES[button.optionKey]
+	local knownpath = Options.FILES[button.optionKey]
 	local filterOptions = "RNQS File (*.RNQS)|*.rnqs|All files (*.*)|*.*"
 
 	-- If the custom settings file hasn't ever been set, show the folder containing preloaded setting files
-	if Utils.isNilOrEmpty(path) or not FileManager.fileExists(path) then
-		path = FileManager.getRandomizerSettingsPath()
+	if Utils.isNilOrEmpty(knownpath) or not FileManager.fileExists(knownpath) then
+		knownpath = FileManager.getRandomizerSettingsPath()
 	end
 
-	Utils.tempDisableBizhawkSound()
-
-	local file = forms.openfile("SELECT RNQS", path, filterOptions)
-	if not Utils.isNilOrEmpty(file) then
-		local extension = FileManager.extractFileExtensionFromPath(file)
+	local filepath, success = ExternalUI.BizForms.openFilePrompt("SELECT RNQS", knownpath, filterOptions)
+	if success then
+		local extension = FileManager.extractFileExtensionFromPath(filepath)
 		if extension == "rnqs" then
-			Options.FILES[button.optionKey] = file
+			Options.FILES[button.optionKey] = filepath
 			button.isSet = true
 			-- After changing the setup, read-in any existing attempts counter for the new quickload choice or force-create a new one if it doesn't exist
 			Main.ReadAttemptsCount(true)
@@ -357,10 +340,8 @@ function QuickloadScreen.handleSetCustomSettings(button)
 			Main.DisplayError("The file selected is not a Randomizer Settings file.\n\nPlease select an RNQS file: has the file extension \".rnqs\"")
 		end
 	end
-
 	QuickloadScreen.refreshButtons()
 	Program.redraw(true)
-	Utils.tempEnableBizhawkSound()
 end
 
 -- USER INPUT FUNCTIONS

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -412,7 +412,7 @@ function SetupScreen.openEditControlsWindow()
 		end
 	end)
 	form:createButton(Resources.AllScreens.Cancel, 320, offsetY + 5, function()
-		Utils.closeBizhawkForm(form)
+		form:destroy()
 	end)
 end
 

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -368,9 +368,9 @@ function SetupScreen.createButtons()
 end
 
 function SetupScreen.openEditControlsWindow()
-	local form = Utils.createBizhawkForm(Resources.SetupScreen.PromptEditControllerTitle, 445, 215)
+	local form = ExternalUI.BizForms.createForm(Resources.SetupScreen.PromptEditControllerTitle, 445, 215)
 
-	forms.label(form, Resources.SetupScreen.PromptEditControllerDesc, 19, 10, 410, 20)
+	form:createLabel(Resources.SetupScreen.PromptEditControllerDesc, 19, 10)
 
 	local controlKeyMap = {
 		{"Load next seed", "PromptEditControllerLoadNext", },
@@ -386,39 +386,34 @@ function SetupScreen.openEditControlsWindow()
 
 	for i, controlTuple in ipairs(controlKeyMap) do
 		local controlLabel = string.format("%s:", Resources.SetupScreen[controlTuple[2]])
-		forms.label(form, controlLabel, col1X, offsetY, col2X - col1X, 20)
-		inputTextboxes[i] = forms.textbox(form, Options.CONTROLS[controlTuple[1]], 140, 21, nil, col2X, offsetY - 2)
+		form:createLabel(controlLabel, col1X, offsetY)
+		inputTextboxes[i] = form:createTextBox(Options.CONTROLS[controlTuple[1]], col2X, offsetY - 2, 140, 21)
 		offsetY = offsetY + 24
 	end
 
 	-- Buttons
 	local saveCloseLabel = string.format("%s && %s", Resources.AllScreens.Save, Resources.AllScreens.Close)
-	local btnSave = forms.button(form, saveCloseLabel, function()
+	form:createButton(saveCloseLabel, 45, offsetY + 5, function()
 		for i, controlTuple in ipairs(controlKeyMap) do
-			local controlCombination = Utils.formatControls(forms.gettext(inputTextboxes[i] or ""))
+			local text = ExternalUI.BizForms.getText(inputTextboxes[i])
+			local controlCombination = Utils.formatControls(text)
 			if not Utils.isNilOrEmpty(controlCombination) then
 				Options.CONTROLS[controlTuple[1]] = controlCombination
 			end
 		end
 		Main.SaveSettings(true)
 		Program.redraw(true)
-
-		Utils.closeBizhawkForm(form)
-	end, 45, offsetY + 5)
-	forms.setproperty(btnSave, "AutoSize", true)
-
-	local btnReset = forms.button(form, Resources.SetupScreen.PromptEditControllerResetDefault, function()
+		form:destroy()
+	end)
+	form:createButton(Resources.SetupScreen.PromptEditControllerResetDefault, 175, offsetY + 5, function()
 		for i, controlTuple in ipairs(controlKeyMap) do
-			local default = Options.Defaults.CONTROLS[controlTuple[1]]
-			forms.settext(inputTextboxes[i], default or "")
+			local defaultText = Options.Defaults.CONTROLS[controlTuple[1]] or ""
+			ExternalUI.BizForms.setText(inputTextboxes[i], defaultText)
 		end
-	end, 175, offsetY + 5)
-	forms.setproperty(btnReset, "AutoSize", true)
-
-	local btnClose = forms.button(form, Resources.AllScreens.Cancel, function()
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 320, offsetY + 5, function()
 		Utils.closeBizhawkForm(form)
-	end, 320, offsetY + 5)
-	forms.setproperty(btnClose, "AutoSize", true)
+	end)
 end
 
 -- USER INPUT FUNCTIONS

--- a/ironmon_tracker/screens/StartupScreen.lua
+++ b/ironmon_tracker/screens/StartupScreen.lua
@@ -95,7 +95,7 @@ StartupScreen.Buttons = {
 }
 
 function StartupScreen.initialize()
-	StartupScreen.setPokemonIcon(Options["Startup Pokemon displayed"])
+	StartupScreen.setPokemonIcon(tostring(Options["Startup Pokemon displayed"]))
 
 	for _, button in pairs(StartupScreen.Buttons) do
 		if button.textColor == nil then
@@ -125,6 +125,7 @@ function StartupScreen.refreshButtons()
 	end
 end
 
+---@param displayOption string
 function StartupScreen.setPokemonIcon(displayOption)
 	local pokemonID = Utils.randomPokemonID()
 
@@ -156,7 +157,7 @@ function StartupScreen.setPokemonIcon(displayOption)
 end
 
 function StartupScreen.openChoosePokemonWindow()
-	local form = Utils.createBizhawkForm(Resources.StartupScreen.PromptChooseAPokemonTitle, 330, 145)
+	local form = ExternalUI.BizForms.createForm(Resources.StartupScreen.PromptChooseAPokemonTitle, 330, 145)
 
 	local dropdownOptions = {
 		string.format("-- %s", Resources.StartupScreen.PromptChooseAPokemonByAttempt),
@@ -169,13 +170,6 @@ function StartupScreen.openChoosePokemonWindow()
 		table.insert(allPokemon, opt)
 	end
 	table.insert(allPokemon, "...................................") -- A spacer to separate special options
-
-	forms.label(form,Resources.StartupScreen.PromptChooseAPokemonDesc, 49, 10, 250, 20)
-	local pokedexDropdown = forms.dropdown(form, {["Init"]="Loading Pokedex"}, 50, 30, 145, 30)
-	forms.setdropdownitems(pokedexDropdown, allPokemon, true) -- true = alphabetize the list
-	forms.setproperty(pokedexDropdown, "AutoCompleteSource", "ListItems")
-	forms.setproperty(pokedexDropdown, "AutoCompleteMode", "Append")
-
 	local initialChoice
 	if Options["Startup Pokemon displayed"] == Options.StartupIcon.attempts then
 		initialChoice = dropdownOptions[1]
@@ -186,32 +180,31 @@ function StartupScreen.openChoosePokemonWindow()
 	else
 		initialChoice = PokemonData.Pokemon[Options["Startup Pokemon displayed"] or "1"].name
 	end
-	forms.settext(pokedexDropdown, initialChoice)
 
-	forms.button(form, Resources.AllScreens.Save, function()
-		local optionSelected = forms.gettext(pokedexDropdown)
+	form:createLabel(Resources.StartupScreen.PromptChooseAPokemonDesc, 49, 10)
+	local pokedexDropdown = form:createDropdown(allPokemon, 50, 30, 145, 30, initialChoice)
 
-		if optionSelected == dropdownOptions[1] then
-			optionSelected = Options.StartupIcon.attempts
-		elseif optionSelected == dropdownOptions[2] then
-			optionSelected = Options.StartupIcon.random
-		elseif optionSelected == dropdownOptions[3] then
-			optionSelected = Options.StartupIcon.none
-		elseif optionSelected ~= "..................................." then
+	form:createButton(Resources.AllScreens.Save, 200, 29, function()
+		local choice = ExternalUI.BizForms.getText(pokedexDropdown)
+		if choice == dropdownOptions[1] then
+			choice = Options.StartupIcon.attempts
+		elseif choice == dropdownOptions[2] then
+			choice = Options.StartupIcon.random
+		elseif choice == dropdownOptions[3] then
+			choice = Options.StartupIcon.none
+		elseif choice ~= "..................................." then
 			-- The option is a Pokemon's name and needs to be convered to an ID
-			optionSelected = PokemonData.getIdFromName(optionSelected) or -1
+			choice = tostring(PokemonData.getIdFromName(choice) or -1)
 		end
-
-		StartupScreen.setPokemonIcon(optionSelected)
+		StartupScreen.setPokemonIcon(choice)
 		Program.redraw(true)
 		Main.SaveSettings(true)
+		form:destroy()
+	end)
 
-		Utils.closeBizhawkForm(form)
-	end, 200, 29)
-
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 120, 69)
+	form:createButton(Resources.AllScreens.Cancel, 120, 69, function()
+		form:destroy()
+	end)
 end
 
 -- USER INPUT FUNCTIONS

--- a/ironmon_tracker/screens/StreamConnectOverlay.lua
+++ b/ironmon_tracker/screens/StreamConnectOverlay.lua
@@ -1354,11 +1354,10 @@ function StreamConnectOverlay.openNetworkOptionPrompt(modeKey)
 end
 
 function StreamConnectOverlay.openNetworkFolderPrompt(modeKey)
-	local path = Network.Options[modeKey] or ""
+	local path = tostring(Network.Options[modeKey] or "")
 	local filterOptions = "Json File (*.JSON)|*.json|All files (*.*)|*.*"
-	Utils.tempDisableBizhawkSound()
-	local filepath = forms.openfile("SELECT ANY JSON FILE", path, filterOptions)
-	if not Utils.isNilOrEmpty(filepath) then
+	local filepath, success = ExternalUI.BizForms.openFilePrompt("SELECT ANY JSON FILE", path, filterOptions)
+	if success then
 		-- Since the user had to pick a file, strip out the file name to just get the folder path
 		local pattern = "^.*()" .. FileManager.slash
 		filepath = filepath:sub(0, (filepath:match(pattern) or 1) - 1)
@@ -1374,7 +1373,6 @@ function StreamConnectOverlay.openNetworkFolderPrompt(modeKey)
 		end
 		Main.SaveSettings(true)
 	end
-	Utils.tempEnableBizhawkSound()
 	SCREEN.refreshButtons()
 	Program.redraw(true)
 end

--- a/ironmon_tracker/screens/StreamConnectOverlay.lua
+++ b/ironmon_tracker/screens/StreamConnectOverlay.lua
@@ -1235,7 +1235,7 @@ function StreamConnectOverlay.openEventOptionsPrompt(event)
 		elseif type(currentValue) == "string" or type(currentValue) == "number" then
 			local optionText = Resources.StreamConnect[optionKey] or optionKey or Constants.BLANKLINE
 			form:createLabel(optionText .. ":", x, y)
-			optionsInForm[optionKey] = form:createTextBox(tostring(currentValue), x + rightColOffset, y, 92, 19, nil)
+			optionsInForm[optionKey] = form:createTextBox(tostring(currentValue), x + rightColOffset, y, 92, 19)
 			y = y + lineHeight
 		end
 	end
@@ -1386,7 +1386,7 @@ function StreamConnectOverlay.openGetCodeWindow()
 	y = y + lineHeight
 	form:createLabel('3. Restart Streamerbot.', x, y)
 	y = y + lineHeight
-	form:createTextBox(codeText, x - 1, y, 763, 442, nil, true, true, "Vertical")
+	form:createTextBox(codeText, x - 1, y, 763, 442, "", true, true, "Vertical")
 	form:createLabel(string.format("Streamerbot Code Version: %s", Network.STREAMERBOT_VERSION), x, 530)
 	form:createButton(Resources.AllScreens.Close, 350, 530, function()
 		form:destroy()

--- a/ironmon_tracker/screens/StreamConnectOverlay.lua
+++ b/ironmon_tracker/screens/StreamConnectOverlay.lua
@@ -1093,43 +1093,43 @@ function StreamConnectOverlay.changeTab(tab)
 end
 
 function StreamConnectOverlay.openCommandRenamePrompt(event)
-	local form = Utils.createBizhawkForm("Edit Command", 320, 140, 100, 50)
+	local form = ExternalUI.BizForms.createForm("Edit Command", 320, 140, 100, 50)
 	local x, y, lineHeight = 30, 15, 20
 
-	forms.label(form, string.format("Command: %s", event.Name), x - 1, y, 300, y)
+	form:createLabel(string.format("Command: %s", event.Name), x - 1, y)
 	y = y + lineHeight
-	local textbox = forms.textbox(form, event.Command, 120, lineHeight, nil, x + 1, y)
+	local textbox = form:createTextBox(event.Command, x + 1, y, 120, lineHeight)
 	y = y + lineHeight
 
 	y = y + 15
-	forms.button(form, Resources.AllScreens.Save, function()
-		local text = forms.gettext(textbox) or ""
+	form:createButton(Resources.AllScreens.Save, 30, y, function()
+		local text = ExternalUI.BizForms.getText(textbox)
 		if #text > 2 and text:sub(1,1) == "!" then -- Command requirements
 			event.Command = Utils.toLowerUTF8(text)
 			EventHandler.saveEventSetting(event, "Command")
 			SCREEN.refreshButtons()
 			Program.redraw(true)
 		end
-		Utils.closeBizhawkForm(form)
-	end, 30, y)
-	forms.button(form, string.format("(%s)", Resources.StreamConnect.PromptDefault), function()
+		form:destroy()
+	end)
+	form:createButton(string.format("(%s)", Resources.StreamConnect.PromptDefault), 120, y, function()
 		local defaultEvent = EventHandler.DefaultEvents[event.Key]
 		if defaultEvent then
-			forms.settext(textbox, defaultEvent.Command)
+			ExternalUI.BizForms.setText(textbox, defaultEvent.Command)
 		end
-	end, 120, y)
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 210, y)
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 210, y, function()
+		form:destroy()
+	end)
 end
 
 function StreamConnectOverlay.openCommandRolesPrompt()
-	local form = Utils.createBizhawkForm("Edit Command Roles", 320, 255, 100, 40)
+	local form = ExternalUI.BizForms.createForm("Edit Command Roles", 320, 255, 100, 40)
 
 	local x, y = 20, 15
 	local lineHeight = 21
 	local commandLabel = string.format("Select user roles that can use Tracker chat commands:")
-	forms.label(form, commandLabel, x - 1, y, 300, 20)
+	form:createLabel(commandLabel, x - 1, y)
 	y = y + lineHeight
 
 	-- Current role options, from the user settings
@@ -1142,47 +1142,48 @@ function StreamConnectOverlay.openCommandRolesPrompt()
 	local roleCheckboxes = {}
 	local customRoleTextbox
 
+	-- Enable or Disable all non-Everyone roles based on the state of Everyone role being allowed
+	local function enableDisableAll()
+		local allowEveryone = ExternalUI.BizForms.isChecked(roleCheckboxes["Everyone"])
+		for _, roleKey in ipairs(orderedRoles) do
+			if roleKey ~= "Everyone" and roleKey ~= "Broadcaster" then
+				ExternalUI.BizForms.setProperty(roleCheckboxes[roleKey], ExternalUI.BizForms.Properties.ENABLED, not allowEveryone)
+			end
+		end
+		if customRoleTextbox then
+			ExternalUI.BizForms.setProperty(customRoleTextbox, ExternalUI.BizForms.Properties.ENABLED, not allowEveryone)
+		end
+	end
+
 	for i, roleKey in ipairs(orderedRoles) do
 		local roleLabel = roleKey
 		if roleKey == "Custom" then
 			roleLabel = "Custom Role:"
-			customRoleTextbox = forms.textbox(form, Network.Options["CustomCommandRole"], 120, 19, nil, x + 143, y + lineHeight * (i - 1))
+			customRoleTextbox = form:createTextBox(Network.Options["CustomCommandRole"], x + 143, y + lineHeight * (i - 1), 120, 19)
 		end
-		roleCheckboxes[roleKey] = forms.checkbox(form, roleLabel, x, y + lineHeight * (i - 1))
+		local clickFunc = (roleKey == "Everyone" and enableDisableAll) or nil
+		roleCheckboxes[roleKey] = form:createCheckbox(roleLabel, x, y + lineHeight * (i - 1), clickFunc)
 		local roleAllowed = currentRoles["Everyone"] ~= nil or currentRoles[roleKey] ~= nil
-		forms.setproperty(roleCheckboxes[roleKey], "Checked", roleAllowed)
+		ExternalUI.BizForms.setChecked(roleCheckboxes[roleKey], roleAllowed)
 	end
-	forms.setproperty(roleCheckboxes["Broadcaster"], "Checked", true)
-	forms.setproperty(roleCheckboxes["Broadcaster"], "Enabled", false)
+	ExternalUI.BizForms.setChecked(roleCheckboxes["Broadcaster"], true)
+	ExternalUI.BizForms.setProperty(roleCheckboxes["Broadcaster"], ExternalUI.BizForms.Properties.ENABLED, false)
 
-	-- Enable or Disable all non-Everyone roles based on the state of Everyone role being allowed
-	local function enableDisableAll()
-		local allowEveryone = forms.ischecked(roleCheckboxes["Everyone"])
-		for _, roleKey in ipairs(orderedRoles) do
-			if roleKey ~= "Everyone" and roleKey ~= "Broadcaster" then
-				forms.setproperty(roleCheckboxes[roleKey], "Enabled", not allowEveryone)
-			end
-		end
-		if customRoleTextbox then
-			forms.setproperty(customRoleTextbox, "Enabled", not allowEveryone)
-		end
-	end
-	forms.addclick(roleCheckboxes["Everyone"], enableDisableAll)
 	enableDisableAll()
 
 	local buttonRowY = y + lineHeight * #orderedRoles + 15
-	forms.button(form, Resources.AllScreens.Save, function()
-		if forms.ischecked(roleCheckboxes["Everyone"]) then
+	form:createButton(Resources.AllScreens.Save, 30, buttonRowY, function()
+		if ExternalUI.BizForms.isChecked(roleCheckboxes["Everyone"]) then
 			Network.Options["CommandRoles"] = EventHandler.CommandRoles.Everyone
 		else
-			if forms.ischecked(roleCheckboxes["Custom"]) and customRoleTextbox then
-				Network.Options["CustomCommandRole"] = forms.gettext(customRoleTextbox) or ""
+			if ExternalUI.BizForms.isChecked(roleCheckboxes["Custom"]) and customRoleTextbox then
+				Network.Options["CustomCommandRole"] = ExternalUI.BizForms.getText(customRoleTextbox)
 			else
 				Network.Options["CustomCommandRole"] = ""
 			end
 			local allowedRoles = {}
 			for _, roleKey in ipairs(orderedRoles) do
-				if forms.ischecked(roleCheckboxes[roleKey]) then
+				if ExternalUI.BizForms.isChecked(roleCheckboxes[roleKey]) then
 					if roleKey == "Custom" then
 						if not Utils.isNilOrEmpty(Network.Options["CustomCommandRole"]) then
 							table.insert(allowedRoles, Network.Options["CustomCommandRole"])
@@ -1200,25 +1201,25 @@ function StreamConnectOverlay.openCommandRolesPrompt()
 		}))
 		SCREEN.refreshButtons()
 		Program.redraw(true)
-		Utils.closeBizhawkForm(form)
-	end, 30, buttonRowY)
-	forms.button(form, string.format("(%s)", Resources.StreamConnect.PromptDefault), function()
+		form:destroy()
+	end)
+	form:createButton(string.format("(%s)", Resources.StreamConnect.PromptDefault), 120, buttonRowY, function()
 		for _, roleKey in ipairs(orderedRoles) do
-			forms.setproperty(roleCheckboxes[roleKey], "Checked", true)
+			ExternalUI.BizForms.setChecked(roleCheckboxes[roleKey], true)
 		end
-		forms.settext(customRoleTextbox, "")
+		ExternalUI.BizForms.setText(customRoleTextbox, "")
 		enableDisableAll()
-	end, 120, buttonRowY)
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 210, buttonRowY)
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 210, buttonRowY, function()
+		form:destroy()
+	end)
 end
 
 function StreamConnectOverlay.openEventOptionsPrompt(event)
 	local x, y, lineHeight = 20, 15, 20
-	local form = Utils.createBizhawkForm("Edit Reward Options", 320, 130 + (#event.Options * lineHeight), 100, 50)
+	local form = ExternalUI.BizForms.createForm("Edit Reward Options", 320, 130 + (#event.Options * lineHeight))
 
-	forms.label(form, event.Name, x, y, 300, lineHeight)
+	form:createLabel(event.Name, x, y)
 	y = y + lineHeight + 5
 
 	local rightColOffset = 180
@@ -1227,30 +1228,30 @@ function StreamConnectOverlay.openEventOptionsPrompt(event)
 		local currentValue = event[optionKey]
 		if type(currentValue) == "boolean" then
 			local optionText = Resources.StreamConnect[optionKey] or optionKey or Constants.BLANKLINE
-			forms.label(form, optionText .. ":", x, y, rightColOffset - 2, lineHeight)
-			optionsInForm[optionKey] = forms.checkbox(form, "", x + rightColOffset, y - 4)
-			forms.setproperty(optionsInForm[optionKey], "Checked", currentValue)
+			form:createLabel(optionText .. ":", x, y)
+			optionsInForm[optionKey] = form:createCheckbox("", x + rightColOffset, y - 4)
+			ExternalUI.BizForms.setChecked(optionsInForm[optionKey], currentValue)
 			y = y + lineHeight
 		elseif type(currentValue) == "string" or type(currentValue) == "number" then
 			local optionText = Resources.StreamConnect[optionKey] or optionKey or Constants.BLANKLINE
-			forms.label(form, optionText .. ":", x, y, rightColOffset - 2, lineHeight)
-			optionsInForm[optionKey] = forms.textbox(form, tostring(currentValue), 92, 19, nil, x + rightColOffset, y)
+			form:createLabel(optionText .. ":", x, y)
+			optionsInForm[optionKey] = form:createTextBox(tostring(currentValue), x + rightColOffset, y, 92, 19, nil)
 			y = y + lineHeight
 		end
 	end
 
 	local buttonRowY = y + 15
-	forms.button(form, Resources.AllScreens.Save, function()
+	form:createButton(Resources.AllScreens.Save, 30, buttonRowY, function()
 		for optionKey, formHandle in pairs(optionsInForm) do
 			local currentValue = event[optionKey]
 			local newValue
 			if type(currentValue) == "boolean" then
-				newValue = forms.ischecked(formHandle)
+				newValue = ExternalUI.BizForms.isChecked(formHandle)
 			elseif type(currentValue) == "string" or type(currentValue) == "number" then
-				newValue = forms.gettext(formHandle) or ""
+				newValue = ExternalUI.BizForms.getText(formHandle)
 			elseif type(currentValue) == "number" then
-				newValue = forms.gettext(formHandle) or ""
-				-- newValue = tonumber(forms.gettext(formHandle) or "") or "" -- numbers not yet supported
+				newValue = ExternalUI.BizForms.getText(formHandle)
+				-- newValue = tonumber(ExternalUI.BizForms.getText(formHandle)) or "" -- numbers not yet supported
 			end
 			-- Save only new changes
 			if newValue ~= nil and newValue ~= currentValue then
@@ -1260,9 +1261,9 @@ function StreamConnectOverlay.openEventOptionsPrompt(event)
 		end
 		SCREEN.refreshButtons()
 		Program.redraw(true)
-		Utils.closeBizhawkForm(form)
-	end, 30, buttonRowY)
-	forms.button(form, string.format("(%s)", Resources.StreamConnect.PromptDefault), function()
+		form:destroy()
+	end)
+	form:createButton(string.format("(%s)", Resources.StreamConnect.PromptDefault), 120, buttonRowY, function()
 		local defaultEvent = EventHandler.DefaultEvents[event.Key]
 		if not defaultEvent then
 			return
@@ -1272,41 +1273,39 @@ function StreamConnectOverlay.openEventOptionsPrompt(event)
 			if defaultValue ~= nil then
 				local currentValue = event[optionKey]
 				if type(currentValue) == "boolean" then
-					forms.setproperty(formHandle, "Checked", defaultValue)
+					ExternalUI.BizForms.setChecked(formHandle, defaultValue)
 				elseif type(currentValue) == "string" or type(currentValue) == "number" then
-					forms.settext(formHandle, defaultValue)
+					ExternalUI.BizForms.setText(formHandle, defaultValue)
 				end
 			end
 		end
-	end, 120, buttonRowY)
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 210, buttonRowY)
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 210, buttonRowY, function()
+		form:destroy()
+	end)
 end
 
 function StreamConnectOverlay.openRewardListPrompt(event)
-	local form = Utils.createBizhawkForm("Edit Reward Association", 320, 170, 100, 50)
+	local form = ExternalUI.BizForms.createForm("Edit Reward Association", 320, 170)
 	local rewardEventText = string.format("Tracker Reward: %s", event.Name)
-	forms.label(form, rewardEventText, 28, 10, 300, 20)
+	form:createLabel(rewardEventText, 28, 10)
 	local rewardTriggerTxt = "Triggered by Twitch Reward:"
-	forms.label(form, rewardTriggerTxt, 28, 35, 250, 20)
+	form:createLabel(rewardTriggerTxt, 28, 35)
 
 	local CHOICE_NONE = "(None)"
 	local rewardsList = { CHOICE_NONE }
 	for _, rewardTitle in pairs(EventHandler.RewardsExternal) do
 		table.insert(rewardsList, rewardTitle)
 	end
-
-	local dropdown = forms.dropdown(form, {["Init"]="Loading Rewards"}, 33, 60, 230, 30)
-	forms.setdropdownitems(dropdown, rewardsList, true) -- true = alphabetize the list
-	forms.setproperty(dropdown, "AutoCompleteSource", "ListItems")
-	forms.setproperty(dropdown, "AutoCompleteMode", "Append")
+	local initialChoice = CHOICE_NONE
 	if not Utils.isNilOrEmpty(EventHandler.RewardsExternal[event.RewardId]) then
-		forms.settext(dropdown, EventHandler.RewardsExternal[event.RewardId])
+		initialChoice = EventHandler.RewardsExternal[event.RewardId]
 	end
 
-	forms.button(form, Resources.AllScreens.Save, function()
-		local optionSelected = forms.gettext(dropdown)
+	local dropdown = form:createDropdown(rewardsList, 33, 60, 230, 30, initialChoice)
+
+	form:createButton(Resources.AllScreens.Save, 30, 100, function()
+		local optionSelected = ExternalUI.BizForms.getText(dropdown)
 		if not optionSelected or optionSelected == CHOICE_NONE then
 			event.RewardId = ""
 		else
@@ -1321,24 +1320,23 @@ function StreamConnectOverlay.openRewardListPrompt(event)
 		EventHandler.saveEventSetting(event, "RewardId")
 		SCREEN.refreshButtons()
 		Program.redraw(true)
-		Utils.closeBizhawkForm(form)
-	end, 30, 100)
-	forms.button(form, Resources.AllScreens.Clear, function()
-		forms.settext(dropdown, CHOICE_NONE)
-	end, 120, 100)
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 210, 100)
+		form:destroy()
+	end)
+	form:createButton(Resources.AllScreens.Clear, 120, 100, function()
+		ExternalUI.BizForms.setText(dropdown, CHOICE_NONE)
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 210, 100, function()
+		form:destroy()
+	end)
 end
 
 function StreamConnectOverlay.openNetworkOptionPrompt(modeKey)
-	local form = Utils.createBizhawkForm(string.format("Edit %s", modeKey), 320, 130, 100, 50)
-	forms.label(form, string.format("%s:", modeKey), 28, 20, 110, 20)
+	local form = ExternalUI.BizForms.createForm(string.format("Edit %s", modeKey), 320, 130)
+	form:createLabel(string.format("%s:", modeKey), 28, 20)
+	local textbox = form:createTextBox(tostring(Network.Options[modeKey] or ""), 134, 20, 150, 18)
 
-	local textbox = forms.textbox(form, Network.Options[modeKey] or "", 134, 20, nil, 150, 18)
-
-	forms.button(form, Resources.AllScreens.Save, function()
-		local text = forms.gettext(textbox) or ""
+	form:createButton(Resources.AllScreens.Save, 30, 50, function()
+		local text = ExternalUI.BizForms.getText(textbox)
 		if #text ~= 0 then
 			Network.closeConnections()
 			Network.Options[modeKey] = text
@@ -1346,11 +1344,11 @@ function StreamConnectOverlay.openNetworkOptionPrompt(modeKey)
 			SCREEN.refreshButtons()
 			Program.redraw(true)
 		end
-		Utils.closeBizhawkForm(form)
-	end, 30, 50)
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 210, 50)
+		form:destroy()
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 210, 50, function()
+		form:destroy()
+	end)
 end
 
 function StreamConnectOverlay.openNetworkFolderPrompt(modeKey)
@@ -1378,22 +1376,21 @@ function StreamConnectOverlay.openNetworkFolderPrompt(modeKey)
 end
 
 function StreamConnectOverlay.openGetCodeWindow()
-	local form = Utils.createBizhawkForm("Import to Streamerbot", 800, 600)
+	local form = ExternalUI.BizForms.createForm("Import to Streamerbot", 800, 600)
 	local x, y, lineHeight = 20, 15, 20
 	local codeText = Network.getStreamerbotCode()
 
-	forms.label(form, '1. On Streamerbot, click the IMPORT button at the top.', x, y, 495, lineHeight)
+	form:createLabel('1. On Streamerbot, click the IMPORT button at the top.', x, y)
 	y = y + lineHeight
-	forms.label(form, '2. Copy/paste the below code into the top textbox. Click "Import" and "OK".', x, y, 495, lineHeight)
+	form:createLabel('2. Copy/paste the below code into the top textbox. Click "Import" and "OK".', x, y)
 	y = y + lineHeight
-	forms.label(form, '3. Restart Streamerbot.', x, y, 495, lineHeight)
+	form:createLabel('3. Restart Streamerbot.', x, y)
 	y = y + lineHeight
-	forms.textbox(form, codeText, 763, 442, nil, x - 1, y, true, true, "Vertical")
-
-	forms.label(form, string.format("Streamerbot Code Version: %s", Network.STREAMERBOT_VERSION), x, 530, 250, lineHeight)
-	forms.button(form, Resources.AllScreens.Close, function()
-		Utils.closeBizhawkForm(form)
-	end, 350, 530)
+	form:createTextBox(codeText, x - 1, y, 763, 442, nil, true, true, "Vertical")
+	form:createLabel(string.format("Streamerbot Code Version: %s", Network.STREAMERBOT_VERSION), x, 530)
+	form:createButton(Resources.AllScreens.Close, 350, 530, function()
+		form:destroy()
+	end)
 end
 
 -- USER INPUT FUNCTIONS

--- a/ironmon_tracker/screens/StreamerScreen.lua
+++ b/ironmon_tracker/screens/StreamerScreen.lua
@@ -129,12 +129,12 @@ function StreamerScreen.refreshButtons()
 end
 
 function StreamerScreen.openEditAttemptsWindow()
-	local form = Utils.createBizhawkForm(Resources.StreamerScreen.PromptEditAttemptsTitle, 320, 130)
+	local form = ExternalUI.BizForms.createForm(Resources.StreamerScreen.PromptEditAttemptsTitle, 320, 130)
 
-	forms.label(form, Resources.StreamerScreen.PromptEditAttemptsDesc, 48, 10, 300, 20)
-	local textBox = forms.textbox(form, Main.currentSeed, 200, 30, "UNSIGNED", 50, 30)
-	forms.button(form, Resources.AllScreens.Save, function()
-		local formInput = forms.gettext(textBox)
+	form:createLabel(Resources.StreamerScreen.PromptEditAttemptsDesc, 48, 10)
+	local textBox = form:createTextBox(tostring(Main.currentSeed), 50, 30, 200, 30, "UNSIGNED", nil, true)
+	form:createButton(Resources.AllScreens.Save, 72, 60, function()
+		local formInput = ExternalUI.BizForms.getText(textBox)
 		if not Utils.isNilOrEmpty(formInput) then
 			local newAttemptsCount = tonumber(formInput)
 			if newAttemptsCount ~= nil and Main.currentSeed ~= newAttemptsCount then
@@ -143,37 +143,34 @@ function StreamerScreen.openEditAttemptsWindow()
 				Program.redraw(true)
 			end
 		end
-		Utils.closeBizhawkForm(form)
-	end, 72, 60)
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 157, 60)
+		form:destroy()
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 157, 60, function()
+		form:destroy()
+	end)
 end
 
 function StreamerScreen.openEditWelcomeMessageWindow()
-	local form = Utils.createBizhawkForm(Resources.StreamerScreen.PromptEditWelcomeTitle, 515, 235)
+	local form = ExternalUI.BizForms.createForm(Resources.StreamerScreen.PromptEditWelcomeTitle, 515, 235)
 
 	local welcomeMsg = Utils.formatSpecialCharacters(Options["Welcome message"])
 	welcomeMsg = Utils.encodeDecodeForSettingsIni(welcomeMsg, false)
 
-	forms.label(form, Resources.StreamerScreen.PromptEditWelcomeDesc, 9, 10, 495, 20)
-	local welcomeTextBox = forms.textbox(form, welcomeMsg, 480, 120, nil, 10, 35, true, false, "Vertical")
-	forms.button(form, Resources.AllScreens.Save, function()
-		local newMessage = Utils.formatSpecialCharacters(forms.gettext(welcomeTextBox))
+	form:createLabel(Resources.StreamerScreen.PromptEditWelcomeDesc, 9, 10)
+	local welcomeTextBox = form:createTextBox(welcomeMsg, 10, 35, 480, 120, nil, true, false, "Vertical")
+	form:createButton(Resources.AllScreens.Save, 120, 165, function()
+		local newMessage = Utils.formatSpecialCharacters(ExternalUI.BizForms.getText(welcomeTextBox))
 		newMessage = Utils.encodeDecodeForSettingsIni(newMessage, true)
 		Options["Welcome message"] = newMessage
 		Main.SaveSettings(true)
-
-		Utils.closeBizhawkForm(form)
-	end, 120, 165)
-
-	forms.button(form, Resources.AllScreens.Clear, function()
-		forms.settext(welcomeTextBox, "")
-	end, 205, 165)
-
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 290, 165)
+		form:destroy()
+	end)
+	form:createButton(Resources.AllScreens.Clear, 205, 165, function()
+		ExternalUI.BizForms.setText(welcomeTextBox, "")
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 290, 165, function()
+		form:destroy()
+	end)
 end
 
 function StreamerScreen.openPokemonPickerWindow(iconButton, initPokemonID)
@@ -182,30 +179,23 @@ function StreamerScreen.openPokemonPickerWindow(iconButton, initPokemonID)
 		initPokemonID = Utils.randomPokemonID()
 	end
 
-	local form = Utils.createBizhawkForm(Resources.StreamerScreen.PromptChooseFavoriteTitle, 330, 145)
+	local form = ExternalUI.BizForms.createForm(Resources.StreamerScreen.PromptChooseFavoriteTitle, 330, 145)
 
 	local allPokemon = PokemonData.namesToList()
+	local pokemonName = PokemonData.Pokemon[initPokemonID].name
 
-	forms.label(form, Resources.StreamerScreen.PromptChooseFavoriteDesc, 24, 10, 300, 20)
-	local pokedexDropdown = forms.dropdown(form, {["Init"]="Loading Pokedex"}, 50, 30, 145, 30)
-	forms.setdropdownitems(pokedexDropdown, allPokemon, true) -- true = alphabetize the list
-	forms.setproperty(pokedexDropdown, "AutoCompleteSource", "ListItems")
-	forms.setproperty(pokedexDropdown, "AutoCompleteMode", "Append")
-	forms.settext(pokedexDropdown, PokemonData.Pokemon[initPokemonID].name)
-
-	forms.button(form, Resources.AllScreens.Save, function()
-		local optionSelected = forms.gettext(pokedexDropdown)
+	form:createLabel(Resources.StreamerScreen.PromptChooseFavoriteDesc, 24, 10)
+	local pokedexDropdown = form:createDropdown(allPokemon, 50, 30, 145, 30, pokemonName)
+	form:createButton(Resources.AllScreens.Save, 200, 29, function()
+		local optionSelected = ExternalUI.BizForms.getText(pokedexDropdown)
 		iconButton.pokemonID = PokemonData.getIdFromName(optionSelected) or 0
-
 		StreamerScreen.saveFavorites()
 		Program.redraw(true)
-
-		Utils.closeBizhawkForm(form)
-	end, 200, 29)
-
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 120, 69)
+		form:destroy()
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 120, 69, function()
+		form:destroy()
+	end)
 end
 
 function StreamerScreen.loadFavorites()

--- a/ironmon_tracker/screens/StreamerScreen.lua
+++ b/ironmon_tracker/screens/StreamerScreen.lua
@@ -132,7 +132,7 @@ function StreamerScreen.openEditAttemptsWindow()
 	local form = ExternalUI.BizForms.createForm(Resources.StreamerScreen.PromptEditAttemptsTitle, 320, 130)
 
 	form:createLabel(Resources.StreamerScreen.PromptEditAttemptsDesc, 48, 10)
-	local textBox = form:createTextBox(tostring(Main.currentSeed), 50, 30, 200, 30, "UNSIGNED", nil, true)
+	local textBox = form:createTextBox(tostring(Main.currentSeed), 50, 30, 200, 30, "UNSIGNED", false, true)
 	form:createButton(Resources.AllScreens.Save, 72, 60, function()
 		local formInput = ExternalUI.BizForms.getText(textBox)
 		if not Utils.isNilOrEmpty(formInput) then
@@ -157,7 +157,7 @@ function StreamerScreen.openEditWelcomeMessageWindow()
 	welcomeMsg = Utils.encodeDecodeForSettingsIni(welcomeMsg, false)
 
 	form:createLabel(Resources.StreamerScreen.PromptEditWelcomeDesc, 9, 10)
-	local welcomeTextBox = form:createTextBox(welcomeMsg, 10, 35, 480, 120, nil, true, false, "Vertical")
+	local welcomeTextBox = form:createTextBox(welcomeMsg, 10, 35, 480, 120, "", true, false, "Vertical")
 	form:createButton(Resources.AllScreens.Save, 120, 165, function()
 		local newMessage = Utils.formatSpecialCharacters(ExternalUI.BizForms.getText(welcomeTextBox))
 		newMessage = Utils.encodeDecodeForSettingsIni(newMessage, true)

--- a/ironmon_tracker/screens/TrackedDataScreen.lua
+++ b/ironmon_tracker/screens/TrackedDataScreen.lua
@@ -115,27 +115,25 @@ function TrackedDataScreen.refreshButtons()
 end
 
 function TrackedDataScreen.openSaveDataPrompt()
-	local form = Utils.createBizhawkForm(Resources.TrackedDataScreen.PromptHeaderSave, 290, 130)
-
+	local form = ExternalUI.BizForms.createForm(Resources.TrackedDataScreen.PromptHeaderSave, 290, 130)
 	local suggestedFileName = GameSettings.getRomName() or ""
-
 	local enterFilename = string.format("%s:", Resources.TrackedDataScreen.PromptEnterFilename)
-	forms.label(form, enterFilename, 18, 10, 300, 20)
-	local saveTextBox = forms.textbox(form, suggestedFileName, 200, 30, nil, 20, 30)
-	forms.label(form, ".TDAT", 219, 32, 45, 20)
-	forms.button(form, Resources.TrackedDataScreen.ButtonSaveData, function()
-		local formInput = forms.gettext(saveTextBox)
+	form:createLabel(enterFilename, 18, 10)
+	local nameTextbox = form:createTextBox(suggestedFileName, 20, 30, 200, 30)
+	form:createLabel(".TDAT", 219, 32)
+	form:createButton(Resources.TrackedDataScreen.ButtonSaveData, 55, 60, function()
+		local formInput = ExternalUI.BizForms.getText(nameTextbox)
 		if not Utils.isNilOrEmpty(formInput) then
 			if formInput:sub(-5):lower() ~= FileManager.Extensions.TRACKED_DATA then
 				formInput = formInput .. FileManager.Extensions.TRACKED_DATA
 			end
 			Tracker.saveData(formInput)
 		end
-		Utils.closeBizhawkForm(form)
-	end, 55, 60)
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 140, 60)
+		form:destroy()
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 140, 60, function()
+		form:destroy()
+	end)
 end
 
 function TrackedDataScreen.openLoadDataPrompt()
@@ -147,10 +145,8 @@ function TrackedDataScreen.openLoadDataPrompt()
 		workingDir = workingDir:sub(1, -2) -- remove trailing slash
 	end
 
-	Utils.tempDisableBizhawkSound()
-
-	local filepath = forms.openfile(suggestedFileName, workingDir, filterOptions)
-	if not Utils.isNilOrEmpty(filepath) then
+	local filepath, success = ExternalUI.BizForms.openFilePrompt(suggestedFileName, workingDir, filterOptions)
+	if success then
 		local playtime = Tracker.Data.playtime
 		local loadStatus = Tracker.loadData(filepath, true)
 		Tracker.Data.playtime = playtime
@@ -166,8 +162,6 @@ function TrackedDataScreen.openLoadDataPrompt()
 			print("> " .. filepath)
 		end
 	end
-
-	Utils.tempEnableBizhawkSound()
 end
 
 -- USER INPUT FUNCTIONS

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -792,68 +792,61 @@ end
 function TrackerScreen.openNotePadWindow(pokemonId)
 	if not PokemonData.isValid(pokemonId) then return end
 
+	local BLANK = Constants.BLANKLINE
 	local pokemonName = PokemonData.Pokemon[pokemonId].name
-	local form = Utils.createBizhawkForm(string.format("%s (%s)", Resources.TrackerScreen.LeaveANote, pokemonName), 465, 220)
+	local form = ExternalUI.BizForms.createForm(string.format("%s (%s)", Resources.TrackerScreen.LeaveANote, pokemonName), 465, 220)
 
-	forms.label(form, string.format("%s %s:", Resources.TrackerScreen.PromptNoteDesc, pokemonName), 9, 10, 300, 20)
-	local noteTextBox = forms.textbox(form, Tracker.getNote(pokemonId), 430, 20, nil, 10, 30)
+	form:createLabel(string.format("%s %s:", Resources.TrackerScreen.PromptNoteDesc, pokemonName), 9, 10)
+	local noteTextBox = form:createTextBox(Tracker.getNote(pokemonId), 10, 30, 430, 20)
+	form:createLabel(string.format("%s %s:", Resources.TrackerScreen.PromptNoteAbilityDesc, pokemonName), 9, 60)
 
 	local abilityList = {}
-	table.insert(abilityList, Constants.BLANKLINE)
+	table.insert(abilityList, BLANK)
 	abilityList = AbilityData.populateAbilityDropdown(abilityList)
 
-	forms.label(form, string.format("%s %s:", Resources.TrackerScreen.PromptNoteAbilityDesc, pokemonName), 9, 60, 220, 20)
-	local abilityOneDropdown = forms.dropdown(form, {["Init"]="Loading Ability1"}, 10, 80, 145, 30)
-	forms.setdropdownitems(abilityOneDropdown, abilityList, true) -- true = alphabetize list
-	forms.setproperty(abilityOneDropdown, "AutoCompleteSource", "ListItems")
-	forms.setproperty(abilityOneDropdown, "AutoCompleteMode", "Append")
-	local abilityTwoDropdown = forms.dropdown(form, {["Init"]="Loading Ability2"}, 10, 110, 145, 30)
-	forms.setdropdownitems(abilityTwoDropdown, abilityList, true) -- true = alphabetize list
-	forms.setproperty(abilityTwoDropdown, "AutoCompleteSource", "ListItems")
-	forms.setproperty(abilityTwoDropdown, "AutoCompleteMode", "Append")
-
 	local trackedAbilities = Tracker.getAbilities(pokemonId)
-	local trackedAbility1 = trackedAbilities[1].id
-	local trackedAbility2 = trackedAbilities[2].id
-
-	if AbilityData.isValid(trackedAbility1) then
-		forms.settext(abilityOneDropdown, AbilityData.Abilities[trackedAbility1].name)
+	local trackedAbility1 = BLANK
+	local trackedAbility2 = BLANK
+	if AbilityData.isValid(trackedAbilities[1].id) then
+		trackedAbility1 = AbilityData.Abilities[trackedAbilities[1].id].name
 	end
-	if AbilityData.isValid(trackedAbility2) then
-		forms.settext(abilityTwoDropdown, AbilityData.Abilities[trackedAbility2].name)
+	if AbilityData.isValid(trackedAbilities[2].id) then
+		trackedAbility2 = AbilityData.Abilities[trackedAbilities[2].id].name
 	end
+	local abilityOneDropdown = form:createDropdown(abilityList, 10, 80, 145, 30, trackedAbility1)
+	local abilityTwoDropdown = form:createDropdown(abilityList, 10, 110, 145, 30, trackedAbility2)
 
 	local saveAndClose = string.format("%s && %s", Resources.AllScreens.Save, Resources.AllScreens.Close)
-	forms.button(form, saveAndClose, function()
-		local formInput = forms.gettext(noteTextBox)
+	form:createButton(saveAndClose, 80, 145, function()
+		local formInput = ExternalUI.BizForms.getText(noteTextBox)
 		if formInput ~= nil then
-			local abilityOneText = forms.gettext(abilityOneDropdown)
-			local abilityTwoText = forms.gettext(abilityTwoDropdown)
+			local abilityOneText = ExternalUI.BizForms.getText(abilityOneDropdown)
+			local abilityTwoText = ExternalUI.BizForms.getText(abilityTwoDropdown)
 			Tracker.TrackNote(pokemonId, formInput)
 			Tracker.setAbilities(pokemonId, abilityOneText, abilityTwoText)
 			Program.redraw(true)
 		end
-		Utils.closeBizhawkForm(form)
-	end, 80, 145, 105, 25)
-	forms.button(form, Resources.TrackerScreen.PromptNoteClearAbilities, function()
-		forms.settext(abilityOneDropdown, Constants.BLANKLINE)
-		forms.settext(abilityTwoDropdown, Constants.BLANKLINE)
-	end, 195, 145, 105, 25)
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 310, 145, 55, 25)
+		form:destroy()
+	end)
+	form:createButton(Resources.TrackerScreen.PromptNoteClearAbilities, 195, 145, function()
+		ExternalUI.BizForms.setText(abilityOneDropdown, BLANK)
+		ExternalUI.BizForms.setText(abilityTwoDropdown, BLANK)
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 310, 145, function()
+		form:destroy()
+	end)
 end
 
 function TrackerScreen.openEditStepGoalWindow()
-	local form = Utils.createBizhawkForm(Resources.TrackerScreen.PromptStepsTitle, 350, 170)
+	local form = ExternalUI.BizForms.createForm(Resources.TrackerScreen.PromptStepsTitle, 350, 170)
+	local currentSteps = tostring(Program.Pedometer.goalSteps or 0)
 
-	forms.label(form, Resources.TrackerScreen.PromptStepsDesc1, 36, 10, 300, 20)
-	forms.label(form, string.format("[%s]", Resources.TrackerScreen.PromptStepsDesc2), 110, 28, 300, 20)
-	forms.label(form, Resources.TrackerScreen.PromptStepsEnterGoal, 58, 50, 300, 20)
-	local textBox = forms.textbox(form, (Program.Pedometer.goalSteps or 0), 200, 30, "UNSIGNED", 60, 70)
-
-	forms.button(form, Resources.AllScreens.Save, function()
-		local formInput = forms.gettext(textBox)
+	form:createLabel(Resources.TrackerScreen.PromptStepsDesc1, 36, 10)
+	form:createLabel(string.format("[%s]", Resources.TrackerScreen.PromptStepsDesc2), 110, 28)
+	form:createLabel(Resources.TrackerScreen.PromptStepsEnterGoal, 58, 50)
+	local textBox = form:createTextBox(currentSteps, 60, 70, 200, 30, "UNSIGNED", nil, true)
+	form:createButton(Resources.AllScreens.Save, 82, 100, function()
+		local formInput = ExternalUI.BizForms.getText(textBox)
 		if not Utils.isNilOrEmpty(formInput) then
 			local newStepGoal = tonumber(formInput)
 			if newStepGoal ~= nil then
@@ -861,11 +854,11 @@ function TrackerScreen.openEditStepGoalWindow()
 				Program.redraw(true)
 			end
 		end
-		Utils.closeBizhawkForm(form)
-	end, 82, 100)
-	forms.button(form, Resources.AllScreens.Cancel, function()
-		Utils.closeBizhawkForm(form)
-	end, 167, 100)
+		form:destroy()
+	end)
+	form:createButton(Resources.AllScreens.Cancel, 167, 100, function()
+		form:destroy()
+	end)
 end
 
 function TrackerScreen.randomlyChooseBall()

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -844,7 +844,7 @@ function TrackerScreen.openEditStepGoalWindow()
 	form:createLabel(Resources.TrackerScreen.PromptStepsDesc1, 36, 10)
 	form:createLabel(string.format("[%s]", Resources.TrackerScreen.PromptStepsDesc2), 110, 28)
 	form:createLabel(Resources.TrackerScreen.PromptStepsEnterGoal, 58, 50)
-	local textBox = form:createTextBox(currentSteps, 60, 70, 200, 30, "UNSIGNED", nil, true)
+	local textBox = form:createTextBox(currentSteps, 60, 70, 200, 30, "UNSIGNED", false, true)
 	form:createButton(Resources.AllScreens.Save, 82, 100, function()
 		local formInput = ExternalUI.BizForms.getText(textBox)
 		if not Utils.isNilOrEmpty(formInput) then

--- a/ironmon_tracker/screens/UpdateScreen.lua
+++ b/ironmon_tracker/screens/UpdateScreen.lua
@@ -366,7 +366,7 @@ function UpdateScreen.performUpdate()
 	-- With the changes to parallel updates only working after a restart, if the update is successful, simply restart the Tracker scripts
 	if UpdateScreen.currentState == UpdateScreen.States.SUCCESS then
 		-- Close any open pop-up forms
-		Program.destroyActiveForm()
+		ExternalUI.closeBizhawkForm()
 		Drawing.AnimatedPokemon:destroy()
 		-- Restart the Tracker code
 		IronmonTracker.startTracker()

--- a/ironmon_tracker/screens/UpdateScreen.lua
+++ b/ironmon_tracker/screens/UpdateScreen.lua
@@ -366,7 +366,7 @@ function UpdateScreen.performUpdate()
 	-- With the changes to parallel updates only working after a restart, if the update is successful, simply restart the Tracker scripts
 	if UpdateScreen.currentState == UpdateScreen.States.SUCCESS then
 		-- Close any open pop-up forms
-		ExternalUI.closeBizhawkForm()
+		ExternalUI.BizForms.destroyForm()
 		Drawing.AnimatedPokemon:destroy()
 		-- Restart the Tracker code
 		IronmonTracker.startTracker()


### PR DESCRIPTION
This PR adds a long overdue wrapper for many of the [native Bizhawk Lua functions](https://tasvideos.org/BizHawk/LuaFunctions) for dealing with `forms`. Functionally speaking, nothing should change for the user outside of some form texts now actually being visible for non-English languages.

**The main purpose behind this was to make it easier to create and manage form popup windows**, including the individual Control elements associated with that form. The most notably change here is being able to easily apply a universal change to the creation of a given form Control, such as adding the property `"AutoSize"=true` on every Label used in all forms everywhere; great for translated text.

I did my best to document this new enhancement, update any old deprecated functions to use the new stuff, and test as many form popups as I could find on Bizhawk 2.8 and Bizhawk 2.9. Feel free to double-check me on any of these.

I'm also open to renaming the new `ExternalUI.lua` class to something shorter, if possible, since usage tends to get lengthy in some places. Note: This class has potential to be used for non-Bizhawk form things as well, as soon as we have a need for it.