### PR TITLE
Include known range for learned moves & display definitely known moves

### DIFF
--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -430,7 +430,24 @@ function Program.update()
 			-- Check if a Pokemon in the player's party is learning a move, if so track it
 			local learnedInfoTable = Program.getLearnedMoveInfoTable()
 			if learnedInfoTable.pokemonID ~= nil then
+				-- start level
 				Tracker.TrackMove(learnedInfoTable.pokemonID, learnedInfoTable.moveId, learnedInfoTable.level)
+				-- track max possible level
+				local data = DataHelper.buildPokemonInfoDisplay(learnedInfoTable.pokemonID)
+				local totalLearnableMoves = #data.p.movelvls
+				-- TODO: this works in most scenarios, but need to figure out handling 2 other things: mons that learn multiple
+				-- 		moves at the same level, and mons
+				for i, moveLvl in ipairs(data.p.movelvls) do
+					if moveLvl == learnedInfoTable.level then
+						-- Tracker.TrackMove(learnedInfoTable.pokemonID, learnedInfoTable.moveId, i)
+						if totalLearnableMoves >= i + 4 then
+							Tracker.TrackMove(learnedInfoTable.pokemonID, learnedInfoTable.moveId, data.p.movelvls[i + 4] - 1)
+						else
+							Tracker.TrackMove(learnedInfoTable.pokemonID, learnedInfoTable.moveId, 100)
+						end
+						break
+					end
+				end
 			end
 
 			if Options["Display repel usage"] and not Battle.inActiveBattle() then

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -280,6 +280,9 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 		for key, value in pairs(moveToCopy) do
 			data.m.moves[i][key] = value
 		end
+		if i > #definitelyKnownMoves then
+			data.m.moves[i].name = data.m.moves[i].name .. "*"
+		end
 
 		local move = data.m.moves[i]
 

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -245,6 +245,15 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 	end
 
 	local trackedMoves = Tracker.getMoves(viewedPokemon.pokemonID)
+	local definitelyKnownMoves = {}
+	local maybeKnownMoves = {}
+	for _, move in ipairs(trackedMoves) do
+		if move.minLv <= data.p.level and move.maxLv >= data.p.level then
+			table.insert(definitelyKnownMoves, move)
+		else
+			table.insert(maybeKnownMoves, move)
+		end
+	end
 	for i = 1, 4, 1 do
 		local moveToCopy = MoveData.BlankMove
 		if data.x.viewingOwn or useOpenBookInfo then
@@ -254,7 +263,13 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 			end
 		else
 			-- If the Pokemon doesn't belong to the player, pull move data from tracked data
-			local trackedMove = trackedMoves[i] or {}
+			local trackedMove
+			if (i <= #definitelyKnownMoves) then
+				trackedMove = definitelyKnownMoves[i]
+			else
+				-- todo: consider marking this with a bit to display asterisk next to it
+				trackedMove = maybeKnownMoves[i - #definitelyKnownMoves]
+			end
 			if MoveData.isValid(trackedMove.id) then
 				moveToCopy = MoveData.Moves[trackedMove.id]
 			end


### PR DESCRIPTION
Run the other day had an instance where gym leader had the same mon as the player. Player ended up speeding through looking at the tracked moves & forgot for a moment they were the last moves the player mon had learned, not the ones you'd see at there level.

The three main changes intended:
* When learning a move, mark the level it is learned as the low, and the last level we know it'll be had as the high (this is just from looking at the learn levels and looking 4 moves ahead)
* When inspecting an opposing mon, make sure moves that the player would know it will have are listed first -- we know it will have the move if minLv is below / equal to it and maxLv is above / equal to it, as any two of the same mon at the same level will have the same move.
* When a move is not guaranteed to be had by the given mon, mark it with an asterisk so the player knows to try and confirm more details in the move history window.

There's definitely some clean up I listed inline, just making a pr to point to as a reference for discord :)

* Handling for mons that learn 2 moves at the same level (could hack this sort of thing in but figured easier to just leave in case there was an obvious approach to it)
* just made a quick concat for the * next to 'not sure if known moves', would want to match the blue color probably
* Could be considered to be doing too much calc for the player: could either add a flag on the tracked move that it was learned on a level up / can exclude from list of moves, or recalculate from the levels, to narrow down displayed moves a bit more when you know the move isn't learned until later
* need to update move button https://github.com/besteon/Ironmon-Tracker/blob/dev/ironmon_tracker/Input.lua#L261, probably better approach is to move most of the datahelper changes to tracker.getMoves & have that take an optional parameter of level.

Couple quick screenshots of what this does after:
* catching level 3 hariyama
* leveling to 19
* returning and seeing a level 3 in grass

![image](https://github.com/besteon/Ironmon-Tracker/assets/5615930/2b20b1cc-5196-4b0c-9f20-6b81a918ff2d)
![image](https://github.com/besteon/Ironmon-Tracker/assets/5615930/80fa901c-03b4-4ced-ac61-c11d104e216a)

