### PR TITLE
8.6.2 Patch Release

### DIFF
--- a/UpdateOrInstall.lua
+++ b/UpdateOrInstall.lua
@@ -356,7 +356,9 @@ function UpdateOrInstall.buildCopyFilesCommand(extractedFolder, isOnWindows)
 			string.format('echo %s', messages.filesready),
 			string.format('cd "%s"', IronmonTracker.workingDir), -- required for mGBA on Windows
 			string.format('echo %s', messages.updating),
-			string.format('xcopy "%s" /s /y /q', extractedFolder),
+			-- /s: for subdirectories, /y: no overwrite prompts, /q: no msg display, /c: skip files with errors
+			string.format('xcopy "%s" /s /y /q /c', extractedFolder),
+			-- /s: deletes directory tree, /q: no confirmation prompts
 			string.format('rmdir "%s" /s /q', extractedFolder),
 			'echo;',
 			string.format('echo %s', messages.completed),
@@ -373,6 +375,7 @@ function UpdateOrInstall.buildCopyFilesCommand(extractedFolder, isOnWindows)
 		batchCommands = {
 			string.format('echo %s', messages.filesready),
 			string.format('echo %s', messages.updating),
+			-- -f: force, -r: recursive
 			string.format('cp -fr "%s" "%s"', extractedFolder .. UpdateOrInstall.slash .. ".", destinationFolder),
 			string.format('rm -rf "%s"', extractedFolder),
 			'echo',

--- a/ironmon_tracker/Drawing.lua
+++ b/ironmon_tracker/Drawing.lua
@@ -90,12 +90,14 @@ end
 ---@param scaleWithSpeedup boolean? [Optional] If true, will sync the counter to real time instead of the client's frame rate, ignoring speedup
 function Drawing.clearImageCache(waitFramesBeforeClearing, scaleWithSpeedup)
 	if not Main.IsOnBizhawk() then return end
-	if type(waitFramesBeforeClearing) == "number" and waitFramesBeforeClearing > 0 then
-		Program.addFrameCounter("ClearImageCache", waitFramesBeforeClearing, function()
-			gui.clearImageCache()
-		end, 1, scaleWithSpeedup)
-	else
+	local function clearCacheAndForceDraw()
 		gui.clearImageCache()
+		gui.drawPixel(Constants.SCREEN.WIDTH + Constants.SCREEN.RIGHT_GAP + 1, 1, 0x01000000)
+	end
+	if type(waitFramesBeforeClearing) == "number" and waitFramesBeforeClearing > 0 then
+		Program.addFrameCounter("ClearImageCache", waitFramesBeforeClearing, clearCacheAndForceDraw, 1, scaleWithSpeedup)
+	else
+		clearCacheAndForceDraw()
 	end
 end
 

--- a/ironmon_tracker/MGBA.lua
+++ b/ironmon_tracker/MGBA.lua
@@ -1335,6 +1335,14 @@ MGBA.CommandMap = {
 			printf(" %s", DataHelper.EventRequests.getDungeon(params))
 		end,
 	},
+	["UNFOUGHT"] = {
+		getDesc = function(self) return Resources.StreamConnect.CMD_Unfought_Help end,
+		usageSyntax = 'UNFOUGHT() | UNFOUGHT "dungeon"',
+		usageExample = 'UNFOUGHT()',
+		execute = function(self, params)
+			printf(" %s", DataHelper.EventRequests.getUnfoughtTrainers(params))
+		end,
+	},
 	["PIVOTS"] = {
 		getDesc = function(self) return Resources.StreamConnect.CMD_Pivots_Help end,
 		usageSyntax = 'PIVOTS()',
@@ -1503,6 +1511,10 @@ function installext(...) INSTALLEXT(...) end
 function DUNGEON(...) MGBA.CommandMap["DUNGEON"]:execute(...) end
 function Dungeon(...) DUNGEON(...) end
 function dungeon(...) DUNGEON(...) end
+
+function UNFOUGHT(...) MGBA.CommandMap["UNFOUGHT"]:execute(...) end
+function Unfought(...) UNFOUGHT(...) end
+function unfought(...) UNFOUGHT(...) end
 
 function PIVOTS(...) MGBA.CommandMap["PIVOTS"]:execute(...) end
 function Pivots(...) PIVOTS(...) end

--- a/ironmon_tracker/MGBADisplay.lua
+++ b/ironmon_tracker/MGBADisplay.lua
@@ -540,6 +540,7 @@ MGBADisplay.LineBuilder = {
 			MGBA.CommandMap["COVERAGE"],
 			MGBA.CommandMap["PIVOTS"],
 			MGBA.CommandMap["DUNGEON"],
+			MGBA.CommandMap["UNFOUGHT"],
 			MGBA.CommandMap["PROGRESS"],
 			MGBA.CommandMap["HEALS"],
 			MGBA.CommandMap["TMS"],

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "8", minor = "6", patch = "1" }
+Main.Version = { major = "8", minor = "6", patch = "2" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/screens/UpdateScreen.lua
+++ b/ironmon_tracker/screens/UpdateScreen.lua
@@ -318,9 +318,8 @@ function UpdateScreen.beginAutoUpdate()
 	if Main.IsOnBizhawk() then
 		-- Required to make Bizhawk release images so that they can be replaced
 		Drawing.allowCachedImages = false
-		Drawing.clearImageCache()
-		Drawing.clearImageCache(60) -- delay 1 second, then clear again
-		updateStartDelay = 60 * 2 + 2 -- delay 2 seconds, so images can uncache and unlock
+		Drawing.clearImageCache(60) -- delay 1 second
+		updateStartDelay = 60 * 5 + 2 -- delay a few seconds, so images can uncache and unlock
 	else
 		updateStartDelay = 15
 	end


### PR DESCRIPTION
_(Critical hotfix patch)_

Fixes a critical issue that is current preventing many people from updating their Tracker. No idea how this issue got introduced, happened sometime in the last 4-6 months.

This fix will resolve itself automatically for the broken Trackers when they try to update to this new version. The updater is structured in such a way to first download the new files, then load in any changes to the Update script, and use those to perform the update. In other words, they'll get the fixed file before updating over all other files.

### Release Notes
- Fixed a critical error that prevented the Tracker from self-updating in some cases
- [MGBA] Added the UNFOUGHT() command included in the previous patch
- For a full list of new features, changes and bug fixes, check out the **[Version Changelog](https://github.com/besteon/Ironmon-Tracker/wiki/Version-Changelog)**