### PR TITLE
Tracking Fix

### DIFF
--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -930,7 +930,7 @@ function Program.getLearnedMoveInfoTable()
 	local battleMsg = Memory.readdword(GameSettings.gBattlescriptCurrInstr)
 
 	-- If the battle message relates to learning a new move, read in that move id
-	if GameSettings.BattleScript_LearnMoveLoop <= battleMsg and battleMsg <= GameSettings.BattleScript_LearnMoveReturn then
+	if GameSettings.BattleScript_LearnMoveLoop <= battleMsg and battleMsg < GameSettings.BattleScript_LearnMoveReturn then
 		local moveToLearnId = Memory.readword(GameSettings.gMoveToLearn)
 
 		local battleStructAddress
@@ -944,6 +944,7 @@ function Program.getLearnedMoveInfoTable()
 		local partyIndex = Memory.readbyte(battleStructAddress + Program.Addresses.offsetPokemonGettingExp) + 1 -- Party index of player (1-6)
 		local pokemon = Tracker.getPokemon(partyIndex, true)
 		if pokemon ~= nil then
+			--Utils.printDebug("Move: %s, Battle Script: %s, Pokemon: %s, Level: %s", moveToLearnId, battleMsg, pokemon.pokemonID, pokemon.level)
 			return {
 				pokemonID = pokemon.pokemonID,
 				level = pokemon.level,


### PR DESCRIPTION
- Fixing bug where on normal level up, the last known level up move learning information was being applied to the current mon. The very last address is called for normal level ups, not just learning a move.
- Also adding a log for the future in case it errors again