### PR TITLE
8.7.2 Patch Release

### DIFF
--- a/ironmon_tracker/CustomCode.lua
+++ b/ironmon_tracker/CustomCode.lua
@@ -14,6 +14,15 @@ CustomCode = {
 	-- An ordered list of extensions (references to ExtensionLibrary list items) that are currently enabled
 	-- Only extension present in this list are "enabled" and integrated into Tracker code
 	EnabledExtensions = {},
+
+	-- Additional helper functions for use with popular custom rom hacks and extensions
+	RomHacks = {
+		-- Known compatible extensions
+		ExtensionKeys = {
+			NatDex = "NatDexExtension",
+			MoveExpansion = "MoveExpansionExtension",
+		},
+	},
 }
 
 -- Returns true if the settings option for custom code extensions is enabled; false otherwise
@@ -262,6 +271,25 @@ function CustomCode.logError(err)
 		CustomCode.KnownErrors[errorMessage] = true
 		FileManager.logError(errorMessage)
 	end
+end
+
+function CustomCode.RomHacks.isPlayingNatDex()
+	local EXT_KEY = CustomCode.RomHacks.ExtensionKeys.NatDex
+	if not TrackerAPI.isExtensionEnabled(EXT_KEY) then
+		return false
+	end
+	-- The NatDex extension has a built-in method for checking if it's being used
+	local extension = TrackerAPI.getExtensionSelf(EXT_KEY) or {}
+	return type(extension.checkIfNatDexROM) == "function" and extension:checkIfNatDexROM()
+end
+
+function CustomCode.RomHacks.isPlayingMoveExpansion()
+	local EXT_KEY = CustomCode.RomHacks.ExtensionKeys.MoveExpansion
+	if not TrackerAPI.isExtensionEnabled(EXT_KEY) then
+		return false
+	end
+	-- Have to manually check added data to determine if Move Expansion extension is in use
+	return MoveData.Moves[355] ~= nil and MoveData.Moves[356] ~= nil
 end
 
 --------------------------------------------------------------------------------------------------

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -256,6 +256,7 @@ function Input.infoShortcutPressed()
 			end
 		else
 			if TrainerInfoScreen.buildScreen(Battle.opposingTrainerId) then
+				TrainerInfoScreen.previousScreen = TrackerScreen
 				Program.changeScreenView(TrainerInfoScreen)
 			end
 		end
@@ -283,6 +284,7 @@ function Input.infoShortcutPressed()
 		end
 	else
 		if TrainersOnRouteScreen.buildScreen(TrackerAPI.getMapId()) then
+			TrainersOnRouteScreen.previousScreen = TrackerScreen
 			Program.changeScreenView(TrainersOnRouteScreen)
 		end
 	end

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -10,6 +10,8 @@ Input = {
 	resumeJoypad = false, -- Set to true to enable corresponding input on the next frame
 }
 
+Input.NO_KEY_MAPPING = "NOTBOUND"
+
 Input.OrderedControllerInputs = { "A", "B",  "Select",  "Start",  "Right",  "Left",  "Up",  "Down",  "R",  "L" }
 
 Input.StatHighlighter = {

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -175,7 +175,11 @@ function Input.checkJoypadInput()
 
 	if joypad[nextBtn] and not Input.prevJoypadInput[nextBtn] then
 		if LogOverlay.isDisplayed then
-			LogOverlay.Windower:nextPage()
+			if LogOverlay.Windower.currentTab == LogTabPokemonDetails then
+				LogTabPokemonDetails.Pager:nextPage()
+			else
+				LogOverlay.Windower:nextPage()
+			end
 		elseif StreamConnectOverlay.isDisplayed then
 			StreamConnectOverlay.Pager:nextPage()
 		elseif Program.currentScreen and Program.currentScreen.Pager and type(Program.currentScreen.Pager.nextPage) == "function" then
@@ -185,7 +189,11 @@ function Input.checkJoypadInput()
 
 	if joypad[previousBtn] and not Input.prevJoypadInput[previousBtn] then
 		if LogOverlay.isDisplayed then
-			LogOverlay.Windower:prevPage()
+			if LogOverlay.Windower.currentTab == LogTabPokemonDetails then
+				LogTabPokemonDetails.Pager:prevPage()
+			else
+				LogOverlay.Windower:prevPage()
+			end
 		elseif StreamConnectOverlay.isDisplayed then
 			StreamConnectOverlay.Pager:prevPage()
 		elseif Program.currentScreen and Program.currentScreen.Pager and type(Program.currentScreen.Pager.prevPage) == "function" then
@@ -235,12 +243,12 @@ end
 
 function Input.infoShortcutPressed()
 	-- Only open an info screen for Bizhawk if on the base tracker screen, to prevent opening while changing settings or viewing other pages
-	if not Main.IsOnBizhawk() or Program.currentScreen ~= TrackerScreen then
+	if not Main.IsOnBizhawk() or Program.currentScreen ~= TrackerScreen or Input.StatHighlighter:isActive() then
 		return
 	end
 
 	-- If in battle, lookup on the opposing Pokémon or enemy Trainer
-	if Battle.inActiveBattle() then
+	if Battle.inBattleScreen then -- Use `inBattleScreen` instead of `inActiveBattle()` for proper timing
 		if Battle.isWildEncounter then
 			local pokemon = Tracker.getPokemon(1, false) or {}
 			if PokemonData.isValid(pokemon.pokemonID) then

--- a/ironmon_tracker/Languages/English.lua
+++ b/ironmon_tracker/Languages/English.lua
@@ -636,7 +636,7 @@ ScreenResources{
 		CMD_Dungeon_Name = "Dungeon Info",
 		CMD_Dungeon_Help = "name > Displays info about which trainers have been defeated for an area.",
 		CMD_Unfought_Name = "Unfought Trainers",
-		CMD_Unfought_Help = "[dungeon] [sevii] > Displays a list of areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' to include partially completed dungeons.)",
+		CMD_Unfought_Help = "[dungeon] [no doubles] [sevii] > Lists areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' for partially completed dungeons and/or 'nodoubles' to exclude double battles.)",
 		CMD_Pivots_Name = "Pivots Seen",
 		CMD_Pivots_Help = "[safari] > Displays known early game wild encounters for an area. (Add param 'safari' for high-level encounters from Safari Zone).",
 		CMD_Revo_Name = "Pokémon Random Evolutions",

--- a/ironmon_tracker/Languages/French.lua
+++ b/ironmon_tracker/Languages/French.lua
@@ -637,7 +637,7 @@ ScreenResources{
 		CMD_Dungeon_Name = "Dungeon Info",
 		CMD_Dungeon_Help = "name > Displays info about which trainers have been defeated for an area.",
 		CMD_Unfought_Name = "Unfought Trainers",
-		CMD_Unfought_Help = "[dungeon] [sevii] > Displays a list of areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' to include partially completed dungeons.)",
+		CMD_Unfought_Help = "[dungeon] [no doubles] [sevii] > Lists areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' for partially completed dungeons and/or 'nodoubles' to exclude double battles.)",
 		CMD_Pivots_Name = "Pivots Seen",
 		CMD_Pivots_Help = "[safari] > Displays known early game wild encounters for an area. (Add param 'safari' for high-level encounters from Safari Zone).",
 		CMD_Revo_Name = "Pokémon Random Evolutions",

--- a/ironmon_tracker/Languages/German.lua
+++ b/ironmon_tracker/Languages/German.lua
@@ -637,7 +637,7 @@ ScreenResources{
 		CMD_Dungeon_Name = "Dungeon Info",
 		CMD_Dungeon_Help = "name > Displays info about which trainers have been defeated for an area.",
 		CMD_Unfought_Name = "Unfought Trainers",
-		CMD_Unfought_Help = "[dungeon] [sevii] > Displays a list of areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' to include partially completed dungeons.)",
+		CMD_Unfought_Help = "[dungeon] [no doubles] [sevii] > Lists areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' for partially completed dungeons and/or 'nodoubles' to exclude double battles.)",
 		CMD_Pivots_Name = "Pivots Seen",
 		CMD_Pivots_Help = "[safari] > Displays known early game wild encounters for an area. (Add param 'safari' for high-level encounters from Safari Zone).",
 		CMD_Revo_Name = "Pokémon Random Evolutions",

--- a/ironmon_tracker/Languages/Italian.lua
+++ b/ironmon_tracker/Languages/Italian.lua
@@ -637,7 +637,7 @@ ScreenResources{
 		CMD_Dungeon_Name = "Dungeon Info",
 		CMD_Dungeon_Help = "name > Displays info about which trainers have been defeated for an area.",
 		CMD_Unfought_Name = "Unfought Trainers",
-		CMD_Unfought_Help = "[dungeon] [sevii] > Displays a list of areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' to include partially completed dungeons.)",
+		CMD_Unfought_Help = "[dungeon] [no doubles] [sevii] > Lists areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' for partially completed dungeons and/or 'nodoubles' to exclude double battles.)",
 		CMD_Pivots_Name = "Pivots Seen",
 		CMD_Pivots_Help = "[safari] > Displays known early game wild encounters for an area. (Add param 'safari' for high-level encounters from Safari Zone).",
 		CMD_Revo_Name = "Pokémon Random Evolutions",

--- a/ironmon_tracker/Languages/Japanese.lua
+++ b/ironmon_tracker/Languages/Japanese.lua
@@ -639,7 +639,7 @@ ScreenResources{
 		CMD_Dungeon_Name = "Dungeon Info",
 		CMD_Dungeon_Help = "name > Displays info about which trainers have been defeated for an area.",
 		CMD_Unfought_Name = "Unfought Trainers",
-		CMD_Unfought_Help = "[dungeon] [sevii] > Displays a list of areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' to include partially completed dungeons.)",
+		CMD_Unfought_Help = "[dungeon] [no doubles] [sevii] > Lists areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' for partially completed dungeons and/or 'nodoubles' to exclude double battles.)",
 		CMD_Pivots_Name = "Pivots Seen",
 		CMD_Pivots_Help = "[safari] > Displays known early game wild encounters for an area. (Add param 'safari' for high-level encounters from Safari Zone).",
 		CMD_Revo_Name = "Pokémon Random Evolutions",

--- a/ironmon_tracker/Languages/Spanish.lua
+++ b/ironmon_tracker/Languages/Spanish.lua
@@ -637,7 +637,7 @@ ScreenResources{
 		CMD_Dungeon_Name = "Dungeon Info",
 		CMD_Dungeon_Help = "name > Displays info about which trainers have been defeated for an area.",
 		CMD_Unfought_Name = "Unfought Trainers",
-		CMD_Unfought_Help = "[dungeon] [sevii] > Displays a list of areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' to include partially completed dungeons.)",
+		CMD_Unfought_Help = "[dungeon] [no doubles] [sevii] > Lists areas ordered by lowest-level, undefeated trainers. (Add param 'dungeon' for partially completed dungeons and/or 'nodoubles' to exclude double battles.)",
 		CMD_Pivots_Name = "Pivots Seen",
 		CMD_Pivots_Help = "[safari] > Displays known early game wild encounters for an area. (Add param 'safari' for high-level encounters from Safari Zone).",
 		CMD_Revo_Name = "Pokémon Random Evolutions",

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "8", minor = "7", patch = "1" }
+Main.Version = { major = "8", minor = "7", patch = "2" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -52,7 +52,8 @@ Program = {
 		offsetPokemonStatsMaxHpAtk = 0x58,
 		offsetPokemonStatsDefSpe = 0x5C,
 		offsetPokemonStatsSpaSpd = 0x60,
-		offsetOptionsButtonMode = 0x13,
+		offsetRivalName = 0x3A4C, -- SaveBlock1
+		offsetOptionsButtonMode = 0x13, -- SaveBlock2
 
 		sizeofBaseStatsPokemon = 0x1C,
 		sizeofExpTablePokemon = 0x194,
@@ -856,9 +857,16 @@ function Program.readTrainerGameData(trainerId)
 	trainer.trainerClass = Utils.formatSpecialCharacters(trainer.trainerClass)
 
 	-- TRAINER NAME
+	local trainerNameAddr
+	-- Don't use the Rival's true name if playing FRLG, as that is hidden information used to calc enemy Pokémon natures
+	if GameSettings.game == 3 and TrainerData.isRival(trainerId) then
+		trainerNameAddr = Utils.getSaveBlock1Addr() + Program.Addresses.offsetRivalName
+	else
+		trainerNameAddr = startAddress + 0x04
+	end
 	trainer.trainerName = ""
 	for i = 0, Program.Addresses.sizeofTrainerName - 1, 1 do
-		local charByte = Memory.readbyte(startAddress + 0x04 + i)
+		local charByte = Memory.readbyte(trainerNameAddr + i)
 		if charByte == Program.Addresses.nicknameCharEnd then break end -- end of sequence
 		trainer.trainerName = trainer.trainerName .. (GameSettings.GameCharMap[charByte] or Constants.HIDDEN_INFO)
 	end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -1199,10 +1199,15 @@ function Program.isInStartMenu()
 end
 
 ---Forcibly change the in-game option for "Button Mode" from "HELP" to "LR"; allowing additional Tracker controls
-function Program.changeGameSettingForLR()
+---@param forced? boolean Optional, if true will force change the setting regardless of game being played or existing setting
+function Program.changeGameSettingForLR(forced)
+	-- Do not change this setting if playing NatDex, as that rom hack defaults to ButtonMode:LR
+	if not forced and CustomCode.RomHacks.isPlayingNatDex() then
+		return
+	end
 	local addr2 = Utils.getSaveBlock2Addr()
 	local currentSetting = Memory.readbyte(addr2 + Program.Addresses.offsetOptionsButtonMode)
-	if currentSetting == 0 then -- 0 is the default setting for the game
+	if forced or currentSetting == 0 then -- 0 is the default setting for the game
 		Memory.writebyte(addr2 + Program.Addresses.offsetOptionsButtonMode, Program.Values.ButtonModeLR)
 	end
 end

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -72,7 +72,8 @@ Program = {
 	},
 	Values = {
 		ShinyOdds = 8, -- n/65536
-	}
+		ButtonModeLR = 1, -- 0:NORMAL(HELP), 1:LR, 2:L_EQUALS_A; default setting for new game is 0
+	},
 }
 
 Program.GameData = {
@@ -1193,9 +1194,8 @@ end
 function Program.changeGameSettingForLR()
 	local addr2 = Utils.getSaveBlock2Addr()
 	local currentSetting = Memory.readbyte(addr2 + Program.Addresses.offsetOptionsButtonMode)
-	-- 0:NORMAL(HELP), 1:LR, 2:L_EQUALS_A
-	if currentSetting == 0 then
-		Memory.writebyte(addr2 + Program.Addresses.offsetOptionsButtonMode, 1)
+	if currentSetting == 0 then -- 0 is the default setting for the game
+		Memory.writebyte(addr2 + Program.Addresses.offsetOptionsButtonMode, Program.Values.ButtonModeLR)
 	end
 end
 

--- a/ironmon_tracker/data/EventData.lua
+++ b/ironmon_tracker/data/EventData.lua
@@ -312,6 +312,7 @@ end
 ---@return string response
 function EventData.getUnfoughtTrainers(params)
 	local allowPartialDungeons = Utils.containsText(params, "dungeon", true)
+	local excludeDoubles = Utils.containsText(params, "nodoubles", true) or Utils.containsText(params, "no doubles", true)
 	local includeSevii
 	if GameSettings.game == 3 then
 		includeSevii = Utils.containsText(params, "sevii", true)
@@ -339,7 +340,9 @@ function EventData.getUnfoughtTrainers(params)
 		if checkedIds[trainerId] or trainersToExclude[trainerId] or not TrainerData.shouldUseTrainer(trainerId) then
 			return nil
 		end
-		if Program.hasDefeatedTrainer(trainerId, saveBlock1Addr) then
+		-- Skip trainer if already beaten, or if doubles and the option to exclude doubles is specified
+		local trainerGame = Program.readTrainerGameData(trainerId)
+		if trainerGame.defeated or (excludeDoubles and trainerGame.doubleBattle) then
 			return nil
 		end
 

--- a/ironmon_tracker/data/EventData.lua
+++ b/ironmon_tracker/data/EventData.lua
@@ -1162,6 +1162,11 @@ function EventData.getHelp(params)
 		end
 		table.sort(info, function(a,b) return a < b end)
 	end
-	local prefix = string.format("%s %s", "Tracker Commands", OUTPUT_CHAR)
+	local prefix
+	if #info > 1 then
+		prefix = string.format("%s %s", "Tracker Commands", OUTPUT_CHAR)
+	else
+		prefix = string.format("%s %s", "Command:", OUTPUT_CHAR)
+	end
 	return buildResponse(prefix, info, ", ")
 end

--- a/ironmon_tracker/data/EventData.lua
+++ b/ironmon_tracker/data/EventData.lua
@@ -303,7 +303,7 @@ function EventData.getDungeon(params)
 		local trainersText = string.format("%s: %s/%s", "Trainers defeated", #defeatedTrainers, totalTrainers)
 		table.insert(info, trainersText)
 	end
-	local routeName = route.area and route.area.name or route.name
+	local routeName = RouteData.getRouteOrAreaName(routeId)
 	local prefix = string.format("%s %s", routeName, OUTPUT_CHAR)
 	return buildResponse(prefix, info)
 end
@@ -384,7 +384,7 @@ function EventData.getUnfoughtTrainers(params)
 
 		-- Add to info if route/area has unfought trainers (not all defeated)
 		if #defeatedTrainers < totalTrainers and ifDungeonAndIncluded then
-			local routeName = route.area and route.area.name or route.name
+			local routeName = RouteData.getRouteOrAreaName(routeId)
 			return string.format("%s (%s/%s)", routeName, #defeatedTrainers, totalTrainers)
 		end
 	end

--- a/ironmon_tracker/data/RouteData.lua
+++ b/ironmon_tracker/data/RouteData.lua
@@ -386,6 +386,22 @@ RouteData.BlankRoute = {
 	name = Constants.BLANKLINE,
 }
 
+---Returns the name of a route or it's combined area
+---@param mapId number
+---@param simplifiedName? boolean Optional, if true will simplify the name by removing any parentheses; default false
+---@return string
+function RouteData.getRouteOrAreaName(mapId, simplifiedName)
+	if not RouteData.hasRoute(mapId) then
+		return "Unknown Area"
+	end
+	local route = RouteData.Info[mapId]
+	local routeName = route.area and route.area.name or route.name
+	if simplifiedName then
+		routeName = Utils.replaceText(routeName, "%(.*%)", "")
+	end
+	return routeName
+end
+
 -- https://github.com/pret/pokefirered/blob/918ed2d31eeeb036230d0912cc2527b83788bc85/include/constants/layouts.h
 -- https://www.serebii.net/pokearth/kanto/3rd/route1.shtml
 function RouteData.setupRouteInfoAsFRLG()
@@ -4762,7 +4778,7 @@ function RouteData.setupRouteInfoAsRSE()
 		icon = RouteData.Icons.CaveEntrance,
 		area = RouteData.CombinedAreas.SeafloorCavern,
 		dungeon = true,
-		trainers = isGameEmerald and { 6, 7, 8, 9, 567, 33, 34 } -- All caverns combined here
+		trainers = isGameEmerald and { 6, 7, 8, 567, 33, 34 } -- All caverns combined here
 			or { 6, 7, 8, 33, 34 },
 		[RouteData.EncounterArea.LAND] = {
 			{ pokemonID = 41, rate = 0.90, },

--- a/ironmon_tracker/data/TrainerData.lua
+++ b/ironmon_tracker/data/TrainerData.lua
@@ -152,6 +152,14 @@ function TrainerData.shouldUseClassName(trainerId)
 	return false
 end
 
+---Returns true if the trainer is a possible rival (Note: you fight only 1 of 3 rivals throughout a game)
+---@param trainerId number
+---@return boolean
+function TrainerData.isRival(trainerId)
+	local trainerInternal = TrainerData.getTrainerInfo(trainerId) or {}
+	return trainerInternal.whichRival ~= nil
+end
+
 -- Determines if this trainer should be used; if it's a rival then it has to be the correct rival for the player
 function TrainerData.shouldUseTrainer(trainerId)
 	local trainerInternal = TrainerData.getTrainerInfo(trainerId) or {}

--- a/ironmon_tracker/screens/TrackerScreen.lua
+++ b/ironmon_tracker/screens/TrackerScreen.lua
@@ -747,7 +747,7 @@ function TrackerScreen.buildCarousel()
 			if RouteData.hasRouteTrainers() then
 				local routeId = TrackerAPI.getMapId()
 				local route = RouteData.Info[routeId]
-				local routeName = route.area and route.area.name or route.name
+				local routeName = RouteData.getRouteOrAreaName(routeId)
 				local defeatedTrainersList, totalInArea
 				if route.area ~= nil then
 					defeatedTrainersList, totalInArea = Program.getDefeatedTrainersByCombinedArea(route.area)

--- a/ironmon_tracker/screens/TrainerInfoScreen.lua
+++ b/ironmon_tracker/screens/TrainerInfoScreen.lua
@@ -262,7 +262,7 @@ function TrainerInfoScreen.buildScreen(trainerId)
 	end
 	trainerGame.avgIVs = math.max(math.floor(ivTotal / #trainerGame.party), 0) -- min of 0
 
-	if trainerGame.avgIVs >= 0 then
+	if trainerGame.avgIVs > 0 then
 		trainerGame.avgIVsColor = SCREEN.Colors.highlight
 	else
 		trainerGame.avgIVsColor = SCREEN.Colors.text

--- a/ironmon_tracker/screens/TrainerInfoScreen.lua
+++ b/ironmon_tracker/screens/TrainerInfoScreen.lua
@@ -249,7 +249,7 @@ function TrainerInfoScreen.buildScreen(trainerId)
 		lvRange
 	)
 	local leadPokemon = Tracker.getPokemon(1)
-	if leadPokemon and leadPokemon.level < maxLv then
+	if leadPokemon and leadPokemon.level < minLv then
 		trainerGame.partyLvColor = SCREEN.Colors.badValue
 	else
 		trainerGame.partyLvColor = SCREEN.Colors.highlight


### PR DESCRIPTION
### Release Notes
- Fixed an issue where pressing the R button to mark a stat would incorrectly show a different screen
- Fixed an issue with Nat Dex compatibility for the new LR Button Mode Tracker setting override
- [FRLG] Fixed an issue where the Rival's true name was revealed instead of the name entered by the player
- Added a way to unbind a Tracker Controller button
- The Trainers on route info screen now shows all trainers for a given dungeon/area if more than one floor.
- [Stream Connect] Can now use the parameter "nodoubles" with the !unfought command to exclude double battles
- Several minor UI improvements and internal data fixes
- For a full list of new features, changes and bug fixes, check out the **[Version Changelog](https://github.com/besteon/Ironmon-Tracker/wiki/Version-Changelog)**