### PR TITLE
New Feature: Stat marking grading score sheet

### DIFF
--- a/ironmon_tracker/FileManager.lua
+++ b/ironmon_tracker/FileManager.lua
@@ -141,6 +141,7 @@ FileManager.LuaCode = {
 	{ name = "TypeDefensesScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "TypeDefensesScreen.lua", },
 	{ name = "HealsInBagScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "HealsInBagScreen.lua", },
 	{ name = "GameOverScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "GameOverScreen.lua", },
+	{ name = "StatMarkingScoreSheet", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "StatMarkingScoreSheet.lua", },
 	{ name = "StreamerScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "StreamerScreen.lua", },
 	{ name = "TimeMachineScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "TimeMachineScreen.lua", },
 	{ name = "CustomExtensionsScreen", filepath = FileManager.Folders.ScreensCode .. FileManager.slash .. "CustomExtensionsScreen.lua", },

--- a/ironmon_tracker/Languages/English.lua
+++ b/ironmon_tracker/Languages/English.lua
@@ -527,6 +527,8 @@ ScreenResources{
 		Title = "G a m e O v e r",
 		LabelAttempt = "Attempt",
 		LabelPlayTime = "Play Time",
+		LabelNotesGrade = "Notes Grade",
+		ButtonViewGrade = "View",
 		QuoteCongratulations = "CONGRATULATIONS!!",
 		ButtonContinuePlaying = "Continue playing",
 		ButtonRetryBattle = "Retry the battle",
@@ -536,6 +538,13 @@ ScreenResources{
 		ButtonSaveFailed = "Unable to save",
 		ButtonInspectLogFile = "Inspect the log",
 		ButtonOpenLogFile = "Open a log file",
+	},
+	StatMarkingScoreSheet = {
+		Title = "Stat Marking Score Sheet",
+		LabelGreatMarks = "Great marks",
+		LabelPoorMarks = "Poor marks",
+		LabelTotal = "Total",
+		LabelPercentage = "Percentage",
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos",

--- a/ironmon_tracker/Languages/English.lua
+++ b/ironmon_tracker/Languages/English.lua
@@ -545,6 +545,7 @@ ScreenResources{
 		LabelPoorMarks = "Poor marks",
 		LabelTotal = "Total",
 		LabelPercentage = "Percentage",
+		MessageTakeNotesByMarking = "Take notes while playing by marking stats on opposing Pokémon. (The Speed stat is excluded from grading.)",
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos",

--- a/ironmon_tracker/Languages/French.lua
+++ b/ironmon_tracker/Languages/French.lua
@@ -527,6 +527,8 @@ ScreenResources{
 		Title = "G a m e O v e r", -- NEEDS TRANSLATION
 		LabelAttempt = "Attempt", -- NEEDS TRANSLATION
 		LabelPlayTime = "Play Time", -- NEEDS TRANSLATION
+		LabelNotesGrade = "Notes Grade", -- NEEDS TRANSLATION
+		ButtonViewGrade = "View", -- NEEDS TRANSLATION
 		QuoteCongratulations = "CONGRATULATIONS!!", -- NEEDS TRANSLATION
 		ButtonContinuePlaying = "Continue playing", -- NEEDS TRANSLATION
 		ButtonRetryBattle = "Retry the battle", -- NEEDS TRANSLATION
@@ -536,6 +538,13 @@ ScreenResources{
 		ButtonSaveFailed = "Unable to save", -- NEEDS TRANSLATION
 		ButtonInspectLogFile = "Inspect the log", -- NEEDS TRANSLATION
 		ButtonOpenLogFile = "Open a log file", -- NEEDS TRANSLATION
+	},
+	StatMarkingScoreSheet = {
+		Title = "Stat Marking Score Sheet", -- NEEDS TRANSLATION
+		LabelGreatMarks = "Great marks", -- NEEDS TRANSLATION
+		LabelPoorMarks = "Poor marks", -- NEEDS TRANSLATION
+		LabelTotal = "Total", -- NEEDS TRANSLATION
+		LabelPercentage = "Percentage", -- NEEDS TRANSLATION
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/French.lua
+++ b/ironmon_tracker/Languages/French.lua
@@ -545,6 +545,7 @@ ScreenResources{
 		LabelPoorMarks = "Poor marks", -- NEEDS TRANSLATION
 		LabelTotal = "Total", -- NEEDS TRANSLATION
 		LabelPercentage = "Percentage", -- NEEDS TRANSLATION
+		MessageTakeNotesByMarking = "Take notes while playing by marking stats on opposing Pokémon. (The Speed stat is excluded from grading.)", -- NEEDS TRANSLATION
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/German.lua
+++ b/ironmon_tracker/Languages/German.lua
@@ -527,6 +527,8 @@ ScreenResources{
 		Title = "G a m e O v e r", -- NEEDS TRANSLATION
 		LabelAttempt = "Attempt", -- NEEDS TRANSLATION
 		LabelPlayTime = "Play Time", -- NEEDS TRANSLATION
+		LabelNotesGrade = "Notes Grade", -- NEEDS TRANSLATION
+		ButtonViewGrade = "View", -- NEEDS TRANSLATION
 		QuoteCongratulations = "CONGRATULATIONS!!", -- NEEDS TRANSLATION
 		ButtonContinuePlaying = "Continue playing", -- NEEDS TRANSLATION
 		ButtonRetryBattle = "Retry the battle", -- NEEDS TRANSLATION
@@ -536,6 +538,13 @@ ScreenResources{
 		ButtonSaveFailed = "Unable to save", -- NEEDS TRANSLATION
 		ButtonInspectLogFile = "Inspect the log", -- NEEDS TRANSLATION
 		ButtonOpenLogFile = "Open a log file", -- NEEDS TRANSLATION
+	},
+	StatMarkingScoreSheet = {
+		Title = "Stat Marking Score Sheet", -- NEEDS TRANSLATION
+		LabelGreatMarks = "Great marks", -- NEEDS TRANSLATION
+		LabelPoorMarks = "Poor marks", -- NEEDS TRANSLATION
+		LabelTotal = "Total", -- NEEDS TRANSLATION
+		LabelPercentage = "Percentage", -- NEEDS TRANSLATION
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/German.lua
+++ b/ironmon_tracker/Languages/German.lua
@@ -545,6 +545,7 @@ ScreenResources{
 		LabelPoorMarks = "Poor marks", -- NEEDS TRANSLATION
 		LabelTotal = "Total", -- NEEDS TRANSLATION
 		LabelPercentage = "Percentage", -- NEEDS TRANSLATION
+		MessageTakeNotesByMarking = "Take notes while playing by marking stats on opposing Pokémon. (The Speed stat is excluded from grading.)", -- NEEDS TRANSLATION
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Italian.lua
+++ b/ironmon_tracker/Languages/Italian.lua
@@ -527,6 +527,8 @@ ScreenResources{
 		Title = "G a m e O v e r", -- NEEDS TRANSLATION
 		LabelAttempt = "Attempt", -- NEEDS TRANSLATION
 		LabelPlayTime = "Play Time", -- NEEDS TRANSLATION
+		LabelNotesGrade = "Notes Grade", -- NEEDS TRANSLATION
+		ButtonViewGrade = "View", -- NEEDS TRANSLATION
 		QuoteCongratulations = "CONGRATULATIONS!!", -- NEEDS TRANSLATION
 		ButtonContinuePlaying = "Continue playing", -- NEEDS TRANSLATION
 		ButtonRetryBattle = "Retry the battle", -- NEEDS TRANSLATION
@@ -536,6 +538,13 @@ ScreenResources{
 		ButtonSaveFailed = "Unable to save", -- NEEDS TRANSLATION
 		ButtonInspectLogFile = "Inspect the log", -- NEEDS TRANSLATION
 		ButtonOpenLogFile = "Open a log file", -- NEEDS TRANSLATION
+	},
+	StatMarkingScoreSheet = {
+		Title = "Stat Marking Score Sheet", -- NEEDS TRANSLATION
+		LabelGreatMarks = "Great marks", -- NEEDS TRANSLATION
+		LabelPoorMarks = "Poor marks", -- NEEDS TRANSLATION
+		LabelTotal = "Total", -- NEEDS TRANSLATION
+		LabelPercentage = "Percentage", -- NEEDS TRANSLATION
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Italian.lua
+++ b/ironmon_tracker/Languages/Italian.lua
@@ -545,6 +545,7 @@ ScreenResources{
 		LabelPoorMarks = "Poor marks", -- NEEDS TRANSLATION
 		LabelTotal = "Total", -- NEEDS TRANSLATION
 		LabelPercentage = "Percentage", -- NEEDS TRANSLATION
+		MessageTakeNotesByMarking = "Take notes while playing by marking stats on opposing Pokémon. (The Speed stat is excluded from grading.)", -- NEEDS TRANSLATION
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Japanese.lua
+++ b/ironmon_tracker/Languages/Japanese.lua
@@ -547,6 +547,7 @@ ScreenResources{
 		LabelPoorMarks = "Poor marks", -- NEEDS TRANSLATION
 		LabelTotal = "Total", -- NEEDS TRANSLATION
 		LabelPercentage = "Percentage", -- NEEDS TRANSLATION
+		MessageTakeNotesByMarking = "Take notes while playing by marking stats on opposing Pokémon. (The Speed stat is excluded from grading.)", -- NEEDS TRANSLATION
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Japanese.lua
+++ b/ironmon_tracker/Languages/Japanese.lua
@@ -529,6 +529,8 @@ ScreenResources{
 		Title = "G a m e O v e r", -- NEEDS TRANSLATION
 		LabelAttempt = "Attempt", -- NEEDS TRANSLATION
 		LabelPlayTime = "Play Time", -- NEEDS TRANSLATION
+		LabelNotesGrade = "Notes Grade", -- NEEDS TRANSLATION
+		ButtonViewGrade = "View", -- NEEDS TRANSLATION
 		QuoteCongratulations = "CONGRATULATIONS!!", -- NEEDS TRANSLATION
 		ButtonContinuePlaying = "Continue playing", -- NEEDS TRANSLATION
 		ButtonRetryBattle = "Retry the battle", -- NEEDS TRANSLATION
@@ -538,6 +540,13 @@ ScreenResources{
 		ButtonSaveFailed = "Unable to save", -- NEEDS TRANSLATION
 		ButtonInspectLogFile = "Inspect the log", -- NEEDS TRANSLATION
 		ButtonOpenLogFile = "Open a log file", -- NEEDS TRANSLATION
+	},
+	StatMarkingScoreSheet = {
+		Title = "Stat Marking Score Sheet", -- NEEDS TRANSLATION
+		LabelGreatMarks = "Great marks", -- NEEDS TRANSLATION
+		LabelPoorMarks = "Poor marks", -- NEEDS TRANSLATION
+		LabelTotal = "Total", -- NEEDS TRANSLATION
+		LabelPercentage = "Percentage", -- NEEDS TRANSLATION
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Spanish.lua
+++ b/ironmon_tracker/Languages/Spanish.lua
@@ -527,6 +527,8 @@ ScreenResources{
 		Title = "G a m e O v e r", -- NEEDS TRANSLATION
 		LabelAttempt = "Attempt", -- NEEDS TRANSLATION
 		LabelPlayTime = "Play Time", -- NEEDS TRANSLATION
+		LabelNotesGrade = "Notes Grade", -- NEEDS TRANSLATION
+		ButtonViewGrade = "View", -- NEEDS TRANSLATION
 		QuoteCongratulations = "CONGRATULATIONS!!", -- NEEDS TRANSLATION
 		ButtonContinuePlaying = "Continue playing", -- NEEDS TRANSLATION
 		ButtonRetryBattle = "Retry the battle", -- NEEDS TRANSLATION
@@ -536,6 +538,13 @@ ScreenResources{
 		ButtonSaveFailed = "Unable to save", -- NEEDS TRANSLATION
 		ButtonInspectLogFile = "Inspect the log", -- NEEDS TRANSLATION
 		ButtonOpenLogFile = "Open a log file", -- NEEDS TRANSLATION
+	},
+	StatMarkingScoreSheet = {
+		Title = "Stat Marking Score Sheet", -- NEEDS TRANSLATION
+		LabelGreatMarks = "Great marks", -- NEEDS TRANSLATION
+		LabelPoorMarks = "Poor marks", -- NEEDS TRANSLATION
+		LabelTotal = "Total", -- NEEDS TRANSLATION
+		LabelPercentage = "Percentage", -- NEEDS TRANSLATION
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Spanish.lua
+++ b/ironmon_tracker/Languages/Spanish.lua
@@ -545,6 +545,7 @@ ScreenResources{
 		LabelPoorMarks = "Poor marks", -- NEEDS TRANSLATION
 		LabelTotal = "Total", -- NEEDS TRANSLATION
 		LabelPercentage = "Percentage", -- NEEDS TRANSLATION
+		MessageTakeNotesByMarking = "Take notes while playing by marking stats on opposing Pokémon. (The Speed stat is excluded from grading.)", -- NEEDS TRANSLATION
 	},
 	RandomEvosScreen = {
 		LabelRandomEvos = "Random Evos", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -141,6 +141,8 @@ function Utils.formatTime(numSeconds)
 end
 
 -- Returns an offset that will center-align the given text based on a specified area's width
+---@param text string
+---@param areaWidth? number Optional, defaults to the full width of the Tracker Screen
 function Utils.getCenteredTextX(text, areaWidth)
 	areaWidth = areaWidth or Constants.SCREEN.RIGHT_GAP
 	local textSize = Utils.calcWordPixelLength(text or "")

--- a/ironmon_tracker/data/AbilityData.lua
+++ b/ironmon_tracker/data/AbilityData.lua
@@ -1,6 +1,10 @@
 AbilityData = {}
 
 AbilityData.Values = {
+	HugePowerId = 37,
+	ThickFatId = 47,
+	HustleId = 55,
+	PurePowerId = 74,
 	CacophonyId = 76,
 }
 
@@ -269,7 +273,6 @@ AbilityData.Abilities = {
 	{
 		id = 53,
 		name = "Pickup",
-
 	},
 	{
 		id = 54,

--- a/ironmon_tracker/data/PokemonData.lua
+++ b/ironmon_tracker/data/PokemonData.lua
@@ -228,7 +228,7 @@ function PokemonData.buildData(forced)
 			local baseHPAttack = Memory.readword(addrOffset + PokemonData.Addresses.offsetBaseStats)
 			local baseDefenseSpeed = Memory.readword(addrOffset + PokemonData.Addresses.offsetBaseStats + 2)
 			local baseSpASpD = Memory.readword(addrOffset + PokemonData.Addresses.offsetBaseStats + 4)
-			local baseStats = {
+			pokemon.baseStats = {
 				hp = Utils.getbits(baseHPAttack, 0, 8),
 				atk = Utils.getbits(baseHPAttack, 8, 8),
 				def = Utils.getbits(baseDefenseSpeed, 0, 8),
@@ -237,12 +237,8 @@ function PokemonData.buildData(forced)
 				spd = Utils.getbits(baseSpASpD, 8, 8)
 			}
 			pokemon.bstCalculated = 0
-			for _, baseStat in pairs(baseStats) do
+			for _, baseStat in pairs(pokemon.baseStats) do
 				pokemon.bstCalculated = pokemon.bstCalculated + baseStat
-			end
-			-- For now, only bother storing this info if Open Book mode is on
-			if Options["Open Book Play Mode"] then
-				pokemon.baseStats = baseStats
 			end
 
 			-- Types (2 bytes)
@@ -311,13 +307,15 @@ function PokemonData.getTypeResource(typename)
 	return Resources.Game.PokemonTypes[typename] or Resources.Game.PokemonTypes.unknown
 end
 
---- @return integer abilityId The abilityId of the Pokémon, or 0 if it doesn't exist
-function PokemonData.getAbilityId(pokemonID, abilityNum)
-	if abilityNum == nil or not PokemonData.isValid(pokemonID) then
+---@param pokemonID number
+---@param abilityIndex number Specify 0 for the first ability or 1 for the second ability
+---@return integer abilityId The abilityId of the Pokémon, or 0 if it doesn't exist
+function PokemonData.getAbilityId(pokemonID, abilityIndex)
+	if abilityIndex == nil or not PokemonData.isValid(pokemonID) then
 		return 0
 	end
 	local pokemon = PokemonData.Pokemon[pokemonID]
-	return pokemon.abilities[abilityNum + 1] or 0 -- abilityNum stored from memory as [0 or 1]
+	return pokemon.abilities[abilityIndex + 1] or 0 -- abilityNum stored from memory as [0 or 1]
 end
 
 ---Returns true if the pokemonId is a valid, existing id of a pokemon in PokemonData.Pokemon

--- a/ironmon_tracker/screens/GameOverScreen.lua
+++ b/ironmon_tracker/screens/GameOverScreen.lua
@@ -31,11 +31,22 @@ GameOverScreen.Buttons = {
 			Program.redraw(true)
 		end,
 	},
+	ViewNoteScoreSheet = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		getText = function(self) return string.format("(%s)", Resources.GameOverScreen.ButtonViewGrade) end,
+		textColor = "Intermediate text",
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 57, Constants.SCREEN.MARGIN + 35, 25, 10 },
+		onClick = function (self)
+			StatMarkingScoreSheet.previousScreen = GameOverScreen
+			StatMarkingScoreSheet.buildScreen()
+			Program.changeScreenView(StatMarkingScoreSheet)
+		end,
+	},
 	ContinuePlaying = {
 		type = Constants.ButtonTypes.ICON_BORDER,
 		image = Constants.PixelImages.RIGHT_ARROW,
 		getText = function(self) return Resources.GameOverScreen.ButtonContinuePlaying end,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 14, Constants.SCREEN.MARGIN + 66, 112, 16 },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 14, Constants.SCREEN.MARGIN + 74, 112, 16 },
 		onClick = function(self)
 			GameOverScreen.status = GameOverScreen.Statuses.STILL_PLAYING
 			LogOverlay.isGameOver = false
@@ -57,7 +68,7 @@ GameOverScreen.Buttons = {
 			end
 		end,
 		confirmAction = false,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 14, Constants.SCREEN.MARGIN + 87, 112, 16 },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 14, Constants.SCREEN.MARGIN + 93, 112, 16 },
 		isVisible = function(self) return Main.IsOnBizhawk() and GameOverScreen.battleStartSaveState ~= nil and GameOverScreen.status ~= GameOverScreen.Statuses.WON end,
 		updateSelf = function(self)
 			self.textColor = "Lower box text"
@@ -93,7 +104,7 @@ GameOverScreen.Buttons = {
 			end
 		end,
 		clickedStatus = "Not Clicked", -- checked later when clicked
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 14, Constants.SCREEN.MARGIN + 108, 112, 16 },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 14, Constants.SCREEN.MARGIN + 112, 112, 16 },
 		-- Only visible if the player is using the Tracker's Quickload feature
 		isVisible = function(self) return Options["Use premade ROMs"] or Options["Generate ROM each time"] end,
 		reset = function(self)
@@ -123,7 +134,7 @@ GameOverScreen.Buttons = {
 				return Resources.GameOverScreen.ButtonOpenLogFile
 			end
 		end,
-		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 14, Constants.SCREEN.MARGIN + 129, 112, 16 },
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 14, Constants.SCREEN.MARGIN + 131, 112, 16 },
 		isVisible = function(self) return true end,
 		onClick = function(self)
 			LogOverlay.viewLogFile(FileManager.PostFixes.AUTORANDOMIZED)
@@ -138,9 +149,14 @@ function GameOverScreen.initialize()
 	GameOverScreen.status = GameOverScreen.Statuses.STILL_PLAYING
 
 	for _, button in pairs(GameOverScreen.Buttons) do
-		button.textColor = "Lower box text"
-		button.boxColors = { "Lower box border", "Lower box background" }
+		if button.textColor == nil then
+			button.textColor = "Lower box text"
+		end
+		if button.boxColors == nil then
+			button.boxColors = { "Lower box border", "Lower box background" }
+		end
 	end
+
 	GameOverScreen.refreshButtons()
 	GameOverScreen.Buttons.SaveGameFiles:reset()
 end
@@ -329,7 +345,7 @@ function GameOverScreen.drawScreen()
 		x = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN,
 		y = Constants.SCREEN.MARGIN,
 		width = Constants.SCREEN.RIGHT_GAP - (Constants.SCREEN.MARGIN * 2),
-		height = 56,
+		height = 71,
 		text = Theme.COLORS["Default text"],
 		border = Theme.COLORS["Upper box border"],
 		fill = Theme.COLORS["Upper box background"],
@@ -337,9 +353,9 @@ function GameOverScreen.drawScreen()
 	}
 	local botBox = {
 		x = topBox.x,
-		y = topBox.y + topBox.height + 5,
+		y = topBox.y + topBox.height,
 		width = topBox.width,
-		height = Constants.SCREEN.HEIGHT - topBox.height - 15,
+		height = Constants.SCREEN.HEIGHT - topBox.height - 10,
 		text = Theme.COLORS["Lower box text"],
 		border = Theme.COLORS["Lower box border"],
 		fill = Theme.COLORS["Lower box background"],
@@ -359,12 +375,12 @@ function GameOverScreen.drawScreen()
 	textLineY = textLineY + Constants.SCREEN.LINESPACING
 
 	-- Draw some game stats
-	local columnOffsetX = 54
+	local columnOffsetX = 57
 	if Main.currentSeed and Main.currentSeed ~= 1 then
 		Drawing.drawText(topBox.x + 2, textLineY, Resources.GameOverScreen.LabelAttempt .. ":", topBox.text, topBox.shadow)
 		Drawing.drawText(topBox.x + columnOffsetX, textLineY, Utils.formatNumberWithCommas(Main.currentSeed), topBox.text, topBox.shadow)
 	end
-	textLineY = textLineY + Constants.SCREEN.LINESPACING - 1
+	textLineY = textLineY + Constants.SCREEN.LINESPACING
 
 	if Tracker.Data.playtime and Tracker.Data.playtime > 0 then
 		Drawing.drawText(topBox.x + 2, textLineY, Resources.GameOverScreen.LabelPlayTime .. ":", topBox.text, topBox.shadow)
@@ -372,26 +388,24 @@ function GameOverScreen.drawScreen()
 	end
 	textLineY = textLineY + Constants.SCREEN.LINESPACING
 
+	-- TODO: Language
+	Drawing.drawText(topBox.x + 2, textLineY, Resources.GameOverScreen.LabelNotesGrade .. ":", topBox.text, topBox.shadow)
+	textLineY = textLineY + Constants.SCREEN.LINESPACING + 2
+
 	-- Draw the game winning message or a random Pokémon Stadium announcer quote
+	local msgToDisplay
 	if GameOverScreen.status == GameOverScreen.Statuses.WON then
-		local wrappedQuotes = Utils.getWordWrapLines(Resources.GameOverScreen.QuoteCongratulations, 30)
-		local firstTwoLines = { wrappedQuotes[1], wrappedQuotes[2] }
-		textLineY = textLineY + 5 * (2 - #firstTwoLines)
-		for _, line in pairs(firstTwoLines) do
-			local centerOffsetX = math.floor(topBox.width / 2 - Utils.calcWordPixelLength(line) / 2) - 1
-			Drawing.drawText(topBox.x + centerOffsetX, textLineY, line, topBox.text, topBox.shadow)
-			textLineY = textLineY + Constants.SCREEN.LINESPACING - 1
-		end
+		msgToDisplay = Resources.GameOverScreen.QuoteCongratulations
 	else
-		local announcerQuote = Resources.GameOverScreenQuotes[GameOverScreen.chosenQuoteIndex] or ""
-		local wrappedQuotes = Utils.getWordWrapLines(announcerQuote, 30)
-		local firstTwoLines = { wrappedQuotes[1], wrappedQuotes[2] }
-		textLineY = textLineY + 5 * (2 - #firstTwoLines)
-		for _, line in pairs(firstTwoLines) do
-			local centerOffsetX = math.floor(topBox.width / 2 - Utils.calcWordPixelLength(line) / 2) - 1
-			Drawing.drawText(topBox.x + centerOffsetX, textLineY, line, topBox.text, topBox.shadow)
-			textLineY = textLineY + Constants.SCREEN.LINESPACING - 1
-		end
+		msgToDisplay = Resources.GameOverScreenQuotes[GameOverScreen.chosenQuoteIndex] or ""
+	end
+	local wrappedQuotes = Utils.getWordWrapLines("This is a battle between obviously mismatched Pokémon." or msgToDisplay, 30)
+	local firstTwoLines = { wrappedQuotes[1], wrappedQuotes[2] }
+	textLineY = textLineY + 5 * (2 - #firstTwoLines)
+	for _, line in pairs(firstTwoLines) do
+		local centerOffsetX = math.floor(topBox.width / 2 - Utils.calcWordPixelLength(line) / 2) - 1
+		Drawing.drawText(topBox.x + centerOffsetX, textLineY, line, topBox.text, topBox.shadow)
+		textLineY = textLineY + Constants.SCREEN.LINESPACING - 1
 	end
 
 	-- Draw bottom border box

--- a/ironmon_tracker/screens/GameOverScreen.lua
+++ b/ironmon_tracker/screens/GameOverScreen.lua
@@ -390,7 +390,6 @@ function GameOverScreen.drawScreen()
 	end
 	textLineY = textLineY + Constants.SCREEN.LINESPACING
 
-	-- TODO: Language
 	Drawing.drawText(topBox.x + 2, textLineY, Resources.GameOverScreen.LabelNotesGrade .. ":", topBox.text, topBox.shadow)
 	textLineY = textLineY + Constants.SCREEN.LINESPACING + 2
 
@@ -401,7 +400,7 @@ function GameOverScreen.drawScreen()
 	else
 		msgToDisplay = Resources.GameOverScreenQuotes[GameOverScreen.chosenQuoteIndex] or ""
 	end
-	local wrappedQuotes = Utils.getWordWrapLines("This is a battle between obviously mismatched Pokémon." or msgToDisplay, 30)
+	local wrappedQuotes = Utils.getWordWrapLines(msgToDisplay, 30)
 	local firstTwoLines = { wrappedQuotes[1], wrappedQuotes[2] }
 	textLineY = textLineY + 5 * (2 - #firstTwoLines)
 	for _, line in pairs(firstTwoLines) do

--- a/ironmon_tracker/screens/GameOverScreen.lua
+++ b/ironmon_tracker/screens/GameOverScreen.lua
@@ -36,6 +36,8 @@ GameOverScreen.Buttons = {
 		getText = function(self) return string.format("(%s)", Resources.GameOverScreen.ButtonViewGrade) end,
 		textColor = "Intermediate text",
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 57, Constants.SCREEN.MARGIN + 35, 25, 10 },
+		boxColors = { "Upper box border", "Upper box background" },
+		location = "top",
 		onClick = function (self)
 			StatMarkingScoreSheet.previousScreen = GameOverScreen
 			StatMarkingScoreSheet.buildScreen()
@@ -415,7 +417,11 @@ function GameOverScreen.drawScreen()
 	-- Draw all other buttons
 	for _, button in pairs(GameOverScreen.Buttons) do
 		if button ~= GameOverScreen.Buttons.PokemonIcon then
-			Drawing.drawButton(button, botBox.shadow)
+			if button.location == "top" then
+				Drawing.drawButton(button, topBox.shadow)
+			else
+				Drawing.drawButton(button, botBox.shadow)
+			end
 		end
 	end
 end

--- a/ironmon_tracker/screens/StatMarkingScoreSheet.lua
+++ b/ironmon_tracker/screens/StatMarkingScoreSheet.lua
@@ -1,0 +1,477 @@
+StatMarkingScoreSheet = {
+	Colors = {
+		text = "Default text",
+		highlight = "Intermediate text",
+		positive = "Positive text",
+		negative = "Negative text",
+		border = "Upper box border",
+		boxFill = "Upper box background",
+	},
+	Data = {},
+}
+local SCREEN = StatMarkingScoreSheet
+
+SCREEN.StatMarkingRanges = {
+	MarginOfError = 25,
+	[Constants.STAT_STATES[1].text] = { min = 115, max = 255, }, -- [+] positive
+	[Constants.STAT_STATES[2].text] = { min = 11, max = 70, }, -- [-] negative
+	[Constants.STAT_STATES[3].text] = { min = 70, max = 115, }, -- [=] equal
+}
+
+SCREEN.PixelImages = {
+	SMALL_X = {
+		{1,0,0,0,1},
+		{0,1,0,1,0},
+		{0,0,1,0,0},
+		{0,1,0,1,0},
+		{1,0,0,0,1},
+	},
+	SMALL_CHECK = {
+		{0,0,0,0,1},
+		{0,0,0,1,0},
+		{1,0,1,0,0},
+		{0,1,0,0,0},
+		{0,0,0,0,0},
+	},
+}
+
+local SUMMARY_COL2_X = 53
+local GRIDROW = {
+	X = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 1,
+	Y = Constants.SCREEN.MARGIN + 68,
+	W = Constants.SCREEN.RIGHT_GAP - Constants.SCREEN.MARGIN * 2 - 2,
+	H = 32,
+	COLS_X = { 1, 35, 56, 77, 98, 119 }
+}
+
+local STATS_ORDERED = { "hp", "atk", "def", "spa", "spd" } -- speed is excluded due to notetaking
+
+SCREEN.Pager = {
+	Buttons = {},
+	currentPage = 0,
+	totalPages = 0,
+	defaultSort = function(a, b) return a.score < b.score or (a.score == b.score and a.index < b.index) end, -- Order by least accurate score first
+	realignButtonsToGrid = function(self, x, y, colSpacer, rowSpacer, sortFunc)
+		table.sort(self.Buttons, sortFunc or self.defaultSort)
+		local cutoffX = Constants.SCREEN.WIDTH + Constants.SCREEN.RIGHT_GAP + 1
+		local cutoffY = Constants.SCREEN.HEIGHT - 20
+		local totalPages = Utils.gridAlign(self.Buttons, x, y, colSpacer, rowSpacer, true, cutoffX, cutoffY)
+		self.currentPage = 1
+		self.totalPages = totalPages or 1
+		-- Snap each individual button to their respective button rows
+		for _, buttonRow in ipairs(self.Buttons) do
+			for _, button in ipairs (buttonRow.buttonList or {}) do
+				if type(button.alignToBox) == "function" then
+					button:alignToBox(buttonRow.box)
+				end
+			end
+		end
+	end,
+	getPageText = function(self)
+		if self.totalPages <= 1 then return Resources.AllScreens.Page end
+		local text = string.format("%s/%s", self.currentPage, self.totalPages)
+		local bufferSize = 7 - text:len()
+		return string.rep(" ", bufferSize) .. text
+	end,
+	prevPage = function(self)
+		if self.totalPages <= 1 then return end
+		self.currentPage = ((self.currentPage - 2 + self.totalPages) % self.totalPages) + 1
+		Program.redraw(true)
+	end,
+	nextPage = function(self)
+		if self.totalPages <= 1 then return end
+		self.currentPage = (self.currentPage % self.totalPages) + 1
+		Program.redraw(true)
+	end,
+}
+
+SCREEN.Buttons = {
+	-- TODO:
+	-- giant letter stamp: (B+) use highlight color
+	LabelGreat = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		getText = function(self) return string.format("%s:", Resources.StatMarkingScoreSheet.LabelGreatMarks) end,
+		box = {	Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 1, Constants.SCREEN.MARGIN + 11, 8, 8 },
+		draw = function(self, shadowcolor)
+			local x, y = self.box[1], self.box[2]
+			local value = SCREEN.Data.greatMarkings or Constants.BLANKLINE
+			local color = Theme.COLORS[SCREEN.Colors.positive]
+			Drawing.drawRightJustifiedNumber(x + SUMMARY_COL2_X, y, value, 4, color, shadowcolor)
+			Drawing.drawImageAsPixels(SCREEN.PixelImages.SMALL_CHECK, x + SUMMARY_COL2_X + 25, y + 4, color, shadowcolor)
+		end,
+	},
+	LabelPoor = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		getText = function(self) return string.format("%s:", Resources.StatMarkingScoreSheet.LabelPoorMarks) end,
+		box = {	Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 1, Constants.SCREEN.MARGIN + 22, 8, 8 },
+		draw = function(self, shadowcolor)
+			local x, y = self.box[1], self.box[2]
+			local value = SCREEN.Data.poorMarkings or Constants.BLANKLINE
+			local color = Theme.COLORS[SCREEN.Colors.negative]
+			Drawing.drawRightJustifiedNumber(x + SUMMARY_COL2_X, y, value, 4, color, shadowcolor)
+			Drawing.drawImageAsPixels(SCREEN.PixelImages.SMALL_X, x + SUMMARY_COL2_X + 25, y + 3, color, shadowcolor)
+		end,
+	},
+	LabelTotalNotes = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		getText = function(self) return string.format("%s:", Resources.StatMarkingScoreSheet.LabelTotal) end,
+		box = {	Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 1, Constants.SCREEN.MARGIN + 33, 8, 8 },
+		draw = function(self, shadowcolor)
+			local x, y = self.box[1], self.box[2]
+			local value = SCREEN.Data.totalMarkings or Constants.BLANKLINE
+			Drawing.drawRightJustifiedNumber(x + SUMMARY_COL2_X, y, value, 4, Theme.COLORS[SCREEN.Colors.text], shadowcolor)
+		end,
+	},
+	LabelGradeScore = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		getText = function(self) return string.format("%s:", Resources.StatMarkingScoreSheet.LabelPercentage) end,
+		box = {	Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 1, Constants.SCREEN.MARGIN + 44, 8, 8 },
+		draw = function(self, shadowcolor)
+			local x, y = self.box[1], self.box[2]
+			local value = SCREEN.Data.percentageScore or Constants.BLANKLINE
+			local color = Theme.COLORS[SCREEN.Colors.text]
+			local rightAlignX = 19 - Utils.calcWordPixelLength(value)
+			Drawing.drawText(x + SUMMARY_COL2_X + rightAlignX, y, value, color, shadowcolor)
+			Drawing.drawText(x + SUMMARY_COL2_X + 22, y, "%", color, shadowcolor)
+		end,
+	},
+
+	CurrentPage = {
+		type = Constants.ButtonTypes.NO_BORDER,
+		getText = function(self) return SCREEN.Pager:getPageText() end,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 54, Constants.SCREEN.MARGIN + 135, 50, 10, },
+		isVisible = function() return SCREEN.Pager.totalPages > 1 end,
+	},
+	PrevPage = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = Constants.PixelImages.LEFT_ARROW,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 42, Constants.SCREEN.MARGIN + 136, 10, 10, },
+		isVisible = function() return SCREEN.Pager.totalPages > 1 end,
+		onClick = function(self)
+			SCREEN.Pager:prevPage()
+		end
+	},
+	NextPage = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = Constants.PixelImages.RIGHT_ARROW,
+		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 96, Constants.SCREEN.MARGIN + 136, 10, 10, },
+		isVisible = function() return SCREEN.Pager.totalPages > 1 end,
+		onClick = function(self)
+			SCREEN.Pager:nextPage()
+		end
+	},
+	Back = Drawing.createUIElementBackButton(function()
+		Program.changeScreenView(SCREEN.previousScreen or TrackerScreen)
+		SCREEN.previousScreen = nil
+	end),
+}
+
+function StatMarkingScoreSheet.initialize()
+	StatMarkingScoreSheet.createHeader()
+
+	for _, button in pairs(SCREEN.Buttons) do
+		if button.textColor == nil then
+			button.textColor = SCREEN.Colors.text
+		end
+		if button.boxColors == nil then
+			button.boxColors = { SCREEN.Colors.border, SCREEN.Colors.boxFill }
+		end
+	end
+
+	SCREEN.clearBuiltData()
+	SCREEN.refreshButtons()
+end
+
+function StatMarkingScoreSheet.createHeader()
+	SCREEN.NavButtons = {}
+
+	for i, statKey in ipairs(STATS_ORDERED) do
+		local statText = Utils.toUpperUTF8(statKey)
+		SCREEN.NavButtons[statKey] = {
+			type = Constants.ButtonTypes.NO_BORDER,
+			textColor = SCREEN.Colors.text,
+			box = { GRIDROW.X + GRIDROW.COLS_X[i + 1], GRIDROW.Y - Constants.SCREEN.LINESPACING - 3, 20, 11 },
+			draw = function(self, shadowcolor)
+				local x, y = self.box[1], self.box[2]
+				local textColor = Theme.COLORS[self.textColor]
+				local bgColor = Theme.COLORS[SCREEN.Colors.boxFill]
+				local centerOffset = Utils.getCenteredTextX(statText, 21) - 2
+				Drawing.drawTransparentTextbox(x + centerOffset, y + 2, statText, textColor, bgColor, shadowcolor)
+			end,
+		}
+	end
+end
+
+---Retrieves and builds the data needed to draw this screen; stored in `StatMarkingScoreSheet.Data`
+function StatMarkingScoreSheet.buildScreen()
+	SCREEN.clearBuiltData()
+
+	SCREEN.Data.greatMarkings = 0
+	SCREEN.Data.poorMarkings = 0
+	SCREEN.Data.totalMarkings = 0
+	SCREEN.Data.gradeLetter = -1 -- TODO: perhaps use pixel art
+
+	-- Add to list all pokemon with tracked stat markings
+	SCREEN.Data.pokemon = {}
+	for id, trackedPokemon in pairs(Tracker.Data.allPokemon or {}) do
+		-- Only review pokemon who have at least 1 stat marking
+		if trackedPokemon.sm then
+			local nonSpeedMarked = false
+			for _, statKey in ipairs(STATS_ORDERED) do
+				if (trackedPokemon.sm[statKey] or 0) > 0 then
+					nonSpeedMarked = true
+					break
+				end
+			end
+			if nonSpeedMarked then
+				-- Certain abilities modify how impactful the stats can be
+				local firstAbilityId = PokemonData.getAbilityId(id, 0)
+				local pokemonInfo = {
+					id = id,
+					abilityId = firstAbilityId,
+					statMarkings = trackedPokemon.sm,
+				}
+				table.insert(SCREEN.Data.pokemon, pokemonInfo)
+			end
+		end
+	end
+
+	for _, pokemonInfo in ipairs(SCREEN.Data.pokemon) do
+		local pokemonInternal = PokemonData.Pokemon[pokemonInfo.id] or PokemonData.BlankPokemon
+
+		local buttonRow = {
+			type = Constants.ButtonTypes.NO_BORDER,
+			buttonList = {},
+			pokemon = pokemonInfo,
+			index = pokemonInfo.id, -- Used for sorting after a filter is selected
+			dimensions = { width = GRIDROW.W, height = GRIDROW.H, },
+			isVisible = function(self) return SCREEN.Pager.currentPage == self.pageVisible end,
+			includeInGrid = function(self)
+				return true
+			end,
+			onClick = function(self)
+				if NotebookPokemonNoteView.buildScreen(pokemonInfo.id) then
+					NotebookPokemonNoteView.previousScreen = SCREEN
+					Program.changeScreenView(NotebookPokemonNoteView)
+				end
+			end,
+			draw = function(self, shadowcolor)
+				local x, y, w, h = self.box[1], self.box[2], self.box[3], self.box[4]
+				local borderColor = Theme.COLORS[SCREEN.Colors.border]
+				-- Surround the row with a border
+				gui.drawRectangle(x - 1, y - 1, GRIDROW.W + 2, GRIDROW.H, borderColor)
+				-- Draw vertical dotted lines
+				for i, colX in ipairs(GRIDROW.COLS_X) do
+					if i ~= 1 then -- skip the left-most vertical divider line
+						for offsetY = 1, GRIDROW.H - 1, 2 do
+							gui.drawPixel(x + colX - 1, y + offsetY, borderColor)
+						end
+					end
+				end
+				-- Draw horizontal dotted lines
+				for offsetX = GRIDROW.COLS_X[2] + 1, GRIDROW.W, 2 do
+					gui.drawPixel(x + offsetX, y + 15, borderColor)
+				end
+				for _, button in ipairs(self.buttonList or {}) do
+					Drawing.drawButton(button, shadowcolor)
+				end
+			end,
+		}
+		table.insert(SCREEN.Pager.Buttons, buttonRow)
+
+		-- POKEMON ICON
+		local iconBtn = {
+			type = Constants.ButtonTypes.POKEMON_ICON,
+			getIconId = function(self) return pokemonInfo.id end,
+			isVisible = function(self) return buttonRow:isVisible() end,
+			box = { -1, -1, GRIDROW.H, GRIDROW.H },
+			alignToBox = function(self, box)
+				self.box[1] = box[1] + GRIDROW.COLS_X[1]
+				self.box[2] = box[2] - 4
+			end,
+		}
+		table.insert(buttonRow.buttonList, iconBtn)
+
+		-- POKEMON BASE STATS AND MARKINGS
+		local gradeScore = 0 -- +1 for correct markings, -10 for incorrect
+		local baseStats = pokemonInternal.baseStats or {}
+		for i, statKey in ipairs(STATS_ORDERED) do
+			local baseStatText = tostring(baseStats[statKey] or 0)
+			local statMarking
+			if (pokemonInfo.statMarkings[statKey] or 0) > 0 then
+				local statState = Constants.STAT_STATES[pokemonInfo.statMarkings[statKey]] or {}
+				statMarking = statState.text
+				SCREEN.Data.totalMarkings = SCREEN.Data.totalMarkings + 1
+			end
+			local gradeColor, gradeSymbol
+			if not statMarking then
+				gradeColor = SCREEN.Colors.text
+			elseif SCREEN.isMarkingAccurate(statMarking, baseStats[statKey], statKey, pokemonInfo.abilityId) then
+				gradeScore = gradeScore + 1
+				gradeColor = SCREEN.Colors.positive
+				gradeSymbol = SCREEN.PixelImages.SMALL_CHECK
+				SCREEN.Data.greatMarkings = SCREEN.Data.greatMarkings + 1
+			else
+				gradeScore = gradeScore - 10
+				gradeColor = SCREEN.Colors.negative
+				gradeSymbol = SCREEN.PixelImages.SMALL_X
+				SCREEN.Data.poorMarkings = SCREEN.Data.poorMarkings + 1
+			end
+
+			local statBtn = {
+				type = Constants.ButtonTypes.NO_BORDER,
+				isVisible = function(self) return buttonRow:isVisible() end,
+				box = { -1, -1, 21, GRIDROW.H / 2 },
+				alignToBox = function(self, box)
+					self.box[1] = box[1] + GRIDROW.COLS_X[i + 1]
+					self.box[2] = box[2] + (GRIDROW.H / 2) + 2
+				end,
+				draw = function(self, shadowcolor)
+					local x, y, w = self.box[1], self.box[2], self.box[3]
+					local textColor = Theme.COLORS[SCREEN.Colors.text]
+					local bgColor = Theme.COLORS[SCREEN.Colors.boxFill]
+					if statMarking then
+						local centerOffset = Utils.getCenteredTextX(statMarking, 21) - 2
+						Drawing.drawTransparentTextbox(x + centerOffset, y - 16, statMarking, textColor, bgColor, shadowcolor)
+						if gradeSymbol then
+							Drawing.drawImageAsPixels(gradeSymbol, x + w - 7, y - 17, Theme.COLORS[gradeColor], shadowcolor)
+						end
+					end
+					local centerOffset = Utils.getCenteredTextX(baseStatText, 21) - 2
+					Drawing.drawTransparentTextbox(x + centerOffset, y, baseStatText, textColor, bgColor, shadowcolor)
+				end,
+			}
+			table.insert(buttonRow.buttonList, statBtn)
+		end
+		buttonRow.score = gradeScore
+	end
+
+	-- Place button rows into the grid and update each of their contained buttons
+	SCREEN.Pager:realignButtonsToGrid(GRIDROW.X, GRIDROW.Y, 0, 0)
+
+	if SCREEN.Data.totalMarkings > 0 then
+		if SCREEN.Data.greatMarkings == SCREEN.Data.totalMarkings then
+			SCREEN.Data.percentageScore = "100"
+		else
+			local percentile = SCREEN.Data.greatMarkings * 100 / SCREEN.Data.totalMarkings
+			SCREEN.Data.percentageScore = string.format("%.1f", percentile)
+		end
+	else
+		SCREEN.Data.percentageScore = Constants.BLANKLINE
+	end
+end
+
+---Returns true if the `statMarking` for a given `baseStat` value is within its range [and margin of error], inclusive
+---@param statMarking string
+---@param baseStat number
+---@param statKey? string Optional, pair with `abilityId` to check for abilities that would affect the marking accuracy
+---@param abilityId? number Optional
+---@return boolean
+function StatMarkingScoreSheet.isMarkingAccurate(statMarking, baseStat, statKey, abilityId)
+	local range = SCREEN.StatMarkingRanges[statMarking or false]
+	if not range then
+		return false
+	end
+	local minAllowed = range.min - SCREEN.StatMarkingRanges.MarginOfError
+	local maxAllowed = range.max + SCREEN.StatMarkingRanges.MarginOfError
+
+	local alternativeSuccess = false
+	if statKey == "atk" and (abilityId == AbilityData.Values.HugePowerId or abilityId == AbilityData.Values.PurePowerId) then
+		baseStat = math.min(baseStat * 2, 255) -- treat it as though it's doubled, max 255
+	elseif statKey == "atk" and abilityId == AbilityData.Values.HustleId then
+		baseStat = math.min(baseStat * 1.5, 255) -- treat it as though it's boosted, max 255
+	elseif statKey == "spd" and abilityId == AbilityData.Values.ThickFatId then
+		local altBaseStat = math.min(baseStat * 2, 255) -- treat it as though it's doubled, max 255
+		alternativeSuccess = (altBaseStat >= minAllowed) and (altBaseStat <= maxAllowed)
+	end
+
+	return (baseStat >= minAllowed) and (baseStat <= maxAllowed) or alternativeSuccess
+end
+
+function StatMarkingScoreSheet.getGradePixelImage()
+	if not SCREEN.Data.pokemon or SCREEN.Data.totalMarkings == 0 then
+		return nil
+	end
+	local percentile = tonumber(SCREEN.Data.percentageScore) or 0
+
+	-- TODO: Return a pixel image for each
+	if percentile == 100 then
+		return "A+"
+	elseif percentile >= 90 then
+		return "A"
+	elseif percentile >= 80 then
+		return "B"
+	elseif percentile >= 70 then
+		return "C"
+	else
+		return "D"
+	end
+end
+
+function StatMarkingScoreSheet.refreshButtons()
+	for _, button in pairs(SCREEN.Buttons) do
+		if type(button.updateSelf) == "function" then
+			button:updateSelf()
+		end
+	end
+	for _, button in pairs(SCREEN.NavButtons) do
+		if type(button.updateSelf) == "function" then
+			button:updateSelf()
+		end
+	end
+	for _, button in pairs(SCREEN.Pager.Buttons) do
+		if type(button.updateSelf) == "function" then
+			button:updateSelf()
+		end
+	end
+end
+
+function StatMarkingScoreSheet.clearBuiltData()
+	SCREEN.Data = {}
+	SCREEN.Pager.Buttons = {}
+end
+
+-- USER INPUT FUNCTIONS
+function StatMarkingScoreSheet.checkInput(xmouse, ymouse)
+	Input.checkButtonsClicked(xmouse, ymouse, SCREEN.Buttons)
+	Input.checkButtonsClicked(xmouse, ymouse, SCREEN.NavButtons)
+	Input.checkButtonsClicked(xmouse, ymouse, SCREEN.Pager.Buttons)
+end
+
+-- DRAWING FUNCTIONS
+function StatMarkingScoreSheet.drawScreen()
+	Drawing.drawBackgroundAndMargins()
+	SCREEN.refreshButtons()
+
+	local canvas = {
+		x = Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN,
+		y = Constants.SCREEN.MARGIN + 10,
+		width = Constants.SCREEN.RIGHT_GAP - (Constants.SCREEN.MARGIN * 2),
+		height = Constants.SCREEN.HEIGHT - (Constants.SCREEN.MARGIN * 2) - 10,
+		text = Theme.COLORS[SCREEN.Colors.text],
+		highlight = Theme.COLORS[SCREEN.Colors.highlight],
+		border = Theme.COLORS[SCREEN.Colors.border],
+		fill = Theme.COLORS[SCREEN.Colors.boxFill],
+		shadow = Utils.calcShadowColor(Theme.COLORS[SCREEN.Colors.boxFill]),
+	}
+
+	-- Draw top border box
+	gui.defaultTextBackground(canvas.fill)
+	gui.drawRectangle(canvas.x, canvas.y, canvas.width, canvas.height, canvas.border, canvas.fill)
+	-- Header
+	local headerText = Utils.toUpperUTF8(Resources.StatMarkingScoreSheet.Title)
+	local headerColor = Theme.COLORS["Header text"]
+	local headerShadow = Utils.calcShadowColor(Theme.COLORS["Main background"])
+	Drawing.drawText(canvas.x, Constants.SCREEN.MARGIN - 2, headerText, headerColor, headerShadow)
+
+	-- Draw all buttons
+	for _, button in pairs(SCREEN.Buttons) do
+		Drawing.drawButton(button, canvas.shadow)
+	end
+	for _, button in pairs(SCREEN.NavButtons) do
+		Drawing.drawButton(button, canvas.shadow)
+	end
+	for _, button in pairs(SCREEN.Pager.Buttons) do
+		Drawing.drawButton(button, canvas.shadow)
+	end
+end

--- a/ironmon_tracker/screens/StatMarkingScoreSheet.lua
+++ b/ironmon_tracker/screens/StatMarkingScoreSheet.lua
@@ -203,7 +203,7 @@ SCREEN.Buttons = {
 		iconColors = { SCREEN.Colors.highlight },
 		circleColor = SCREEN.Colors.highlight,
 		box = {	Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 108, Constants.SCREEN.MARGIN + 26, 14, 14 },
-		isVisible = function(self) return self.image ~= nil end,
+		isVisible = function(self) return self.image ~= nil and SCREEN.Data.percentageScore ~= Constants.BLANKLINE end,
 		updateSelf = function(self)
 			if self.image ~= SCREEN.Data.gradeLetter then
 				self.image = SCREEN.Data.gradeLetter
@@ -279,6 +279,7 @@ function StatMarkingScoreSheet.createHeader()
 			type = Constants.ButtonTypes.NO_BORDER,
 			textColor = SCREEN.Colors.text,
 			box = { GRIDROW.X + GRIDROW.COLS_X[i + 1], GRIDROW.Y - Constants.SCREEN.LINESPACING - 3, 20, 11 },
+			isVisible = function(self) return SCREEN.Data.percentageScore ~= Constants.BLANKLINE end,
 			draw = function(self, shadowcolor)
 				local x, y = self.box[1], self.box[2]
 				local textColor = Theme.COLORS[self.textColor]

--- a/ironmon_tracker/screens/StatMarkingScoreSheet.lua
+++ b/ironmon_tracker/screens/StatMarkingScoreSheet.lua
@@ -33,6 +33,70 @@ SCREEN.PixelImages = {
 		{0,1,0,0,0},
 		{0,0,0,0,0},
 	},
+	GRADE_A = {
+		{0,0,0,0,1,1,1,1,1,1,0,0,0,0},
+		{0,0,0,0,1,1,1,1,1,1,0,0,0,0},
+		{0,0,1,1,1,1,0,0,1,1,1,1,0,0},
+		{0,0,1,1,1,1,0,0,1,1,1,1,0,0},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,1,1,1,1,1,1,1,1,1,1},
+		{1,1,1,1,1,1,1,1,1,1,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+	},
+	GRADE_B = {
+		{1,1,1,1,1,1,1,1,1,1,1,1,0,0},
+		{1,1,1,1,1,1,1,1,1,1,1,1,0,0},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,1,1,1,1,1,1,1,1,0,0},
+		{1,1,1,1,1,1,1,1,1,1,1,1,0,0},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,1,1,1,1,1,1,1,1,0,0},
+		{1,1,1,1,1,1,1,1,1,1,1,1,0,0},
+	},
+	GRADE_C = {
+		{0,0,0,0,1,1,1,1,1,1,1,1,0,0},
+		{0,0,0,0,1,1,1,1,1,1,1,1,0,0},
+		{0,0,1,1,1,1,0,0,0,0,1,1,1,1},
+		{0,0,1,1,1,1,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,0,0,0,0},
+		{1,1,1,1,0,0,0,0,0,0,0,0,0,0},
+		{1,1,1,1,0,0,0,0,0,0,0,0,0,0},
+		{1,1,1,1,0,0,0,0,0,0,0,0,0,0},
+		{1,1,1,1,0,0,0,0,0,0,0,0,0,0},
+		{1,1,1,1,0,0,0,0,0,0,0,0,0,0},
+		{0,0,1,1,1,1,0,0,0,0,1,1,1,1},
+		{0,0,1,1,1,1,0,0,0,0,1,1,1,1},
+		{0,0,0,0,1,1,1,1,1,1,1,1,0,0},
+		{0,0,0,0,1,1,1,1,1,1,1,1,0,0},
+	},
+	GRADE_D = {
+		{1,1,1,1,1,1,1,1,1,1,0,0,0,0},
+		{1,1,1,1,1,1,1,1,1,1,0,0,0,0},
+		{1,1,1,1,0,0,0,0,1,1,1,1,0,0},
+		{1,1,1,1,0,0,0,0,1,1,1,1,0,0},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,0,0,1,1,1,1},
+		{1,1,1,1,0,0,0,0,1,1,1,1,0,0},
+		{1,1,1,1,0,0,0,0,1,1,1,1,0,0},
+		{1,1,1,1,1,1,1,1,1,1,0,0,0,0},
+		{1,1,1,1,1,1,1,1,1,1,0,0,0,0},
+	},
 }
 
 local SUMMARY_COL2_X = 53
@@ -86,8 +150,6 @@ SCREEN.Pager = {
 }
 
 SCREEN.Buttons = {
-	-- TODO:
-	-- giant letter stamp: (B+) use highlight color
 	LabelGreat = {
 		type = Constants.ButtonTypes.NO_BORDER,
 		getText = function(self) return string.format("%s:", Resources.StatMarkingScoreSheet.LabelGreatMarks) end,
@@ -133,6 +195,32 @@ SCREEN.Buttons = {
 			local rightAlignX = 19 - Utils.calcWordPixelLength(value)
 			Drawing.drawText(x + SUMMARY_COL2_X + rightAlignX, y, value, color, shadowcolor)
 			Drawing.drawText(x + SUMMARY_COL2_X + 22, y, "%", color, shadowcolor)
+		end,
+	},
+	LetterGradeImage = {
+		type = Constants.ButtonTypes.PIXELIMAGE,
+		image = nil,
+		iconColors = { SCREEN.Colors.highlight },
+		circleColor = SCREEN.Colors.highlight,
+		box = {	Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 108, Constants.SCREEN.MARGIN + 26, 14, 14 },
+		isVisible = function(self) return self.image ~= nil end,
+		updateSelf = function(self)
+			if self.image ~= SCREEN.Data.gradeLetter then
+				self.image = SCREEN.Data.gradeLetter
+			end
+		end,
+		draw = function(self, shadowcolor)
+			local x, y = self.box[1], self.box[2]
+			local color = Theme.COLORS[self.circleColor]
+			local circleX, circleY, circleW, circleH = x - 9, y - 9, 30, 30
+			if Theme.DRAW_TEXT_SHADOWS then
+				gui.drawEllipse(circleX + 1, circleY + 2, circleW, circleH, shadowcolor)
+				gui.drawEllipse(circleX + 2, circleY + 2, circleW, circleH, shadowcolor)
+			end
+			gui.drawEllipse(circleX, circleY, circleW, circleH, color)
+			gui.drawEllipse(circleX, circleY + 1, circleW, circleH, color)
+			gui.drawEllipse(circleX + 1, circleY, circleW, circleH, color - (Drawing.ColorEffects.DARKEN * 2))
+			gui.drawEllipse(circleX + 1, circleY + 1, circleW, circleH, color - (Drawing.ColorEffects.DARKEN * 2))
 		end,
 	},
 
@@ -209,7 +297,7 @@ function StatMarkingScoreSheet.buildScreen()
 	SCREEN.Data.greatMarkings = 0
 	SCREEN.Data.poorMarkings = 0
 	SCREEN.Data.totalMarkings = 0
-	SCREEN.Data.gradeLetter = -1 -- TODO: perhaps use pixel art
+	SCREEN.Data.gradeLetter = nil
 
 	-- Add to list all pokemon with tracked stat markings
 	SCREEN.Data.pokemon = {}
@@ -359,6 +447,9 @@ function StatMarkingScoreSheet.buildScreen()
 	else
 		SCREEN.Data.percentageScore = Constants.BLANKLINE
 	end
+
+	local percentile = tonumber(SCREEN.Data.percentageScore) or 0
+	SCREEN.Data.gradeLetter = SCREEN.getGradePixelImage(percentile)
 end
 
 ---Returns true if the `statMarking` for a given `baseStat` value is within its range [and margin of error], inclusive
@@ -388,23 +479,21 @@ function StatMarkingScoreSheet.isMarkingAccurate(statMarking, baseStat, statKey,
 	return (baseStat >= minAllowed) and (baseStat <= maxAllowed) or alternativeSuccess
 end
 
-function StatMarkingScoreSheet.getGradePixelImage()
-	if not SCREEN.Data.pokemon or SCREEN.Data.totalMarkings == 0 then
-		return nil
-	end
-	local percentile = tonumber(SCREEN.Data.percentageScore) or 0
-
-	-- TODO: Return a pixel image for each
+---Returns a pixel-image table that represents a letter grade from A to D.
+---@param percentile number
+---@return table pixelImage
+function StatMarkingScoreSheet.getGradePixelImage(percentile)
+	percentile = percentile or 0
 	if percentile == 100 then
-		return "A+"
+		return SCREEN.PixelImages.GRADE_A
 	elseif percentile >= 90 then
-		return "A"
+		return SCREEN.PixelImages.GRADE_A
 	elseif percentile >= 80 then
-		return "B"
+		return SCREEN.PixelImages.GRADE_B
 	elseif percentile >= 70 then
-		return "C"
+		return SCREEN.PixelImages.GRADE_C
 	else
-		return "D"
+		return SCREEN.PixelImages.GRADE_D
 	end
 end
 


### PR DESCRIPTION
This feature adds a fun little note score sheet (graded stat markings) after a run ends, accessible on the Game Over screen. It checks all **non-speed** markings the player noted for Pokémon they fought against, and compares their markings to the actual base stats of that Pokémon.

Great markings are those within the acceptable range for that stat marking. Poor markings are outside that range. There is also a margin of error to take into account the uncertainty of markings.

A letter grade will also be displayed in the upper-right corner. This grade can be A, B, C, or D. If all stat markings were graded correctly, then it will be an A+ to indicate a perfect score.

> Note: While these grading ranges for "correct stat markings" are subjective, I still want to do something like this as it seems both fun to look at and encouraging to take better notes. I used a few different samples of data to test and confirm the grading system is within reason, likely compatible with most people's methods of stat marking.

### Stat Grade Ranges
| Symbol | Stat Marking | Range |
| --- | -- | -- |
| `[+]` | High | 115 - 255 |
| `[-]` | Low | 11 - 70 |
| `[=]` | Medium/Equal| 70 - 115 |

All stat ranges are inclusive. The margin of error is +/- 25 for either side of the range.

For example, if the ATK stat with a `[+]` and that Pokémon's base stat value is 100, then it will be graded as correct, or "Great mark", as its within the acceptable range and margin of error.

### Stat Marking Score Sheet screen
![image](https://github.com/user-attachments/assets/70970730-9dbd-47ce-8193-7e8325144d95)
