### PR TITLE
Code to track initial moveset of Pokemon used

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -445,6 +445,16 @@ function Battle.updateTrackedInfo()
 		end
 	end
 
+	-- For trainer battles only, attempt to do a 1-time info tracking for the active Pokémon's moveset (records initial moveset)
+	if not Battle.isWildEncounter then
+		local ownLeftPokemon = Tracker.getPokemon(Battle.Combatants.LeftOwn, true) or {}
+		Tracker.tryTrackInitialMoveset(ownLeftPokemon)
+		if Battle.numBattlers > 2 then
+			local ownRightPokemon = Tracker.getPokemon(Battle.Combatants.RightOwn, true) or {}
+			Tracker.tryTrackInitialMoveset(ownRightPokemon)
+		end
+	end
+
 	-- Always track your own Pokemons' abilities, unless you are in a half-double battle alongside an NPC (3 + 3 vs 3 + 3)
 	local ownLeftPokemon = Tracker.getPokemon(Battle.Combatants.LeftOwn,true)
 	if ownLeftPokemon ~= nil and Battle.Combatants.LeftOwn <= Battle.partySize then

--- a/ironmon_tracker/CustomCode.lua
+++ b/ironmon_tracker/CustomCode.lua
@@ -277,6 +277,7 @@ end
 function CustomCode.checkForRomHacks()
 	-- For NatDex v1.1.3 and lower, it did not have these addresses for the new Trainers lookup feature
 	if CustomCode.RomHacks.isNatDexVersionOrLower("1.1.3") then
+		GameSettings.gLevelUpLearnsets = GameSettings.gLevelUpLearnsets_NatDex_113
 		GameSettings.gTrainers = GameSettings.gTrainers_NatDex_113
 		GameSettings.gTrainerClassNames = GameSettings.gTrainerClassNames_NatDex_113
 	end

--- a/ironmon_tracker/GameSettings.lua
+++ b/ironmon_tracker/GameSettings.lua
@@ -636,6 +636,20 @@ function GameSettings.setRomAddresses(gameIndex, versionIndex)
 			{ 0x08253ae4, 0x08253b54, 0x0824f2ac, 0x0824cbc4, 0x0824df34, 0x08253a08, 0x082104ec },
 			{ 0x08253ac0, 0x08253b30 },
 		},
+		gLevelUpLearnsets = {
+			{ 0x08207bc8, 0x08207be0, 0x08207be0 },
+			{ 0x08207b58, 0x08207b70, 0x08207b70 },
+			{ 0x0832937c },
+			{ 0x0825d7b4, 0x0825d824, 0x08258F7C, 0x08256894, 0x08257C04, 0x0825D6D8, 0x0821A1BC },
+			{ 0x0825d794, 0x0825d804 },
+		},
+		gLevelUpLearnsets_NatDex_113 = {
+			{ nil },
+			{ nil },
+			{ 0x08349750 },
+			{ 0x0829050c, 0x0829050c }, -- Note: only the FireRed v1.1 address is used
+			{ nil },
+		},
 		gTrainers = {
 			{ 0x081f04fc, 0x081f0514, 0x081f0514 },
 			{ 0x081f048c, 0x081f04a4, 0x081f04a4 },

--- a/ironmon_tracker/Program.lua
+++ b/ironmon_tracker/Program.lua
@@ -1173,7 +1173,6 @@ function Program.getLearnedMoveInfoTable()
 			battleStructAddress = Program.Addresses.battleStructDefault
 		end
 
-		-- Note: Determining who is leveling up is a bit buggy, sometimes the wrong mon gets its levelup move tracked
 		local partyIndex = Memory.readbyte(battleStructAddress + Program.Addresses.offsetPokemonGettingExp) + 1 -- Party index of player (1-6)
 		local pokemon = Tracker.getPokemon(partyIndex, true)
 		if pokemon ~= nil then


### PR DESCRIPTION
This solves an outstanding issue where the initial 4 moves of a player's lab/pivot Pokemon are never tracked, since the conditions for tracking a move were "used in battle" or "learned while leveling up".

This remedies that issue by doing a 1-time tracking of the current moveset when battling a trainer (player decided to run this Pokemon for real). It also only tracks moves within its initial moveset if that Pokemon could have naturally learned that move by level up.

### Before 1st Trainer Battle
![image](https://github.com/user-attachments/assets/17520848-ab70-40f5-a947-35cf87146e50)

### After 1st Trainer Battle
![image](https://github.com/user-attachments/assets/9a6009fe-5a27-45fb-b1ab-125b01034e19)
