### PR TITLE
Override moves shown to use known moves if able

### DIFF
--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -398,6 +398,7 @@ function Battle.updateTrackedInfo()
 										local battlerMon = Tracker.getPokemon(battlerTransformData.slot,battlerTransformData.isOwn)
 										if battlerMon ~= nil then
 											Tracker.TrackMove(battlerMon.pokemonID, lastMoveByBattler, battlerMon.level)
+											Tracker.recordBattleMoveByPokemonLevel(battlerMon.pokemonID, lastMoveByBattler, battlerMon.level)
 										end
 									end
 								end
@@ -412,6 +413,7 @@ function Battle.updateTrackedInfo()
 										local attackingMon = Tracker.getPokemon(transformData.slot,transformData.isOwn)
 										if attackingMon ~= nil then
 											Tracker.TrackMove(attackingMon.pokemonID, lastMoveByAttacker, attackingMon.level)
+											Tracker.recordBattleMoveByPokemonLevel(attackingMon.pokemonID, lastMoveByAttacker, attackingMon.level)
 										end
 									end
 								end
@@ -439,6 +441,7 @@ function Battle.updateTrackedInfo()
 					local attackingMon = Tracker.getPokemon(transformData.slot,transformData.isOwn)
 					if attackingMon ~= nil then
 						Tracker.TrackMove(attackingMon.pokemonID, 264, attackingMon.level)
+						Tracker.recordBattleMoveByPokemonLevel(attackingMon.pokemonID, 264, attackingMon.level)
 					end
 				end
 			end
@@ -1073,6 +1076,7 @@ function Battle.trackTransformedMoves()
 		if copiedMon ~= nil then
 			for _, move in pairs(copiedMon.moves) do
 				Tracker.TrackMove(copiedMon.pokemonID, move.id, copiedMon.level)
+				Tracker.recordBattleMoveByPokemonLevel(copiedMon.pokemonID, move.id, copiedMon.level)
 			end
 		end
 	end

--- a/ironmon_tracker/Battle.lua
+++ b/ironmon_tracker/Battle.lua
@@ -761,6 +761,7 @@ function Battle.beginNewBattle()
 	Battle.populateBattlePartyObject()
 	Input.StatHighlighter:resetSelectedStat()
 
+	Tracker.resetBattleNotes()
 	Battle.trySwapScreenBackToMain()
 
 	-- If the lead encountered enemy Pokemon is a shiny, trigger a pulsing sparkle effect
@@ -836,6 +837,7 @@ function Battle.endCurrentBattle()
 		pokemon.statStages = { hp = 6, atk = 6, def = 6, spa = 6, spd = 6, spe = 6, acc = 6, eva = 6 }
 	end
 
+	Tracker.resetBattleNotes()
 	Battle.trySwapScreenBackToMain()
 
 	Battle.opposingTrainerId = 0

--- a/ironmon_tracker/Input.lua
+++ b/ironmon_tracker/Input.lua
@@ -367,7 +367,7 @@ function Input.checkAnyMovesClicked(xmouse, ymouse)
 
 	local pokemonMoves
 	if not Battle.isViewingOwn and not Options["Open Book Play Mode"] then
-		pokemonMoves = Tracker.getMoves(pokemon.pokemonID) -- tracked moves only
+		pokemonMoves = Tracker.getMoves(pokemon.pokemonID, pokemon.level) -- tracked moves only
 	elseif Tracker.Data.hasCheckedSummary then
 		pokemonMoves = pokemon.moves
 	end

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -210,10 +210,6 @@ function Tracker.TrackMove(pokemonID, moveId, level)
 		return
 	end
 
-	if Battle.inActiveBattle() then
-		Tracker.trackBattleMoveByPokemonLevel(pokemonID, moveId, level)
-	end
-
 	local trackedPokemon = Tracker.getOrCreateTrackedPokemon(pokemonID)
 
 	-- If no move data exist, set this as the first move
@@ -559,6 +555,7 @@ function Tracker.resetData()
 	Tracker.LoadStatus = Tracker.LoadStatusKeys.NEW_GAME
 end
 
+---Resets any recorded information that is temporarily noted for the current battle
 function Tracker.resetBattleNotes()
 	Tracker.BattleNotes = {
 		MovesByPokemonAndLevel = {},
@@ -566,8 +563,12 @@ function Tracker.resetBattleNotes()
 	}
 end
 
-function Tracker.trackBattleMoveByPokemonLevel(pokemonID, moveId, level)
-	if not PokemonData.isValid(pokemonID) or not MoveData.isValid(moveId) or type(level) ~= "number" then
+---Records/saves info about a move used by an [enemy] pokemon in battle, temporarily, for the current battle.
+---@param pokemonID any
+---@param moveId any
+---@param level any
+function Tracker.recordBattleMoveByPokemonLevel(pokemonID, moveId, level)
+	if not PokemonData.isValid(pokemonID) or not MoveData.isValid(moveId) or type(level) ~= "number" or not Battle.inActiveBattle() then
 		return
 	end
 	-- Store known/used moves with a key formed by the id & level pair

--- a/ironmon_tracker/Tracker.lua
+++ b/ironmon_tracker/Tracker.lua
@@ -9,6 +9,16 @@ Tracker.LoadStatusKeys = {
 }
 Tracker.LoadStatus = Tracker.LoadStatusKeys.NEW_GAME
 
+-- Holds temporary notes for the current battle only
+Tracker.BattleNotes = {
+	MovesByPokemonAndLevel = {
+		-- [number: an id & level pair] = { [number:moveId1] = {}, [number:moveId2] = {}, ... }
+	},
+	FourMovesIfAllKnown = {
+		-- [number: an id & level pair] = {list of all four known moves}
+	},
+}
+
 ---@class ITrackedData
 Tracker.DefaultData = {
 	-- NOTE: These root attributes cannot be nil, or they won't be loaded from the TDAT file
@@ -83,6 +93,7 @@ Tracker.DataMessage = "" -- Used for StartupScreen to display info about tracked
 
 function Tracker.initialize()
 	Tracker.resetData()
+	Tracker.resetBattleNotes()
 	Tracker.AutoSave.reset()
 end
 
@@ -197,6 +208,10 @@ end
 function Tracker.TrackMove(pokemonID, moveId, level)
 	if not MoveData.isValid(moveId) or moveId == 165 then -- 165 = Struggle
 		return
+	end
+
+	if Battle.inActiveBattle() then
+		Tracker.trackBattleMoveByPokemonLevel(pokemonID, moveId, level)
 	end
 
 	local trackedPokemon = Tracker.getOrCreateTrackedPokemon(pokemonID)
@@ -370,8 +385,16 @@ end
 
 -- If the Pokemon is being tracked, return information on moves; otherwise default move values = 1
 --- @param pokemonID number
+--- @param level? number Optional, if level is provided and ALL 4 moves of an enemy Pokémon were used in battle, return those moves
 --- @return table moves A table of moves for the Pokémon; each has an id, level, and pp value
-function Tracker.getMoves(pokemonID)
+function Tracker.getMoves(pokemonID, level)
+	-- Show all four known moves if they were all used in the current battle, instead of the loose tracked list of moves that are out of order
+	if level and Battle.inActiveBattle() and not Battle.isViewingOwn then
+		local monLvIndex = pokemonID * 1000 + level
+		if Tracker.BattleNotes.FourMovesIfAllKnown[monLvIndex] then
+			return Tracker.BattleNotes.FourMovesIfAllKnown[monLvIndex]
+		end
+	end
 	local trackedPokemon = Tracker.getOrCreateTrackedPokemon(pokemonID, false)
 	return trackedPokemon.moves or {}
 end
@@ -534,6 +557,40 @@ function Tracker.resetData()
 		gameStatsRockSmash = Utils.getGameStat(Constants.GAME_STATS.USED_ROCK_SMASH),
 	})
 	Tracker.LoadStatus = Tracker.LoadStatusKeys.NEW_GAME
+end
+
+function Tracker.resetBattleNotes()
+	Tracker.BattleNotes = {
+		MovesByPokemonAndLevel = {},
+		FourMovesIfAllKnown = {},
+	}
+end
+
+function Tracker.trackBattleMoveByPokemonLevel(pokemonID, moveId, level)
+	if not PokemonData.isValid(pokemonID) or not MoveData.isValid(moveId) or type(level) ~= "number" then
+		return
+	end
+	-- Store known/used moves with a key formed by the id & level pair
+	local monLvIndex = pokemonID * 1000 + level
+	local _moves = Tracker.BattleNotes.MovesByPokemonAndLevel
+	if not _moves[monLvIndex] then
+		_moves[monLvIndex] = {}
+	end
+	-- Check if already noted
+	if _moves[monLvIndex][moveId] or Tracker.BattleNotes.FourMovesIfAllKnown[monLvIndex] then
+		return
+	end
+
+	-- Record the known move in the notes
+	_moves[monLvIndex][moveId] = { id = moveId, level = level, minLv = level, maxLv = level, }
+
+	local knownMoves = {}
+	for _, move in pairs(_moves[monLvIndex]) do
+		table.insert(knownMoves, move)
+	end
+	if #knownMoves == 4 then
+		Tracker.BattleNotes.FourMovesIfAllKnown[monLvIndex] = knownMoves
+	end
 end
 
 ---Saves the Tracker Data (TDAT) to a file

--- a/ironmon_tracker/Utils.lua
+++ b/ironmon_tracker/Utils.lua
@@ -509,7 +509,7 @@ function Utils.calculateMoveStars(pokemonID, level)
 	end
 
 	-- If nothing has been tracked thus far for this Pokemon, return no stars
-	local trackedMoves = Tracker.getMoves(pokemonID)
+	local trackedMoves = Tracker.getMoves(pokemonID, level)
 	if type(trackedMoves[1]) ~= "table" or not MoveData.isValid(trackedMoves[1].id) then
 		return stars
 	end

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -259,7 +259,7 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 		stars = Utils.calculateMoveStars(viewedPokemon.pokemonID, viewedPokemon.level)
 	end
 
-	local trackedMoves = Tracker.getMoves(viewedPokemon.pokemonID)
+	local trackedMoves = Tracker.getMoves(viewedPokemon.pokemonID, viewedPokemon.level)
 	for i = 1, 4, 1 do
 		local moveToCopy = MoveData.BlankMove
 		if data.x.viewingOwn or useOpenBookInfo then


### PR DESCRIPTION
Closes #498 

In some cases, while battling and viewing an enemy Pokémon, that Pokémon will use all four of its moves. When it does, show those four moves on the tracker screen instead of the loose ordering of otherwise "tracked moves" it used to show.

This fixes the bug where 1 of the 4 moves wouldn't be shown even if all were known during that single battle.