### PR TITLE
9.1.2 Patch

### DIFF
--- a/ironmon_tracker/CustomCode.lua
+++ b/ironmon_tracker/CustomCode.lua
@@ -27,8 +27,7 @@ CustomCode = {
 
 	-- When installing/updating extensions, the below files and folders are removed after the release download and before copying over the files/folders
 	DefaultFoldersToExclude = {
-		".vscode",
-		".github",
+		-- Note: The download/extract command will fail if it tries to remove a folder that doesn't exist
 	},
 	DefaultFilenamesToExclude = {
 		'.editorconfig',
@@ -393,9 +392,8 @@ function CustomCode.downloadAndInstallExtensionFiles(githubRepoUrl, folderNamesT
 	local downloadResult = os.execute(downloadCommand)
 	if not (downloadResult == true or downloadResult == 0) then -- true / 0 = successful
 		Utils.tempEnableBizhawkSound()
-		print(string.format("> %s (%s)", "Error updating/installing Tracker Extension"))
-		print(string.format("> URL: %s", githubRepoUrl))
 		print("> ERROR: " .. tostring(downloadErr1))
+		print("> URL: " .. tostring(githubRepoUrl))
 		return false
 	end
 

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "9", minor = "1", patch = "1" }
+Main.Version = { major = "9", minor = "1", patch = "2" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",


### PR DESCRIPTION
This is a 2-part fix. 

One is a failure on my part to properly format a `string.format` command, such that if an error occurred, it would repeatedly try to re-download and re-error, causing an emulator freeze.

The second is not realizing what happens when a command tries to remove a folder that doesn't exist (errors and fails), so I got rid of those folders.

### Release Notes
- [v9.1.2] Fixed a critical error when installing an extension via a URL