### PR TITLE
feat: Use Bizhawk rom path as a fallback for logpath

### DIFF
--- a/ironmon_tracker/screens/LogOverlay.lua
+++ b/ironmon_tracker/screens/LogOverlay.lua
@@ -516,7 +516,8 @@ function LogOverlay.getLogFileAutodetected(postFix)
 		local loadedRomName = plainFormatter(GameSettings.getRomName() .. FileManager.Extensions.GBA_ROM)
 		local autodetectedName = plainFormatter(romname or "")
 		if loadedRomName ~= autodetectedName then
-			local logfile = FileManager.getLoadedRomPath() .. FileManager.slash .. loadedRomName .. FileManager.Extensions.GBA_ROM .. FileManager.Extensions.RANDOMIZER_LOGFILE
+			local filepath = FileManager.getLoadedRomPath() or ''
+			local logfile = filepath .. FileManager.slash .. loadedRomName .. FileManager.Extensions.GBA_ROM .. FileManager.Extensions.RANDOMIZER_LOGFILE
 			if FileManager.fileExists(logfile) then
 				return logfile
 			else

--- a/ironmon_tracker/screens/LogOverlay.lua
+++ b/ironmon_tracker/screens/LogOverlay.lua
@@ -516,8 +516,8 @@ function LogOverlay.getLogFileAutodetected(postFix)
 		local loadedRomName = plainFormatter(GameSettings.getRomName() .. FileManager.Extensions.GBA_ROM)
 		local autodetectedName = plainFormatter(romname or "")
 		if loadedRomName ~= autodetectedName then
-			local filepath = FileManager.getLoadedRomPath() or ''
-			local logfile = filepath .. FileManager.slash .. loadedRomName .. FileManager.Extensions.GBA_ROM .. FileManager.Extensions.RANDOMIZER_LOGFILE
+			local filepath = FileManager.getLoadedRomPath() or ""
+			local logfile = filepath .. FileManager.slash .. GameSettings.getRomName() .. FileManager.Extensions.GBA_ROM .. FileManager.Extensions.RANDOMIZER_LOGFILE
 			if FileManager.fileExists(logfile) then
 				return logfile
 			else

--- a/ironmon_tracker/screens/LogOverlay.lua
+++ b/ironmon_tracker/screens/LogOverlay.lua
@@ -517,7 +517,8 @@ function LogOverlay.getLogFileAutodetected(postFix)
 		local autodetectedName = plainFormatter(romname or "")
 		if loadedRomName ~= autodetectedName then
 			local filepath = FileManager.getLoadedRomPath() or ""
-			local logfile = filepath .. FileManager.slash .. GameSettings.getRomName() .. FileManager.Extensions.GBA_ROM .. FileManager.Extensions.RANDOMIZER_LOGFILE
+			local basepath = filepath and filepath .. FileManager.slash or ""
+			local logfile = basepath .. GameSettings.getRomName() .. FileManager.Extensions.GBA_ROM .. FileManager.Extensions.RANDOMIZER_LOGFILE
 			if FileManager.fileExists(logfile) then
 				return logfile
 			else

--- a/ironmon_tracker/screens/LogOverlay.lua
+++ b/ironmon_tracker/screens/LogOverlay.lua
@@ -516,7 +516,12 @@ function LogOverlay.getLogFileAutodetected(postFix)
 		local loadedRomName = plainFormatter(GameSettings.getRomName() .. FileManager.Extensions.GBA_ROM)
 		local autodetectedName = plainFormatter(romname or "")
 		if loadedRomName ~= autodetectedName then
-			return nil
+			local logfile = FileManager.getLoadedRomPath() .. FileManager.slash .. loadedRomName .. FileManager.Extensions.GBA_ROM .. FileManager.Extensions.RANDOMIZER_LOGFILE
+			if FileManager.fileExists(logfile) then
+				return logfile
+			else
+				return nil
+			end
 		end
 	end
 


### PR DESCRIPTION
1. Remove all New Run profiles from the Tracker
2. Create a new ironmon rom named "TestRom Roguemon.gba"
3. Have the associated log file named "TestRom Roguemon.gba.log" also created, and present in the same folder
4. Open the rom from step 2 into bizhawk, and open the tracker
5. Go to Extras -> View Log -> Open Log

Desired result: Open the log from step 3
Current result: A file prompt popup appears instead asking for the location of the log file