### PR TITLE
Separate variable power logic per individual move

### DIFF
--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -295,36 +295,7 @@ function DataHelper.buildTrackerScreenDisplay(forceView)
 			end
 			move.category = MoveData.getCategory(move.id, move.type)
 		elseif Options["Calculate variable damage"] then
-			if move.id == MoveData.Values.WeatherBallId then
-				move.type, move.power = Utils.calculateWeatherBall(move.type, move.power)
-				move.category = MoveData.getCategory(move.id, move.type)
-			elseif move.id == MoveData.Values.LowKickId and Battle.inActiveBattle() and opposingPokemon ~= nil then
-				local targetWeight
-				if opposingPokemon.weight ~= nil then
-					targetWeight = opposingPokemon.weight
-				elseif PokemonData.Pokemon[opposingPokemon.pokemonID] ~= nil then
-					targetWeight = PokemonData.Pokemon[opposingPokemon.pokemonID].weight
-				else
-					targetWeight = 0
-				end
-				move.power = Utils.calculateWeightBasedDamage(move.power, targetWeight)
-			elseif MoveData.isOHKO(move.id) and Battle.inActiveBattle() and opposingPokemon ~= nil then
-				local levelDiff = viewedPokemon.level - opposingPokemon.level
-				if levelDiff > 0 then
-					local accAsNum = tonumber(move.accuracy or "") or 30 -- 30 is default OHKO accuracy
-					move.accuracy = tostring(math.min(accAsNum + levelDiff, 100))
-				elseif levelDiff < 0 then
-					move.accuracy = "X " -- Ineffective against higher level pokemon
-				end
-			elseif data.x.viewingOwn then
-				if move.id == MoveData.Values.FlailId or move.id == MoveData.Values.ReversalId then
-					move.power = Utils.calculateLowHPBasedDamage(move.power, viewedPokemon.curHP, viewedPokemon.stats.hp)
-				elseif move.id == MoveData.Values.EruptionId or move.id == MoveData.Values.WaterSpoutId then
-					move.power = Utils.calculateHighHPBasedDamage(move.power, viewedPokemon.curHP, viewedPokemon.stats.hp)
-				elseif move.id == MoveData.Values.ReturnId or move.id == MoveData.Values.FrustrationId then
-					move.power = Utils.calculateFriendshipBasedDamage(move.power, viewedPokemon.friendship)
-				end
-			end
+			MoveData.adjustForVariablePower(move, viewedPokemon, opposingPokemon)
 		end
 
 		-- Update: If STAB

--- a/ironmon_tracker/data/MoveData.lua
+++ b/ironmon_tracker/data/MoveData.lua
@@ -1,7 +1,10 @@
 MoveData = {}
 
 MoveData.Values = {
+	GuillotineId = 12,
+	HornDrillId = 32,
 	LowKickId = 67,
+	FissureId = 90,
 	FlailId = 175,
 	ReversalId = 179,
 	ReturnId = 216,
@@ -12,6 +15,7 @@ MoveData.Values = {
 	SkillSwapId = 285,
 	WeatherBallId = 311,
 	WaterSpoutId = 323,
+	SheerColdId = 329,
 
 	-- The below are used by the BattleDetailsScreen
 	PayDayId = 6,
@@ -135,8 +139,9 @@ MoveData.TypeToEffectiveness = {
 	steel = { fire = 0.5, water = 0.5, ice = 2, rock = 2, steel = 0.5, electric = 0.5 },
 }
 
--- Individual formulas for calculating any changes to a move based on contextual information, such as being in battle
-MoveData.VariablePowerAdjustmentFuncs = {
+---Individual formulas for calculating any changes to a move based on contextual information, such as being in battle; key=moveid, val=func
+---@type table<number, function>
+MoveData.MoveValueAdjustmentFuncs = {
 	[MoveData.Values.WeatherBallId] = function(move, sourcePokemon, targetPokemon)
 		if not Battle.inActiveBattle() then return end
 		move.type, move.power = Utils.calculateWeatherBall(move.type, move.power)
@@ -176,8 +181,7 @@ MoveData.VariablePowerAdjustmentFuncs = {
 		if not Battle.isViewingOwn then return end -- Only reveal Friendship for player's pokemon, not enemy
 		move.power = Utils.calculateFriendshipBasedDamage(move.power, sourcePokemon.friendship or 0)
 	end,
-	-- Guillotine
-	[12] = function(move, sourcePokemon, targetPokemon)
+	[MoveData.Values.GuillotineId] = function(move, sourcePokemon, targetPokemon)
 		if not Battle.inActiveBattle() then return end
 		local levelDiff = (sourcePokemon.level or 0) - (targetPokemon.level or 0)
 		if levelDiff > 0 then
@@ -187,8 +191,7 @@ MoveData.VariablePowerAdjustmentFuncs = {
 			move.accuracy = "X " -- Ineffective against higher level pokemon
 		end
 	end,
-	-- Horn Drill
-	[32] = function(move, sourcePokemon, targetPokemon)
+	[MoveData.Values.HornDrillId] = function(move, sourcePokemon, targetPokemon)
 		if not Battle.inActiveBattle() then return end
 		local levelDiff = (sourcePokemon.level or 0) - (targetPokemon.level or 0)
 		if levelDiff > 0 then
@@ -198,8 +201,7 @@ MoveData.VariablePowerAdjustmentFuncs = {
 			move.accuracy = "X " -- Ineffective against higher level pokemon
 		end
 	end,
-	-- Fissure
-	[90] = function(move, sourcePokemon, targetPokemon)
+	[MoveData.Values.FissureId] = function(move, sourcePokemon, targetPokemon)
 		if not Battle.inActiveBattle() then return end
 		local levelDiff = (sourcePokemon.level or 0) - (targetPokemon.level or 0)
 		if levelDiff > 0 then
@@ -209,8 +211,7 @@ MoveData.VariablePowerAdjustmentFuncs = {
 			move.accuracy = "X " -- Ineffective against higher level pokemon
 		end
 	end,
-	-- Sheer Cold
-	[329] = function(move, sourcePokemon, targetPokemon)
+	[MoveData.Values.SheerColdId] = function(move, sourcePokemon, targetPokemon)
 		if not Battle.inActiveBattle() then return end
 		local levelDiff = (sourcePokemon.level or 0) - (targetPokemon.level or 0)
 		if levelDiff > 0 then
@@ -443,14 +444,13 @@ end
 ---@param move table
 ---@param sourcePokemon? table Optional, as not all move adjustment calculations require a source and/or a target
 ---@param targetPokemon? table Optional, as not all move adjustment calculations require a source and/or a target
-function MoveData.adjustForVariablePower(move, sourcePokemon, targetPokemon)
+function MoveData.adjustVariableMoveValues(move, sourcePokemon, targetPokemon)
 	sourcePokemon = sourcePokemon or {}
 	targetPokemon = targetPokemon or {}
-	local adjustmentFunc = MoveData.VariablePowerAdjustmentFuncs[tonumber(move.id or 0) or false]
-	if type(adjustmentFunc) ~= "function" then
-		return
+	local adjustmentFunc = MoveData.MoveValueAdjustmentFuncs[tonumber(move.id or 0) or false]
+	if type(adjustmentFunc) == "function" then
+		adjustmentFunc(move, sourcePokemon, targetPokemon)
 	end
-	adjustmentFunc(move, sourcePokemon, targetPokemon)
 end
 
 MoveData.BlankMove = {

--- a/ironmon_tracker/data/MoveData.lua
+++ b/ironmon_tracker/data/MoveData.lua
@@ -135,6 +135,93 @@ MoveData.TypeToEffectiveness = {
 	steel = { fire = 0.5, water = 0.5, ice = 2, rock = 2, steel = 0.5, electric = 0.5 },
 }
 
+-- Individual formulas for calculating any changes to a move based on contextual information, such as being in battle
+MoveData.VariablePowerAdjustmentFuncs = {
+	[MoveData.Values.WeatherBallId] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.inActiveBattle() then return end
+		move.type, move.power = Utils.calculateWeatherBall(move.type, move.power)
+		move.category = MoveData.getCategory(move.id, move.type)
+	end,
+	[MoveData.Values.LowKickId] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.inActiveBattle() then return end
+		local pokemonInternal = PokemonData.Pokemon[targetPokemon.pokemonID or false] or PokemonData.BlankPokemon
+		local targetWeight = targetPokemon.weight or pokemonInternal.weight or 0
+		move.power = Utils.calculateWeightBasedDamage(move.power, targetWeight)
+	end,
+	[MoveData.Values.FlailId] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.isViewingOwn then return end -- Only reveal HP for player's pokemon, not enemy
+		local maxHP = math.max(sourcePokemon.stats and sourcePokemon.stats.hp or 1, 1) -- minimum of 1
+		move.power = Utils.calculateLowHPBasedDamage(move.power, sourcePokemon.curHP or 0, maxHP)
+	end,
+	[MoveData.Values.ReversalId] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.isViewingOwn then return end -- Only reveal HP for player's pokemon, not enemy
+		local maxHP = math.max(sourcePokemon.stats and sourcePokemon.stats.hp or 1, 1) -- minimum of 1
+		move.power = Utils.calculateLowHPBasedDamage(move.power, sourcePokemon.curHP or 0, maxHP)
+	end,
+	[MoveData.Values.EruptionId] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.isViewingOwn then return end -- Only reveal HP for player's pokemon, not enemy
+		local maxHP = math.max(sourcePokemon.stats and sourcePokemon.stats.hp or 1, 1) -- minimum of 1
+		move.power = Utils.calculateHighHPBasedDamage(move.power, sourcePokemon.curHP or 0, maxHP)
+	end,
+	[MoveData.Values.WaterSpoutId] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.isViewingOwn then return end -- Only reveal HP for player's pokemon, not enemy
+		local maxHP = math.max(sourcePokemon.stats and sourcePokemon.stats.hp or 1, 1) -- minimum of 1
+		move.power = Utils.calculateHighHPBasedDamage(move.power, sourcePokemon.curHP or 0, maxHP)
+	end,
+	[MoveData.Values.ReturnId] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.isViewingOwn then return end -- Only reveal Friendship for player's pokemon, not enemy
+		move.power = Utils.calculateFriendshipBasedDamage(move.power, sourcePokemon.friendship or 0)
+	end,
+	[MoveData.Values.FrustrationId] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.isViewingOwn then return end -- Only reveal Friendship for player's pokemon, not enemy
+		move.power = Utils.calculateFriendshipBasedDamage(move.power, sourcePokemon.friendship or 0)
+	end,
+	-- Guillotine
+	[12] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.inActiveBattle() then return end
+		local levelDiff = (sourcePokemon.level or 0) - (targetPokemon.level or 0)
+		if levelDiff > 0 then
+			local accAsNum = tonumber(move.accuracy or "") or 30 -- 30 is default OHKO accuracy
+			move.accuracy = tostring(math.min(accAsNum + levelDiff, 100)) -- max of 100
+		elseif levelDiff < 0 then
+			move.accuracy = "X " -- Ineffective against higher level pokemon
+		end
+	end,
+	-- Horn Drill
+	[32] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.inActiveBattle() then return end
+		local levelDiff = (sourcePokemon.level or 0) - (targetPokemon.level or 0)
+		if levelDiff > 0 then
+			local accAsNum = tonumber(move.accuracy or "") or 30 -- 30 is default OHKO accuracy
+			move.accuracy = tostring(math.min(accAsNum + levelDiff, 100)) -- max of 100
+		elseif levelDiff < 0 then
+			move.accuracy = "X " -- Ineffective against higher level pokemon
+		end
+	end,
+	-- Fissure
+	[90] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.inActiveBattle() then return end
+		local levelDiff = (sourcePokemon.level or 0) - (targetPokemon.level or 0)
+		if levelDiff > 0 then
+			local accAsNum = tonumber(move.accuracy or "") or 30 -- 30 is default OHKO accuracy
+			move.accuracy = tostring(math.min(accAsNum + levelDiff, 100)) -- max of 100
+		elseif levelDiff < 0 then
+			move.accuracy = "X " -- Ineffective against higher level pokemon
+		end
+	end,
+	-- Sheer Cold
+	[329] = function(move, sourcePokemon, targetPokemon)
+		if not Battle.inActiveBattle() then return end
+		local levelDiff = (sourcePokemon.level or 0) - (targetPokemon.level or 0)
+		if levelDiff > 0 then
+			local accAsNum = tonumber(move.accuracy or "") or 30 -- 30 is default OHKO accuracy
+			move.accuracy = tostring(math.min(accAsNum + levelDiff, 100)) -- max of 100
+		elseif levelDiff < 0 then
+			move.accuracy = "X " -- Ineffective against higher level pokemon
+		end
+	end,
+}
+
 -- Is true when a Status move fails/doesn't work against a checked move type
 MoveData.StatusMovesWillFail = {
 	["73"] = { [PokemonData.Types.GRASS] = true, }, -- Leech Seed
@@ -350,6 +437,20 @@ function MoveData.calcHiddenPowerTypeAndPower(ivs)
 	movePower = math.floor(moveSum * 40 / 63) + 30 -- results in 30 through 70, inclusive
 
 	return moveType, movePower
+end
+
+---Adjusts the move table data based on any variable damage calculations, or other attributes; No return, as this edits the move table directly.
+---@param move table
+---@param sourcePokemon? table Optional, as not all move adjustment calculations require a source and/or a target
+---@param targetPokemon? table Optional, as not all move adjustment calculations require a source and/or a target
+function MoveData.adjustForVariablePower(move, sourcePokemon, targetPokemon)
+	sourcePokemon = sourcePokemon or {}
+	targetPokemon = targetPokemon or {}
+	local adjustmentFunc = MoveData.VariablePowerAdjustmentFuncs[tonumber(move.id or 0) or false]
+	if type(adjustmentFunc) ~= "function" then
+		return
+	end
+	adjustmentFunc(move, sourcePokemon, targetPokemon)
 end
 
 MoveData.BlankMove = {


### PR DESCRIPTION
Closes #518 

Move the logic for calculating variable power info about a move from the DataHelper into separate, individual functions defined in MoveData. In this way, developers can adjust these formulas if needed and/or add new formulas for other/new moves.