### PR TITLE
Patch 9.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Trackers for other games:
 
 ## Latest Changes
 
-### Easier Extension Installs & Updates
+### GachaMon! A Collectable Card Game
 ![The GachaMon Collectable Card Game about page, explaining how the new feature works. Get GachaMon cards by playing the game, catching Pokémon, and defeating trainers. Cards are rated from 1-5 stars.](https://github.com/user-attachments/assets/500037d8-0cf4-4f91-8267-c00a852873ad)
+
+Learn more about GachaMon here: <https://github.com/besteon/Ironmon-Tracker/wiki/GachaMon-Collectable-Card-Game>
 
 See the project's Wiki for a full [Version Changelog](https://github.com/besteon/Ironmon-Tracker/wiki/Version-Changelog).
 

--- a/ironmon_tracker/FileManager.lua
+++ b/ironmon_tracker/FileManager.lua
@@ -98,6 +98,7 @@ FileManager.Urls = {
 	NEW_RUNS = "https://github.com/besteon/Ironmon-Tracker/wiki/New-Runs-Setup",
 	EXTENSIONS = "https://github.com/besteon/Ironmon-Tracker/wiki/Tracker-Add-ons#custom-code-extensions",
 	STREAM_CONNECT = "https://github.com/besteon/Ironmon-Tracker/wiki/Stream-Connect-Guide",
+	GACHAMON = "https://github.com/besteon/Ironmon-Tracker/wiki/GachaMon-Collectable-Card-Game",
 }
 
 -- All Lua code files used by the Tracker, loaded and initialized in the order listed

--- a/ironmon_tracker/Languages/English.lua
+++ b/ironmon_tracker/Languages/English.lua
@@ -781,6 +781,8 @@ ScreenResources{
 		SectionWhatsOnCard = "What's on a Card",
 		LabelStarsAndRating = "Stars:  The Pokémon's rating (1- 5)",
 		LabelBattlePowerAndStrength = "Battle Power:  Its strength for doing card battles",
+		ButtonHelpWiki = "Help",
+		MessageCheckConsole = "Check the Lua Console for a link to the Tracker's GachaMon Help Wiki.",
 	},
 	TeamViewArea = {
 		EggNickname = "EGG",

--- a/ironmon_tracker/Languages/French.lua
+++ b/ironmon_tracker/Languages/French.lua
@@ -781,6 +781,8 @@ ScreenResources{
 		SectionWhatsOnCard = "What's on a Card",
 		LabelStarsAndRating = "Stars:  The Pokémon's rating (1- 5)",
 		LabelBattlePowerAndStrength = "Battle Power:  Its strength for doing card battles",
+		ButtonHelpWiki = "Help",
+		MessageCheckConsole = "Check the Lua Console for a link to the Tracker's GachaMon Help Wiki.",
 	},
 	TeamViewArea = {
 		EggNickname = "EGG", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/German.lua
+++ b/ironmon_tracker/Languages/German.lua
@@ -781,6 +781,8 @@ ScreenResources{
 		SectionWhatsOnCard = "What's on a Card",
 		LabelStarsAndRating = "Stars:  The Pokémon's rating (1- 5)",
 		LabelBattlePowerAndStrength = "Battle Power:  Its strength for doing card battles",
+		ButtonHelpWiki = "Help",
+		MessageCheckConsole = "Check the Lua Console for a link to the Tracker's GachaMon Help Wiki.",
 	},
 	TeamViewArea = {
 		EggNickname = "EGG", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Italian.lua
+++ b/ironmon_tracker/Languages/Italian.lua
@@ -781,6 +781,8 @@ ScreenResources{
 		SectionWhatsOnCard = "What's on a Card",
 		LabelStarsAndRating = "Stars:  The Pokémon's rating (1- 5)",
 		LabelBattlePowerAndStrength = "Battle Power:  Its strength for doing card battles",
+		ButtonHelpWiki = "Help",
+		MessageCheckConsole = "Check the Lua Console for a link to the Tracker's GachaMon Help Wiki.",
 	},
 	TeamViewArea = {
 		EggNickname = "EGG", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Japanese.lua
+++ b/ironmon_tracker/Languages/Japanese.lua
@@ -783,6 +783,8 @@ ScreenResources{
 		SectionWhatsOnCard = "What's on a Card",
 		LabelStarsAndRating = "Stars:  The Pokémon's rating (1- 5)",
 		LabelBattlePowerAndStrength = "Battle Power:  Its strength for doing card battles",
+		ButtonHelpWiki = "Help",
+		MessageCheckConsole = "Check the Lua Console for a link to the Tracker's GachaMon Help Wiki.",
 	},
 	TeamViewArea = {
 		EggNickname = "EGG", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Languages/Spanish.lua
+++ b/ironmon_tracker/Languages/Spanish.lua
@@ -781,6 +781,8 @@ ScreenResources{
 		SectionWhatsOnCard = "What's on a Card",
 		LabelStarsAndRating = "Stars:  The Pokémon's rating (1- 5)",
 		LabelBattlePowerAndStrength = "Battle Power:  Its strength for doing card battles",
+		ButtonHelpWiki = "Help",
+		MessageCheckConsole = "Check the Lua Console for a link to the Tracker's GachaMon Help Wiki.",
 	},
 	TeamViewArea = {
 		EggNickname = "EGG", -- NEEDS TRANSLATION

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -1,7 +1,7 @@
 Main = {}
 
 -- The latest version of the tracker. Should be updated with each PR.
-Main.Version = { major = "9", minor = "2", patch = "2" }
+Main.Version = { major = "9", minor = "2", patch = "3" }
 
 Main.CreditsList = { -- based on the PokemonBizhawkLua project by MKDasher
 	CreatedBy = "Besteon",

--- a/ironmon_tracker/data/GachaMonData.lua
+++ b/ironmon_tracker/data/GachaMonData.lua
@@ -45,6 +45,7 @@ GachaMonData = {
 
 --[[
 TODO LATER:
+- [UI] Update filters for new stuff added, like "Game Winners" and "Trainer prize cards"
 - [Battle] animation showing them fight. Text appears when move gets used. A vertical "HP bar" depletes. Battle time ~10-15 seconds
    - Perhaps draw a Kanto Gym badge/environment to battle on, and have it affect the battle.
    - Use new terrain sheet. Fight on grass or mountains unless both are flying type "Sky Battle".
@@ -995,7 +996,6 @@ function GachaMonData.tryAutoKeepInCollection(mon)
 	if gachamon.Temp.TrainersDefeated < GachaMonData.TRAINERS_TO_DEFEAT then
 		return false
 	end
-
 
 	-- Flag this GachaMon as something to keep in collection
 	GachaMonData.updateGachaMonAndSave(gachamon, nil, true)

--- a/ironmon_tracker/screens/CoverageCalcScreen.lua
+++ b/ironmon_tracker/screens/CoverageCalcScreen.lua
@@ -329,8 +329,6 @@ function CoverageCalcScreen.createButtons()
 			local isPlayingNatDex = CustomCode.RomHacks.isPlayingNatDex()
 			return correctScreen and isPlayingNatDex
 		end
-	else
-		Utils.printDebug("---------------- cant find button")
 	end
 
 	-- POKEMON TABS VIEW

--- a/ironmon_tracker/screens/CoverageCalcScreen.lua
+++ b/ironmon_tracker/screens/CoverageCalcScreen.lua
@@ -19,7 +19,7 @@ local TAB_HEIGHT = 12
 
 SCREEN.OrderedTypeKeys = {
 	"NORMAL", "FIGHTING", "FLYING", "POISON", "GROUND", "ROCK", "BUG", "GHOST", "STEEL",
-	"FIRE", "WATER", "GRASS", "ELECTRIC", "PSYCHIC", "ICE", "DRAGON", "DARK",
+	"FIRE", "WATER", "GRASS", "ELECTRIC", "PSYCHIC", "ICE", "DRAGON", "DARK", "FAIRY",
 }
 
 SCREEN.Buttons = {
@@ -318,6 +318,19 @@ function CoverageCalcScreen.createButtons()
 	for _, button in ipairs(buttonsToAdd) do
 		local btnKey = "MoveType" .. button.moveType
 		SCREEN.Buttons[btnKey] = button
+	end
+
+	-- Individual button adjustments
+
+	local buttonFairy = SCREEN.Buttons["MoveTypefairy"]
+	if buttonFairy then
+		buttonFairy.isVisible = function(self)
+			local correctScreen = SCREEN.currentView == SCREEN.Views.MoveTypes
+			local isPlayingNatDex = CustomCode.RomHacks.isPlayingNatDex()
+			return correctScreen and isPlayingNatDex
+		end
+	else
+		Utils.printDebug("---------------- cant find button")
 	end
 
 	-- POKEMON TABS VIEW

--- a/ironmon_tracker/screens/GachaMonOverlay.lua
+++ b/ironmon_tracker/screens/GachaMonOverlay.lua
@@ -1254,7 +1254,7 @@ GachaMonOverlay.Tabs.About.Buttons = {
 		end,
 	},
 	SampleGachaMonCard = {
-		box = { CANVAS.X + CANVAS.W - 77, CANVAS.Y + 43, 76, 76, },
+		box = { CANVAS.X + CANVAS.W - 77, CANVAS.Y + 44, 76, 76, },
 		gachamon = nil,
 		randomizeCard = function(self)
 			self.gachamon = GachaMonData.createRandomGachaMon()
@@ -1278,6 +1278,15 @@ GachaMonOverlay.Tabs.About.Buttons = {
 			-- Draw card
 			local card = self.gachamon and self.gachamon:getCardDisplayData() or {}
 			GachaMonOverlay.drawGachaCard(card, x, y, 4, false, false)
+		end,
+	},
+	WikiLink = {
+		type = Constants.ButtonTypes.FULL_BORDER,
+		getText = function(self) return string.format(" %s", Resources[SCREEN.Key].ButtonHelpWiki) end,
+		textColor = SCREEN.Colors.highlight,
+		box = { CANVAS.X + CANVAS.W - 31, CANVAS.Y + 126, 26, 12 },
+		onClick = function(self)
+			Utils.openBrowserWindow(FileManager.Urls.GACHAMON, Resources[SCREEN.Key].MessageCheckConsole)
 		end,
 	},
 }

--- a/ironmon_tracker/screens/GachaMonOverlay.lua
+++ b/ironmon_tracker/screens/GachaMonOverlay.lua
@@ -1522,6 +1522,16 @@ function GachaMonOverlay.createTabsAndButtons()
 		}
 		startY = startY + Constants.SCREEN.LINESPACING + 1
 	end
+
+	local optionBtnShowStars = SCREEN.Tabs.Options.Buttons["Show GachaMon stars on main Tracker Screen"]
+	optionBtnShowStars.onClick = function(self)
+		self.toggleState = Options.toggleSetting(self.optionKey)
+		-- If Survival mode for Track PC Heals is also enabled, turn that off as it conflicts by using the same screen space
+		if self.toggleState and Options["Track PC Heals"] then
+			Options.toggleSetting("Track PC Heals")
+		end
+		Program.redraw(true)
+	end
 end
 
 function GachaMonOverlay.buildData()

--- a/ironmon_tracker/screens/SetupScreen.lua
+++ b/ironmon_tracker/screens/SetupScreen.lua
@@ -470,19 +470,39 @@ function SetupScreen.createButtons()
 			isVisible = function(self) return SCREEN.currentTab == SCREEN.Tabs.General end,
 			onClick = function(self)
 				self.toggleState = Options.toggleSetting(self.optionKey)
-				-- If PC Heal tracking switched, invert the count
-				if self.optionKey == "PC heals count downward" then
-					Tracker.Data.centerHeals = math.max(10 - Tracker.Data.centerHeals, 0)
-				end
 				Program.redraw(true)
-				if self.optionKey == "Show Team View" then
-					TeamViewArea.refreshDisplayPadding()
-					TeamViewArea.buildOutPartyScreen()
-					Program.Frames.waitToDraw = 1 -- required to redraw after the redraw
-				end
 			end
 		}
 		startY = startY + Constants.SCREEN.LINESPACING
+	end
+
+	-- Additional onclick checks and actions for some option checkboxes
+
+	local optionBtnTrackHeals = SCREEN.Buttons["Track PC Heals"]
+	optionBtnTrackHeals.onClick = function(self)
+		self.toggleState = Options.toggleSetting(self.optionKey)
+		-- If GachaMon stars option is also enabled, turn that off as it conflicts by using the same screen space
+		if self.toggleState and Options["Show GachaMon stars on main Tracker Screen"] then
+			Options.toggleSetting("Show GachaMon stars on main Tracker Screen")
+		end
+		Program.redraw(true)
+	end
+
+	local optionBtnHealsDownward = SCREEN.Buttons["PC heals count downward"]
+	optionBtnHealsDownward.onClick = function(self)
+		self.toggleState = Options.toggleSetting(self.optionKey)
+		-- If PC Heal tracking switched, invert the count
+		Tracker.Data.centerHeals = math.max(10 - Tracker.Data.centerHeals, 0)
+		Program.redraw(true)
+	end
+
+	local optionBtnTeamView = SCREEN.Buttons["Show Team View"]
+	optionBtnTeamView.onClick = function(self)
+		self.toggleState = Options.toggleSetting(self.optionKey)
+		Program.redraw(true)
+		TeamViewArea.refreshDisplayPadding()
+		TeamViewArea.buildOutPartyScreen()
+		Program.Frames.waitToDraw = 1 -- required to redraw after the redraw
 	end
 
 	-- TAB: CAROUSEL


### PR DESCRIPTION
### Release Notes for 9.2.3
- [9.2.3] Fixed an issue where the Fairy type wasn't displaying for Nat. Dex coverage calculator
- [9.2.3] Added a [GachaMon Help Wiki](https://github.com/besteon/Ironmon-Tracker/wiki/GachaMon-Collectable-Card-Game) link for learning more about it
- ~~[9.2.3] Fixed an issue where Stars wouldn't show on the Tracker if Survival PC heal tracking was enabled~~
- [9.2.3] Changed the behavior of conflicting Gachamon stars and PC Heal tracking options so that only one of the two can be toggled ON at any one time

I understand for the third point about pc heals and survival that this isn't technically accurate description, but I wanted to use as few words as possible to describe the outcome of this change, such that people won't get confused now if they disable-then-enable the "Show stars" option for GachaMon. It will now just work, no questions asked.