### PR TITLE
Allow extensions to define required extensions for use

### DIFF
--- a/extensions/CodeExtensionTemplate.lua.txt
+++ b/extensions/CodeExtensionTemplate.lua.txt
@@ -11,8 +11,15 @@ local function CodeExtensionTemplate()
 	self.name = "My Fancy Extension"
 	self.author = "My Username"
 	self.description = "This is a template file for my fancy custom code extension."
-	self.github = "MyUsername/ExtensionRepo" -- Replace "MyUsername" and "ExtensionRepo" to match your GitHub repo url, if any
-	self.url = string.format("https://github.com/%s", self.github or "") -- Remove this attribute if no host website available for this extension
+
+	-- List of other extension keys required to be enabled in order to use this extension; aka, dependencies. (i.e. Roguemon requires "NatDexExtension")
+	self.requiredExtKeys = {}
+
+	-- Replace "MyUsername" and "ExtensionRepo" to match your GitHub repo url, if any
+	self.github = "MyUsername/ExtensionRepo"
+
+	-- Remove this attribute if no host website available for this extension
+	self.url = string.format("https://github.com/%s", self.github or "")
 
 	--------------------------------------
 	-- INTENRAL TRACKER FUNCTIONS BELOW

--- a/ironmon_tracker/Main.lua
+++ b/ironmon_tracker/Main.lua
@@ -170,7 +170,7 @@ function Main.Run()
 	FileManager.setupErrorLog()
 	Main.ReadAttemptsCount() -- re-check attempts count if different game is loaded
 	FileManager.executeEachFile("initialize") -- initialize all tracker files
-	CustomCode.startup()
+	CustomCode.executeExtensionStartups()
 	CustomCode.checkForRomHacks()
 	Main.tempQuickloadFiles = nil -- From now on, quickload files should be re-checked
 


### PR DESCRIPTION
Some extensions require other extensions to be loaded/started before they themselves can properly startup. This commit adds support for that by adding a new attribute to extension self object: `requiredExtKeys`