### PR TITLE
Fix unintentional reveal of certain log data

### DIFF
--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -615,14 +615,30 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 	data.p.id = pokemonInternal.pokemonID or 0
 	data.p.name = RandomizerLog.getPokemonName(pokemonID)
 	data.p.bst = pokemonInternal.bstCalculated or pokemonInternal.bst or Constants.BLANKLINE
+
 	data.p.types = {
-		pokemonLog.Types[1] or pokemonInternal.types[1],
-		pokemonLog.Types[2] or pokemonInternal.types[2],
+		pokemonLog.Types[1],
+		pokemonLog.Types[2],
 	}
+	-- Sometimes types info isn't available from the log (i.e. vanilla game). As such, show if allowed.
+	if not data.p.types[1] and PokemonData.canShowUnknownTypes() then
+		data.p.types[1] = pokemonInternal.types[1]
+	end
+	if not data.p.types[2] and PokemonData.canShowUnknownTypes() then
+		data.p.types[2] = pokemonInternal.types[2]
+	end
+
 	data.p.abilities = {
-		pokemonLog.Abilities[1] or PokemonData.getAbilityId(pokemonID, 0),
-		pokemonLog.Abilities[2] or PokemonData.getAbilityId(pokemonID, 1),
+		pokemonLog.Abilities[1],
+		pokemonLog.Abilities[2],
 	}
+	-- Sometimes ability info isn't available from the log (i.e. vanilla game). As such, show if allowed.
+	if not data.p.abilities[1] and PokemonData.canShowUnknownAbilities() then
+		data.p.abilities[1] = PokemonData.getAbilityId(pokemonID, 0)
+	end
+	if not data.p.abilities[2] and PokemonData.canShowUnknownAbilities() then
+		data.p.abilities[2] = PokemonData.getAbilityId(pokemonID, 1)
+	end
 
 	-- The following are all Randomizer Log information
 	data.p.helditems = pokemonLog.HeldItems or Constants.BLANKLINE -- unsure how this is formatted
@@ -631,7 +647,7 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 	for _, statKey in ipairs(Constants.OrderedLists.STATSTAGES) do
 		if pokemonLog.BaseStats ~= nil then
 			data.p[statKey] = pokemonLog.BaseStats[statKey] or 0
-		elseif pokemonInternal.baseStats ~= nil then
+		elseif pokemonInternal.baseStats ~= nil and PokemonData.canShowUnknownStats() then
 			data.p[statKey] = pokemonInternal.baseStats[statKey] or 0
 		else
 			data.p[statKey] = 0
@@ -661,7 +677,12 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 
 	-- The Pokemon's level-up move list, in order of levels
 	data.p.moves = {}
-	local moveList = pokemonLog.MoveSet or PokemonData.readLevelUpMoves(pokemonID) or {}
+	local moveList = pokemonLog.MoveSet or {}
+	-- Sometimes moveset info isn't available from the log (i.e. vanilla game). As such, show if allowed.
+	if not moveList[1] and PokemonData.canShowUnknownMoveLearnSets() then
+		moveList = PokemonData.readLevelUpMoves(pokemonID) or {}
+	end
+
 	for _, moveLog in ipairs(moveList) do
 		local move = {
 			id = moveLog.moveId or moveLog.id or 0,

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -623,9 +623,9 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 	-- Sometimes types info isn't available from the log (i.e. vanilla game). As such, show if allowed.
 	if not data.p.types[1] and PokemonData.canShowUnknownTypes() then
 		data.p.types[1] = pokemonInternal.types[1]
-	end
-	if not data.p.types[2] and PokemonData.canShowUnknownTypes() then
-		data.p.types[2] = pokemonInternal.types[2]
+		if not data.p.types[2] then
+			data.p.types[2] = pokemonInternal.types[2]
+		end
 	end
 
 	data.p.abilities = {
@@ -635,9 +635,9 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 	-- Sometimes ability info isn't available from the log (i.e. vanilla game). As such, show if allowed.
 	if not data.p.abilities[1] and PokemonData.canShowUnknownAbilities() then
 		data.p.abilities[1] = PokemonData.getAbilityId(pokemonID, 0)
-	end
-	if not data.p.abilities[2] and PokemonData.canShowUnknownAbilities() then
-		data.p.abilities[2] = PokemonData.getAbilityId(pokemonID, 1)
+		if not data.p.abilities[2] then
+			data.p.abilities[2] = PokemonData.getAbilityId(pokemonID, 1)
+		end
 	end
 
 	-- The following are all Randomizer Log information

--- a/ironmon_tracker/data/DataHelper.lua
+++ b/ironmon_tracker/data/DataHelper.lua
@@ -598,7 +598,11 @@ function DataHelper.buildRouteInfoDisplay(routeId)
 	return data
 end
 
-function DataHelper.buildPokemonLogDisplay(pokemonID)
+---Builds all data needed for displaying log information about a Pokémon
+---@param pokemonID number
+---@param viewingCurrentGame boolean
+---@return table data
+function DataHelper.buildPokemonLogDisplay(pokemonID, viewingCurrentGame)
 	local data = {}
 	data.p = {} -- data about the Pokemon itself
 	data.x = {} -- misc data to display, such as notes
@@ -621,7 +625,7 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 		pokemonLog.Types[2],
 	}
 	-- Sometimes types info isn't available from the log (i.e. vanilla game). As such, show if allowed.
-	if not data.p.types[1] and PokemonData.canShowUnknownTypes() then
+	if not data.p.types[1] and viewingCurrentGame and PokemonData.canShowUnknownTypes() then
 		data.p.types[1] = pokemonInternal.types[1]
 		if not data.p.types[2] then
 			data.p.types[2] = pokemonInternal.types[2]
@@ -633,7 +637,7 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 		pokemonLog.Abilities[2],
 	}
 	-- Sometimes ability info isn't available from the log (i.e. vanilla game). As such, show if allowed.
-	if not data.p.abilities[1] and PokemonData.canShowUnknownAbilities() then
+	if not data.p.abilities[1] and viewingCurrentGame and PokemonData.canShowUnknownAbilities() then
 		data.p.abilities[1] = PokemonData.getAbilityId(pokemonID, 0)
 		if not data.p.abilities[2] then
 			data.p.abilities[2] = PokemonData.getAbilityId(pokemonID, 1)
@@ -679,7 +683,7 @@ function DataHelper.buildPokemonLogDisplay(pokemonID)
 	data.p.moves = {}
 	local moveList = pokemonLog.MoveSet or {}
 	-- Sometimes moveset info isn't available from the log (i.e. vanilla game). As such, show if allowed.
-	if not moveList[1] and PokemonData.canShowUnknownMoveLearnSets() then
+	if not moveList[1] and viewingCurrentGame and PokemonData.canShowUnknownMoveLearnSets() then
 		moveList = PokemonData.readLevelUpMoves(pokemonID) or {}
 	end
 

--- a/ironmon_tracker/screens/GameOverScreen.lua
+++ b/ironmon_tracker/screens/GameOverScreen.lua
@@ -182,7 +182,7 @@ GameOverScreen.Buttons = {
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 14, Constants.SCREEN.MARGIN + 132, 112, 16 },
 		isVisible = function(self) return not Options["Add to collection if prize from trainer victory"] or (GameOverScreen.numDefeatedTrainers or 0) < 2 end,
 		onClick = function(self)
-			LogOverlay.viewLogFile(FileManager.PostFixes.AUTORANDOMIZED)
+			LogOverlay.viewLogFile(FileManager.PostFixes.AUTORANDOMIZED, true)
 		end,
 	},
 	ViewLogFileSmall = {
@@ -192,7 +192,7 @@ GameOverScreen.Buttons = {
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 6, Constants.SCREEN.MARGIN + 132, 60, 16 },
 		isVisible = function(self) return Options["Add to collection if prize from trainer victory"] and (GameOverScreen.numDefeatedTrainers or 0) >= 2 end,
 		onClick = function(self)
-			LogOverlay.viewLogFile(FileManager.PostFixes.AUTORANDOMIZED)
+			LogOverlay.viewLogFile(FileManager.PostFixes.AUTORANDOMIZED, true)
 		end,
 	},
 	GachaMonPrizeCard = {

--- a/ironmon_tracker/screens/LogOverlay.lua
+++ b/ironmon_tracker/screens/LogOverlay.lua
@@ -9,6 +9,7 @@ LogOverlay = {
 	isDisplayed = false,
 	isGameOver = false, -- Set to true when game is over, so we known to show game over screen if X is pressed
 	viewedLog = "None", -- use to note if the opened log is the current seed, previous seed, or other
+	viewingCurrentGame = false, -- True if the log that is opened is for the current game that is loaded
 }
 
 -- Dimensions of the screen space occupied by the currentl visible Tab
@@ -266,6 +267,7 @@ LogOverlay.NavFilters = {
 function LogOverlay.initialize()
 	LogOverlay.isGameOver = false
 	LogOverlay.viewedLog = "None"
+	LogOverlay.viewingCurrentGame = false
 
 	LogOverlay.TabHistory = {}
 	LogOverlay.Windower.currentTab = nil
@@ -479,8 +481,16 @@ function LogOverlay.hasParsedThisLog(postfix)
 	return RandomizerLog.Data.Settings ~= nil and string.find(RandomizerLog.loadedLogPath or "", postfix, 1, true) ~= nil
 end
 
-function LogOverlay.viewLogFile(postfix)
+---Opens a log file to view on the Tracker.
+---@param postfix string For example: "AutoRandomized", "PreviousAttempt", "Other", or "None"
+---@param isCurrent? boolean If the log file being opened is for the game currently loaded; default will check against postfix
+function LogOverlay.viewLogFile(postfix, isCurrent)
+	if isCurrent == nil then
+		isCurrent = postfix == FileManager.PostFixes.AUTORANDOMIZED
+	end
+
 	LogOverlay.viewedLog = postfix or "Other"
+	LogOverlay.viewingCurrentGame = isCurrent
 	local logpath = LogOverlay.getLogFileAutodetected(postfix)
 
 	-- Only prompt for a new file if no autodetect and nothing has been parsed yet

--- a/ironmon_tracker/screens/LogTabPokemonDetails.lua
+++ b/ironmon_tracker/screens/LogTabPokemonDetails.lua
@@ -84,7 +84,7 @@ end
 
 function LogTabPokemonDetails.buildZoomButtons(pokemonID)
 	pokemonID = pokemonID or LogTabPokemonDetails.infoId or -1
-	local data = DataHelper.buildPokemonLogDisplay(pokemonID)
+	local data = DataHelper.buildPokemonLogDisplay(pokemonID, LogOverlay.viewingCurrentGame)
 	LogTabPokemonDetails.infoId = pokemonID
 	LogTabPokemonDetails.dataSet = data
 
@@ -770,7 +770,7 @@ function LogTabPokemonDetails.buildZoomButtons(pokemonID)
 	LogTabPokemonDetails.Pager:changeTab(LogTabPokemonDetails.Tabs.LevelMoves)
 
 	-- LABEL/BUTTON FOR "Show IVs/EVs/BST"
-	local canSeeIVsEVs = LogOverlay.viewedLog == FileManager.PostFixes.AUTORANDOMIZED and LogTabPokemonDetails.playerTeam[pokemonID] ~= nil
+	local canSeeIVsEVs = LogOverlay.viewingCurrentGame and LogTabPokemonDetails.playerTeam[pokemonID] ~= nil
 	local showBtnBox = { LogOverlay.TabBox.x + 66, LogOverlay.TabBox.y + 42, 43, 11 } -- x, y, width, height
 
 	local lblStatGraphHeader = {
@@ -853,7 +853,7 @@ function LogTabPokemonDetails.drawTab()
 	-- Ideally this is done only once on tab change
 	local data = LogTabPokemonDetails.dataSet
 	if data == nil then
-		data = DataHelper.buildPokemonLogDisplay(LogTabPokemonDetails.infoId)
+		data = DataHelper.buildPokemonLogDisplay(LogTabPokemonDetails.infoId, LogOverlay.viewingCurrentGame)
 		LogTabPokemonDetails.dataSet = data
 	end
 

--- a/ironmon_tracker/screens/ViewLogWarningScreen.lua
+++ b/ironmon_tracker/screens/ViewLogWarningScreen.lua
@@ -13,7 +13,7 @@ ViewLogWarningScreen.Buttons = {
 		getText = function(self) return Resources.ViewLogWarningScreen.ButtonViewCurrentLog end,
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 4, Constants.SCREEN.MARGIN + 39, 56, 16 },
 		onClick = function(self)
-			LogOverlay.viewLogFile(FileManager.PostFixes.AUTORANDOMIZED)
+			LogOverlay.viewLogFile(FileManager.PostFixes.AUTORANDOMIZED, true)
 		end,
 	},
 	ViewPreviousLogFile = {
@@ -22,7 +22,7 @@ ViewLogWarningScreen.Buttons = {
 		getText = function(self) return Resources.ViewLogWarningScreen.ButtonViewPreviousLog end,
 		box = { Constants.SCREEN.WIDTH + Constants.SCREEN.MARGIN + 64, Constants.SCREEN.MARGIN + 39, 72, 16 },
 		onClick = function(self)
-			LogOverlay.viewLogFile(FileManager.PostFixes.PREVIOUSATTEMPT)
+			LogOverlay.viewLogFile(FileManager.PostFixes.PREVIOUSATTEMPT, false)
 		end
 	},
 	WarningIcon1 = {


### PR DESCRIPTION
Incorrect assumptions were made to checking for missing log data and filling it in with data from the current game loaded. This now has an additional check to verify it's okay to view that log data (pretty much only when playing a vanilla game or open book mode)